### PR TITLE
Fix start page button colors

### DIFF
--- a/.vitepress/theme/custom.scss
+++ b/.vitepress/theme/custom.scss
@@ -3,10 +3,10 @@
 :root {
   --vp-font-family-base: Avenir Next, sans-serif;
   --vp-c-brand: #db8b0b;
-  --vp-button-brand-border: #f3b655;
-  --vp-button-brand-hover-bg: #c57e0c;
+  --vp-button-brand-border: #efbc6b;
+  --vp-button-brand-hover-bg: #c37d0b;
   --vp-button-brand-hover-border: #f3b655;
-  --vp-button-brand-active-bg: #b3730c;
+  --vp-button-brand-active-bg: #9f660a;
   --vp-button-brand-active-border: #f3b655;
 
   // --vp-c-brand: #039;


### PR DESCRIPTION
The golden start page button currently has an ugly green border that's coming from the VitePress default theme:
<img width="214" alt="Screenshot 2023-04-24 at 15 29 46" src="https://user-images.githubusercontent.com/24377039/234010984-5f77704c-9fcd-4e6b-ba78-0eeedd07a607.png">

It even turns the entire button green if you hover:
<img width="200" alt="Screenshot 2023-04-24 at 15 29 54" src="https://user-images.githubusercontent.com/24377039/234010954-6fba18be-6146-47d0-bc26-9b0935d5ad75.png">

This PR specifies a golden color for border and hover/active background.