### PR TITLE
Styling for `mute-dark`

### DIFF
--- a/.vitepress/theme/custom.scss
+++ b/.vitepress/theme/custom.scss
@@ -27,7 +27,7 @@
   &.dark {
     img { filter: brightness(.9) invert(1) hue-rotate(177deg) }
     .VPHome img, .avatar img, img.ignore-dark { filter:none }
-    img.mute-dark { filter:brightness(0.5) }
+    img.mute-dark { filter:brightness(0.6) }
   }
 }
 


### PR DESCRIPTION
Sometimes our hue rotation doesn't work that well (e.g. inverting SAP logo colors), so I added a class `mute-dark`, which just decreases brightness for dark mode. This is also common in iOS apps, for example. Turning the brightness to `0.5` seemed like a good sweet spot to me.