### PR TITLE
Hide table header if content is empty

### DIFF
--- a/.vitepress/theme/custom.scss
+++ b/.vitepress/theme/custom.scss
@@ -169,6 +169,7 @@ div.aside nav {
   }
 }
 
+// Hide empty table headers
 tr:has(> th:empty:first-child:last-child),
 tr:has(> th:empty:first-child:not(:last-child) + th:empty:last-child) {
   display: none;


### PR DESCRIPTION
This CSS trickery hides empty header cells for Markdown tables.

Before:
<img width="792" alt="Screenshot 2023-05-08 at 09 30 45" src="https://user-images.githubusercontent.com/24377039/236762903-76797c97-ac82-46e8-be9d-f171083e4034.png">

After:
<img width="837" alt="Screenshot 2023-05-08 at 09 30 19" src="https://user-images.githubusercontent.com/24377039/236762943-bccb639d-c1d7-4dc9-a4ef-777a0b1deca7.png">


Filled table headers stay intact, even if partially empty:
<img width="823" alt="Screenshot 2023-05-08 at 09 30 23" src="https://user-images.githubusercontent.com/24377039/236763118-20db3904-7ea9-47ea-ba21-de58efff9dee.png">
