### PR TITLE
Exempt some external links from decoration

### DIFF
--- a/.vitepress/theme/custom.scss
+++ b/.vitepress/theme/custom.scss
@@ -160,10 +160,10 @@ main {
     margin-top: 0
   }
 
-  a[target="_blank"] {
+  a[target="_blank"]:not(.no-ext-link) {
     white-space: nowrap;
     &::after {
-      font-size: 0.8em;
+      font-size: 0.7em;
       content: " \2197";
     }
   }

--- a/java/components/Cds4jLink.vue
+++ b/java/components/Cds4jLink.vue
@@ -3,12 +3,14 @@
     :href="`https://www.javadoc.io/doc/com.sap.cds/cds4j-api/${version}/com/sap/cds/${link}`"
     target="_blank"
     rel="noopener noreferrer"
+    class="no-ext-link"
   >
     <slot />
   </a>
 </template>
 
 <script setup>
+  /* eslint-disable vue/require-default-prop */
 
   const props = defineProps({
     link: String,

--- a/java/components/CdsServicesLink.vue
+++ b/java/components/CdsServicesLink.vue
@@ -3,12 +3,14 @@
     :href="`https://www.javadoc.io/doc/com.sap.cds/cds-services-api/${version}/com/sap/cds/${link}`"
     target="_blank"
     rel="noopener noreferrer"
+    class="no-ext-link"
   >
     <slot />
   </a>
 </template>
 
 <script setup>
+  /* eslint-disable vue/require-default-prop */
 
   const props = defineProps({
     link: String,

--- a/java/index.md
+++ b/java/index.md
@@ -16,8 +16,8 @@ Reference Documentation { .subtitle}
 
 <span class="badges">
 
-<a :href="`https://javadoc.io/doc/com.sap.cds/cds-services-api/${versions.java}/overview-summary.html`" target="_blank" rel="noopener noreferrer"><img :src="`https://img.shields.io/badge/cds--services-${versions.java}-brightgreen.svg`" title="cds-services" crossorigin/></a>
-<a :href="`https://javadoc.io/doc/com.sap.cds/cds4j-api/${versions.java}/com/sap/cds/ql/package-summary.html`" target="_blank" rel="noopener noreferrer"><img :src="`https://img.shields.io/badge/cds4j--api-${versions.java}-brightgreen.svg`" title="cds4j-api" crossorigin/></a>
+<a :href="`https://javadoc.io/doc/com.sap.cds/cds-services-api/${versions.java}/overview-summary.html`" target="_blank" rel="noopener noreferrer" class="no-ext-link"><img :src="`https://img.shields.io/badge/cds--services-${versions.java}-brightgreen.svg`" title="cds-services" crossorigin/></a>
+<a :href="`https://javadoc.io/doc/com.sap.cds/cds4j-api/${versions.java}/com/sap/cds/ql/package-summary.html`" target="_blank" rel="noopener noreferrer" class="no-ext-link"><img :src="`https://img.shields.io/badge/cds4j--api-${versions.java}-brightgreen.svg`" title="cds4j-api" crossorigin/></a>
 
 </span>
 


### PR DESCRIPTION
When we have many external links at once, like in the Java migration page, or in badges, we should not draw the decorator.  Allow this by checking for a class.