### PR TITLE
should be `<entity>.drafts`

### DIFF
--- a/node.js/fiori.md
+++ b/node.js/fiori.md
@@ -21,11 +21,11 @@ Class `ApplicationService` provides built-in support for Fiori Draft, which add 
 You can add your validation logic in the before operation handler for the `CREATE` or `UPDATE` event (as in the case of nondraft implementations) or on the `SAVE` event (specific to drafts only):
 
 ```js
-srv.before ('NEW','Books.draft', ...)  // run before creating new drafts
-srv.after ('NEW','Books.draft', ...)      // for newly created drafts
+srv.before ('NEW','Books.drafts', ...)  // run before creating new drafts
+srv.after ('NEW','Books.drafts', ...)      // for newly created drafts
 srv.after ('EDIT','Books', ...)     // for starting edit draft sessions
-srv.before ('PATCH','Books.draft', ...)   // for field-level validations during editing
-srv.before ('SAVE','Books.draft', ...)    // run at final save only
+srv.before ('PATCH','Books.drafts', ...)   // for field-level validations during editing
+srv.before ('SAVE','Books.drafts', ...)    // run at final save only
 ```
 
 These events get triggered during the draft edit session whenever the user tabs from one field to the next, and can be used to provide early feedback.


### PR DESCRIPTION
i.e., with an s at the end