### PR TITLE
Fix layout and other glitches in `about`

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -241,7 +241,7 @@ All services provide a **uniform** API for programmatic consumption. Thus, appli
 
 <br>
 
-::: tip _[Late-cut µ services](../guides/providing-services/#late-cut-microservices)_{.tip-title}
+::: tip _[Late-cut µ services](../guides/providing-services/#late-cut-microservices)_
 This protocol-agnostic API allows [mocking remote services](../guides/using-services#local-mocking), as well as late changes to service topologies, for example, co-locating services in a single process or deploying them to separate micro services later on.
 :::
 


### PR DESCRIPTION
- Add some more `<br>` to get around the wrapping issues. Proper way would be to embed the side-by-side image/text columns in a div with a 'column' layout.
- Fix the SAP HANA and SAP Fiori links
- Remove the unsupported old `toc-redirect` class.