### PR TITLE
Introduce TextMate grammar for logs

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -77,6 +77,12 @@ export default defineConfig({
         scopeName: 'text.csv',
         path: join(__dirname, 'syntaxes/csv.tmLanguage.json'), // from https://github.com/mechatroner/vscode_rainbow_csv
         aliases: ['csvc']
+      },
+      {
+        id: 'log',
+        scopeName: 'text.log',
+        path: join(__dirname, 'syntaxes/log.tmLanguage.json'),
+        aliases: ['log', 'logs']
       }
     ],
     toc: {

--- a/.vitepress/syntaxes/log.tmLanguage.json
+++ b/.vitepress/syntaxes/log.tmLanguage.json
@@ -1,0 +1,39 @@
+{
+  "name": "log syntax",
+  "scopeName": "text.log",
+  "fileTypes": ["log"],
+  "patterns": [
+    {
+      "name": "comment.indented",
+      "match": "^\\s+(.*)"
+    },
+    {
+      "begin": "\\{",
+      "end": "\\}",
+      "patterns": [
+        {
+          "name": "string.quoted.single",
+          "match": "('.*?')"
+        },
+        {
+          "name": "constant.numeric",
+          "match": "\\b(\\d+)\\b"
+        },
+        {
+          "name": "constant.boolean",
+          "match": "\\b(true|false)\\b"
+        }
+      ]
+    }
+  ],
+  "repository": {
+    "main": {
+      "patterns": [
+        { "include": "#comment.indented" },
+        { "include": "#string.quoted.single" },
+        { "include": "#constant.numeric" },
+        { "include": "#constant.boolean" }
+      ]
+    }
+  }
+}

--- a/get-started/in-a-nutshell.md
+++ b/get-started/in-a-nutshell.md
@@ -159,10 +159,10 @@ _Find this source also in `cap/samples` [for Node.js](https://github.com/sap-sam
 
 As soon as you save your file, the still running `cds watch` reacts immediately with new output like this: {.impl .node}
 
-<pre class="log impl node">
-[cds] - connect to db { database: <em>':memory:'</em> }
+```log
+[cds] - connect to db { database: ':memory:' }
 /> successfully deployed to sqlite in-memory db
-</pre>
+```
 
 This means that `cds watch` detected the changes in _db/schema.cds_ and automatically bootstrapped an in-memory _SQLite_ database when restarting the server process. {.impl .node}
 
@@ -202,10 +202,10 @@ cds db/schema.cds -2 sql
 
 After the recent changes, `cds watch` also prints this message:
 
-<pre class="log">
+```log
 No service definitions found in loaded models.
 Waiting for some to be added...
-</pre>
+```
 
 </div>
 
@@ -255,7 +255,7 @@ service CatalogService @(path:'/browse') { // [!code focus]
 
 This time `cds watch` reacted with additional output like this:
 
-```js
+```log
 [cds] - serving AdminService { at: '/admin' }
 [cds] - serving CatalogService { at: '/browse', impl: 'bookshop/srv/cat-service.js' }
 
@@ -391,10 +391,10 @@ After you’ve added these files, `cds watch` restarts the server with output, t
 
 After you’ve added these files, `mvn cds:watch` restarts the server with output, telling us that the files have been detected and their content been loaded into the database automatically: {.impl .java}
 
-<pre class="log">
- c.s.c.s.impl.persistence.CsvDataLoader   : Filling sap.capire.bookshop.Books from db/data/sap.capire.bookshop-Authors.csv
- c.s.c.s.impl.persistence.CsvDataLoader   : Filling sap.capire.bookshop.Books from db/data/sap.capire.bookshop-Books.csv
-</pre>
+```log
+c.s.c.s.impl.persistence.CsvDataLoader   : Filling sap.capire.bookshop.Books from db/data/sap.capire.bookshop-Authors.csv
+c.s.c.s.impl.persistence.CsvDataLoader   : Filling sap.capire.bookshop.Books from db/data/sap.capire.bookshop-Books.csv
+```
 
 </div>
 


### PR DESCRIPTION
Introduces a TextMate grammar for log output that formats just as Node.js does on your terminal.

Before: Colorful, but randomly colorful candy store with `sh` (unfortunately many false positive tokens):
<img width="761" alt="Screenshot 2023-05-24 at 02 19 48" src="https://github.com/cap-js/docs/assets/24377039/3a175183-ed4d-47e0-901e-db7cb602b57b">

Now: Custom `log` coloring, looking exactly as run on the user terminal:
<img width="832" alt="Screenshot 2023-05-24 at 02 19 19" src="https://github.com/cap-js/docs/assets/24377039/bf83b074-1c2e-4624-85e5-980d5b4d7327">

This way, the terminal output can be copied 1:1 into CAPire with no additional modification (as in `pre.log`).