### PR TITLE
adding docs for cds-k8s-starter for CAP Java

### DIFF
--- a/java/architecture.md
+++ b/java/architecture.md
@@ -198,6 +198,7 @@ To simplify the configuration on basis of Maven dependencies, the CAP Java SDK c
 
 * `cds-starter-spring-odata`: Bundles all dependencies necessary to set up an application exposing OData V4 endpoints on Spring Boot.
 * `cds-starter-cloudfoundry`: Bundles features to make your application production-ready for SAP BTP, Cloud Foundry environment. It comprises XSUAA authentication, SAP HANA persistence, Cloud Foundry environment for SAP BTP, and multitenancy support.
+* `cds-starter-k8s`: Bundles features to make your application production-ready for SAP BTP, Kyma/K8s environment. It comprises XSUAA authentication, SAP HANA persistence, Kyma/K8s environment for SAP BTP, and multitenancy support.
 
-Both starter bundles can be combined.
+Starter bundle `cds-starter-spring-odata` can be combined with one of the other bundles.
 

--- a/java/getting-started.md
+++ b/java/getting-started.md
@@ -113,6 +113,9 @@ This commands adds the following dependency to the pom.xml:
 	<artifactId>cds-starter-cloudfoundry</artifactId>
 </dependency>
 ```
+::: tip
+CAP Java also provides a starter bundle for SAP BTP Kyma environment. See [CAP Starter Bundles](./architecture#starter-bundles) for more details.
+:::
 
 ### Project Layout
 

--- a/java/security.md
+++ b/java/security.md
@@ -50,14 +50,8 @@ Choose an appropriate XSUAA service plan to fit the requirements. For instance, 
 :::
 
 The individual dependencies can be explicitly added in the `pom.xml` file of your service.
-On SAP BTP Cloud Foundry environment, recommended alternative is to use `cds-starter-cloudfoundry` bundle which covers all required dependencies for XSUAA-authentication:
 
-```xml
-<dependency>
-	<groupId>com.sap.cds</groupId>
-	<artifactId>cds-starter-cloudfoundry</artifactId>
-</dependency>
-```
+Recommended alternative is to use the `cds-starter-cloudfoundry` or the `cds-starter-k8s` starter bundle, which covers all required dependencies for XSUAA-authentication.
 
 ### Configure IAS Authentication { #ias}
 


### PR DESCRIPTION
Originally posted in the old capire /cap/docs/pull/4611, but not yet merged.

For 1.34.0 release