### PR TITLE
Fix VS Code spelling

### DIFF
--- a/about/features.md
+++ b/about/features.md
@@ -59,7 +59,7 @@ Following is an index of the features currently covered by CAP, with status and 
 
 <br>
 
-| Editors/IDE Support      | Application Studio | VSCode | Eclipse |
+| Editors/IDE Support      | Application Studio | VS Code | Eclipse |
 |--------------------------|:------------------:|:------:|:-------:|
 | CDS Syntax Highlighting  |        <X/>        |  <X/>  |  <X/>   |
 | CDS Code Completion      |        <X/>        |  <X/>  |  <X/>   |

--- a/get-started/PARKED-using-mock-servers.md
+++ b/get-started/PARKED-using-mock-servers.md
@@ -123,7 +123,7 @@ Use `cds run --in-memory` to quickly start a lightweight Node.js server with *sq
 ###### Create a Project for the Mock Server
 
 1. Create an empty project for the mock server by executing `cds init mockserver` in the terminal.
-2. Execute `code mockserver` to open the newly created project in VSCode.
+2. Execute `code mockserver` to open the newly created project in VS Code.
 3. Open the package.json file and add `"@sap/cds-dk": "^1.0.0"` as a dependency. Execute `npm i` to install all dependencies.
 
 ###### Add Service API Definition

--- a/get-started/in-a-nutshell.md
+++ b/get-started/in-a-nutshell.md
@@ -63,15 +63,15 @@ cds init bookshop --add java
 ```
 :::
 
-2. Open the project in VSCode
+2. Open the project in VS Code
 
 ```sh
 code bookshop
 ```
 
-::: details **Note:** VSCode CLI on macOS needs extra setup
+::: details **Note:** VS Code CLI on macOS needs extra setup
 
-Users on macOS must first run a command (*Shell Command: Install 'code' command in PATH*) to add VS Code executable to the `PATH` environment variable. Read VSCode's [macOS setup guide](https://code.visualstudio.com/docs/setup/mac) for help.
+Users on macOS must first run a command (*Shell Command: Install 'code' command in PATH*) to add VS Code executable to the `PATH` environment variable. Read VS Code's [macOS setup guide](https://code.visualstudio.com/docs/setup/mac) for help.
 
 :::
 

--- a/get-started/jumpstart.md
+++ b/get-started/jumpstart.md
@@ -19,7 +19,7 @@ CAP promotes getting started with **minimal upfront setup**, based on **conventi
 
 ## Setup for Local Development {#setup}
 
-Follow the steps below to setup a local development environment. If you are a developer, then you might already have most things installed, such as Node.js, Git, SQLite, Java, Maven, VSCode, and you only need to install `cds-dk` as described in step 2 below.
+Follow the steps below to setup a local development environment. If you are a developer, then you might already have most things installed, such as Node.js, Git, SQLite, Java, Maven, VS Code, and you only need to install `cds-dk` as described in step 2 below.
 
 
 
@@ -69,7 +69,7 @@ If not, download and run the appropriate installer from [git-scm.com](https://gi
 Choose your preferred editor or IDE for developing CAP applications. <br>
 We recommend Visual Studio Code.
 
-In addition we recommend installing these VSCode Extensions:
+In addition we recommend installing these VS Code Extensions:
 
    - [**SAP CDS Language Support**](https://marketplace.visualstudio.com/items?itemName=SAPSE.vscode-cds)
    - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
@@ -103,9 +103,9 @@ Then open it in Visual Studio Code:
 code bookshop
 ```
 
-::: details **Note:** VSCode CLI on macOS needs extra setup
+::: details **Note:** VS Code CLI on macOS needs extra setup
 
-Users on macOS must first run a command (*Shell Command: Install 'code' command in PATH*) to add VS Code executable to the `PATH` environment variable. Find detailed instructions on this in [VSCode's macOS setup guide](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line).
+Users on macOS must first run a command (*Shell Command: Install 'code' command in PATH*) to add VS Code executable to the `PATH` environment variable. Find detailed instructions on this in [VS Code's macOS setup guide](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line).
 
 :::
 

--- a/node.js/core-services.md
+++ b/node.js/core-services.md
@@ -209,7 +209,7 @@ const cds = require('@sap/cds')
 module.exports = cds.service.impl (function(){ ... }) // [!code focus]
 ```
 
-> Note: `cds.service.impl()` is just a noop wrapper that enables [IntelliSense in VSCode](https://code.visualstudio.com/docs/editor/intellisense).
+> Note: `cds.service.impl()` is just a noop wrapper that enables [IntelliSense in VS Code](https://code.visualstudio.com/docs/editor/intellisense).
 
 This will be translated behind the scenes to the equivalent of this:
 
@@ -543,7 +543,7 @@ Use named functions as event handlers instead of anonymous ones as that will imp
 
 ::: tip Custom domain logic mostly goes into `.before` or `.after` handlers
 
-Your services are mostly constructed by [`cds.serve()`](cds-serve) based on service definitions in CDS models. And these are mostly instances of [`cds.ApplicationService`](app-services), which provide generic handlers for a broad range of CRUD requests. So, the need to provide own `.on` handlers reduces to custom actions and functions. 
+Your services are mostly constructed by [`cds.serve()`](cds-serve) based on service definitions in CDS models. And these are mostly instances of [`cds.ApplicationService`](app-services), which provide generic handlers for a broad range of CRUD requests. So, the need to provide own `.on` handlers reduces to custom actions and functions.
 
 :::
 

--- a/node.js/services.md
+++ b/node.js/services.md
@@ -259,7 +259,7 @@ module.exports = async function(){
 
 ### <span style="color:grey"><i>&#8627;</i> </span>  <i> Wrapped with `cds.service.impl` </i> <!-- TODO duplicated id attribute {#cds-service-impl}-->
 
-Wrap the impl function into `cds.service.impl(...)`, which simply returns the function but gives you code assists in tools like VSCode:
+Wrap the impl function into `cds.service.impl(...)`, which simply returns the function but gives you code assists in tools like VS Code:
 
 ```js
 const cds = require('@sap/cds')

--- a/tools/index.md
+++ b/tools/index.md
@@ -567,7 +567,7 @@ A new shell command `format-cds` is available.
 Show help via `format-cds -h`. This explains all commands and formatting options in detail including the default value for
 each formatting option.
 
-It is recommended to generate once for each project a settings file (_.cdsprettier.json_) with all default formatting options available. Execute `format-cds --init` in the project root. An existing file would not be overwritten. To adapt your settings to your preferred style, open the _.cdsprettier.json_ file in VSCode. You get code completion and help for each option. There is also a settings UI in [SAP CDS Language Support](https://marketplace.visualstudio.com/items?itemName=SAPSE.vscode-cds),
+It is recommended to generate once for each project a settings file (_.cdsprettier.json_) with all default formatting options available. Execute `format-cds --init` in the project root. An existing file would not be overwritten. To adapt your settings to your preferred style, open the _.cdsprettier.json_ file in VS Code. You get code completion and help for each option. There is also a settings UI in [SAP CDS Language Support](https://marketplace.visualstudio.com/items?itemName=SAPSE.vscode-cds),
 reachable via command `CDS: Show Formatting Options Configuration`. This allows to see the effects of each formatting option
 on an editable sample source. Commit the _.cdsprettier.json_ file into your version control system.
 


### PR DESCRIPTION
Changed all occurences of "VSCode" to "VS Code".