### PR TITLE
Slightly increase heading font size

### DIFF
--- a/.vitepress/theme/custom.scss
+++ b/.vitepress/theme/custom.scss
@@ -34,14 +34,14 @@ main {
 
   // Headings
   .vp-doc {
-    h1, .h1 { font-size: 48px; margin: 1em 0 1em; font-weight: 300; line-height: 1.2em }
+    h1, .h1 { font-size: 48px; margin: 1em 0 1em; font-weight: 400; line-height: 1.2em }
     h2, .h2 { font-size: 24px; margin: 4em 0 2em; padding-top: 12px; }
     h3, .h3 { font-size: 20px; margin: 3em 0 1em; }
     h4, .h4 { font-size: 17px; margin: 2em 0 1em; }
     h1 + .subtitle {
       margin: -40px 0 48px;
       font-size: 1.7em;
-      font-weight: 100;
+      font-weight: 400;
     }
     p + h1 {
       margin-top: 3em


### PR DESCRIPTION
As recently discussed in the UA sync.

Looks particularly bad on Chrome for subtitles (note: the actual render in Chrome looks even more messy wrt. font antialiasing, because GitHub scales the screenshot up):

<img width="713" alt="Screenshot 2023-05-26 at 17 57 58" src="https://github.com/cap-js/docs/assets/24377039/3bae11f3-f600-41dd-beda-b355edd3d0d4">

Even on Safari, IMO it looks weird that the running text is bolder than the subheading:
<img width="618" alt="Screenshot 2023-05-26 at 17 55 33" src="https://github.com/cap-js/docs/assets/24377039/c8f6d51f-8f43-4eb8-9c62-e3170d3975ef">

With this change:

<img width="770" alt="Screenshot 2023-05-26 at 17 57 43" src="https://github.com/cap-js/docs/assets/24377039/cddefa6e-6af9-42fa-90a0-633353441137">
