### PR TITLE
annotations.md: Fix missing URLs to some guides

### DIFF
--- a/cds/annotations.md
+++ b/cds/annotations.md
@@ -82,7 +82,7 @@ Shortcuts:
 
 | Annotation          | Description                                          |
 |---------------------|------------------------------------------------------|
-| `@ValueList.entity` | see [Domain Modeling]                                |
+| `@ValueList.entity` | see [Domain Modeling](../guides/domain-modeling)     |
 | `@odata.Type`       | see [OData](../advanced/odata#override-type-mapping) |
 | `@odata.MaxLength`  | see [OData](../advanced/odata#override-type-mapping) |
 | `@odata.Precision`  | see [OData](../advanced/odata#override-type-mapping) |
@@ -99,4 +99,4 @@ Intrinsically supported OData Annotations:
 | `@Core.IsMediaType`    | see [Media Data](../guides/media-data)                          |
 | `@Core.IsUrl`          | see [Media Data](../guides/media-data)                          |
 | `@Capabilities...`     | see [Fiori](../advanced/fiori)                                   |
-| `@Common.FieldControl` | see [Input Validation]                                           |
+| `@Common.FieldControl` | see [Input Validation](../guides/providing-services/#input-validation)) |


### PR DESCRIPTION
It seems some URLs were missing. See screenshot below.
Also note that the annotation `@Common.FieldControl` is not mentioned anywhere else. Is something missing here?

![Screenshot 2023-05-04 at 12 25 06](https://user-images.githubusercontent.com/1667306/236178635-44a4f19b-994a-4206-9224-565144cfbbde.png)
