### PR TITLE
Optimize graphics for dark mode

### DIFF
--- a/guides/providing-services/assets/service-centric-paradigm.drawio.svg
+++ b/guides/providing-services/assets/service-centric-paradigm.drawio.svg
@@ -1,14 +1,14 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="446px" height="342px" viewBox="-0.5 -0.5 446 342" content="&lt;mxfile&gt;&lt;diagram id=&quot;QQJxv4aCTC7ZgE7HHOvM&quot; name=&quot;Page-1&quot;&gt;7VtLc+o2FP41LOPRw/JjmcDNbWfSNjNZtF06tgJuDGKESKC/vkdYMtgyYMDQLEKYwT6WZFnn+87LyoAOp6ufMplPfhMZLwYEZasBHQ0IwSQO4UdL1qUkCGgpGMs8M422gpf8X26EyEiXecYXtYZKiELl87owFbMZT1VNlkgpPuvN3kRRv+s8GZs7oq3gJU0K7jT7M8/UpJRGJNzKf+H5eGLvjIO4vDJNbGMz8GKSZOJzR0R/DOhQCqHKo+lqyAu9eHZdyn6Pe65WE5N8prp0sFP+SIqlebhRopLXZAHrW85Qre1jw2Tn+jBdF/ks45IO6MPnJFf8ZZ6k+sInqBtkEzUt4AzD4atYQsvs6bUSJOn7WGrpH0sFw3AjX5RKDvShkuK9WlhSSYaiEHIzExpsPvoK3DmfjR+EUmIK1xjI3sRMPSbTvNDouv/gs1zCc/zOVwp+fuNZvpzqnu9cpfoGyHTZGb78gNwsDpeKr/auMK70BoDnYsqVXEMT0+EuMF0M1ikNyvPPLXIwMnCY7KCGGVliwDquht7qEw6MSveoN3LU62iVZ4BtczoTWiEPstSaWRwh1USMxSwpnoSYG339w5VaG2YmSyXqaq+rEHdWSkMPWzXvBUCWLCabmeKmTssH1U93WHOwGGIpU9OKGKaqRI65aebv0bDkRaLyj/r4F6krdtT1wuVHDpMjj/fPvw5IUChNIli7YKyPNrbVZepWgfg4R12+ncOgvCgsiiZJOllKfoBX+/XZB+OIpZihHGjQI8xlHW5hnR9frkaKXKMqpkk+u6X+rDJQvxbxtpqjNLyh2vBxY3kNywjM2VnPN6b/Dq50R3WCCVP3OtrRLrtIFos8teLHvKgmdLnN9G0MtmMzy8DiAptpuj6LfKa2CMHMrwOEUS9k9VHKaZiODfVXM+mGCNKZyE9iDMvr+NaigJiUd+Xwftd3qXW+XnyDUV0jEHF6Lba2NcIJPLYfAJ1pS29AWz7LLJVMjAQSwyLUXO2SG89c5vAwXL6UMaq5aNDZfrG7dehqAxqwamj+VKZbQuwynbKrMP2ONJ14XDlxO4pZ6D6Y7t8WRJOkeBvmMi1cKMH6y/Vf+sRj9vTvnVObD7vGwTHnXws8bW7iSuDBTZt0Veyw49jp7AiSIh/PtMOGleRSCxbzsoTxlq80+B4kh1w5ea2Cu7l+hM1DsYcBG2lolpn1sKp+uBaqn/xsf1TYp4cJG8r0ty6/5mFcB4N7SKFtRPqdQnd2Euhm4eAdbnqJEDVjij1Ed8eCcARtPyRmR4fuMdJ063D9+5++cg8L9dNAaaaFSU8oi1yU7SvUWA0jDxy90erFyKuX9TA7F3bN8qDvuKo9MNsOZRuKt7cFvxiKbs0QPMliOeXSLVR0T3Ca6cjpoDm9JHG8MtKDe7oL6nYC29r+sZpFHwVe6lYMv+3GyQVeig5ruFe7UQdLGPRiNghpjHNbm+G7FU8Hhvqtz7wFO5vPISqat3gm5B3svJQ7l6IEt7yDaaNowPqoUNjEp5cE4ZS3Y2OZZDms0SiXsIC50IkFAEz3PKeK1MlY+nu41GGp/XjnE/aw7m75rn/jeLQy5OhrJ8GPUFBP8fFWMFoNdgoCo7U9W+Wq7Ixjas7LvlHMzPm2qz6xPZvEi1Kepgfxs7lzVaraGbMpOxtMB623tSrHigjHwj7iRT5YWhT7FPnwh/ldo0CAPD8KIsgsN18fVfH4CSUHzLwwDgJIE6gf0jhqRAVR5NHIDyiBRoggv3GDrnYflO6xMKIhiQNGAtRwAxA9hghBVhQHFCZhGdB/wuJ/iarrQW7huM6tKI5O4FZc4xZGpG9utdColW9fm1ss8nxEEUYIMhffj+q8ugsI9oAPfhThkAUhC06mFUKAaIL9gCASssb4GGMvogGOkM8osIGdy6oQHsNn8BhxFEah3a5jtydp1xQynwGCUIziq1UBfLcKbd7/X5J5nfsCqVMsv6Gh3cTk1Bl3dwUsRKGf87IoojK2wOYwjimFWIIGYdiIqoGwYIRjMJL6SyPihHtR4BHtCigNw5gE1lDW3ikzCPuhDbPfA+DtHJK4teLh6EUve/tGAKWVcuBNoTGLTtVYL2+eJsW9uTDNs6zYB5a6ne6mzfoej4uT+bLm1sAWOSdbuGC3gU9bMncUu8igPWTuvltX/slnYPtTED5L8ZFnbQWXb0BcERB2G+pBPARXwoNbAR4uF3pXI0FDMA7fSLghEpqbGtqQELe4jF6A0GHPptXhU/LKi2exyE1y/2r2wdY1Vb3gQW142AFQExpKx+ltL5nNRuDpaqw3eHtTkb4v5940kfonXcpi/SA3OHKjiDK7/z/wI4VKzDrdQcTYlxOxkbSFCo5do2G3ltVeTvo9YKVD+fcbK18GKxE7DpWgxaz0ARXWoUT7DZWvApVqv9wBqMQtkcgZSIHT7f+blEnr9r926I//AA==&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="446px" height="342px" viewBox="-0.5 -0.5 446 342" content="&lt;mxfile&gt;&lt;diagram id=&quot;QQJxv4aCTC7ZgE7HHOvM&quot; name=&quot;Page-1&quot;&gt;7VtdU7M4FP41vZTJB+HjUuvruzvju+uMF7t7iRBbVtp00lTb/fV7UhIKhLbUYvXC6igcSAg5z3O+ko7oeLb+KZPF9JfIeDEiKFuP6O2IkJhE8FcLNqWARawUTGSelSK8Ezzm/3EjREa6yjO+bNyohChUvmgKUzGf81Q1ZImU4q1527Momk9dJBPzRLQTPKZJwZ3b/sozNS2lEQl38t94PpnaJ+MgLq/MEnuz6Xg5TTLxVhPRHyM6lkKo8mi2HvNCz52dl7Ld3Z6r1cAkn6s+DeyQX5NiZV7uNlHJU7KE+S1HqDb2tWGwC32Ybop8nnFJR/TmbZor/rhIUn3hDbQNsqmaFXCG4fBJrODO7P6pEiTpy0Rq6Z8rBd1wI1+WSg70oZLipZpYUknGohByOxIabD/6Cjw5n09uhFJiBtcYyJ7FXN0ls7zQ6Lp+5fNcwnv8wdcK/v3iWb6a6ZYvXKX6Acg0qXVffkDuTqeZ4VcuFV/XRGZ6f3Ix40pu4BZz9SowTQzWKQ3K87cdcjAycJjWUMOMLDFgnVRd7/QJB0ale9QbOep1tMozwLY5nQutkBtZas1MjpBqKiZinhT3QiyMvv7lSm0MM5OVEk21N1WIeyulpYedmvcCIEuW0+1IcVune3W3FCuZmpcnhpgqkRNubvPNfXpiDmpY8iJR+WvTKJylrthR1yOXrzmMltxdP/w+IkGhNIlg7oKJPtqaVpepOwXi4xx1+fYeBuVFYVE0TdLpSvIDvNqvzyEYRyzFDOVApR5hLutwB+v8+Hw1UuQaVTFL8vkl9WeVgYa1iJfVHKXhBdWGHbUdUMxwlhGYU5vPZ6Z/Ds50T3WCTVPXOtrRLrtIlss8teK7vKgGdLLNtPaxbjNtHDGczTRNH0Q+VzuEYOY3AcKoF7JmL+W4TMOW+quR9EME6U3kezGB6XV8a1FATMr7cni/6zvXOn9cfINRUyMQcXodtrYzwgk8th8AvWlLL0BbPs8slUyMBBLDItSe7ZIsD1zm8DJcPpYxqrlo0Nl9sb916GsDWrA6rvk60y3+60yn7DJMvyJtJx5XTtz2YiZ6CKb7lwXRNCmex7lMCxdKoBC5+VufeMye/lM7tfmwaxwcc/6p4OlyE5cCD27bpA/FDjuOnd6OICnyyVw7bJhaLrVguShLGM/5WoPvRnLIlZOnKrhb6FfYvhS7GbFbDc0ysx5X1Q/XQg2Tn+2PCof0MGFLmf7O5Tc8jOtg8AAptI1Iv1PofU4CfV44eIXbXiJE7ZhiD9HdviAcQbsPidnRrgeMNN063PD+Z6jcw0L9NFCaYWHyPpRFLsp6F2qshpEHjt5o9WzkNct6mL0Xdu3yoO+4qj0w23VlbxTPz0t+NhTdmiF4kuVqxqVbqOif4LTTkdNBc3pJ4nhlZAD3dBU07QS2tf1jNYshCrzUrRh+241jBV7rsT7HbjTBEgaDmA1CWv1c1mb4bsXTgaFe9Vm0sGOCpf4srNb0TAA8qi+b9WEnwR3LL13sDNgQxQnrogbJDU5ZGJvIJMthOm9zCbOVC51TALZ0y/cUkFwNVSo/bih7TLUf1z7hAPPuVu6Gt4tHi0KOvmq5fYSCZnaPd4Lb9ahWC7jd2LN1rsrGOKbmvGwbxcyc75rqE9uyba+jlKfpQfxsn1xVqWp9tmWDgulY/eDkiI94kQ9GFsU+RT78YH7Vqg0gz4+CCJLK7a+PqlD8hGoDZl4YBwFkCNQPaRy1AoIo8mjkB5TATYggv/WAviYflO6xMKIhiQNGAtTyABA4hghBQhQHFAZhGTB8ruJ/iYLrQW7huMmtKI5O4Fbc4BZGZGhuddCok29fm1ss8nxEEUYIkhbfj5q8ugoI9oAPfhThkAUhC06mFUKAaIL9gCASslb/GGMvogGOkM8osIG9l1UhvIbP4DXiKIxCu1NnU3NNIfMZIAjFKP6wAoDvFqDN0v85Sdd71456hfFbGtr9S06Jsb4hYCkK/Z7nRRGVsQU2h3FMKcQSNAjDVkANhAUjHIOR1L80Ik64FwUe0a6A0jCMSWANZWM5mUHED/cw+3sAvL1DErdMPL591NPevQdAaaUcWCQ0ZtEpGOupzNOkuDYXZnmWFfvA0rTT/bTZ3N5xdh5fltta2CLnJgr99xj4tCNfR7ELCjpAvu671eSffA5mPwXhgxSvedZVZvnGwsdgIaA9oBB8EBTcku94tdTbGAkag0n4BsFlQNDewNAFgrjDRwyCgR77M6367pMnXjyIZW6y+Sez57WppGoxB3VBoYadNiqUDsy7FpTNpt/ZeqL3cnszkb6sFt4skfpfupLF5kZuIeSGDWU6/xnQkUIlZp6uIEQcynXYcMVCBceuvbDbyBoLkf4AWOlR6v3GypfBiv1KwyGoBB1mZQiosB7l2G+ofBWoVHvjDkAl7ghC3oEUON19t6TMUndf0KE//gc=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <path d="M 179 223 C 179 219.69 201.39 217 229 217 C 242.26 217 254.98 217.63 264.36 218.76 C 273.73 219.88 279 221.41 279 223 L 279 261 C 279 264.31 256.61 267 229 267 C 201.39 267 179 264.31 179 261 Z" fill="#ffffff" stroke="#666666" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 179 223 C 179 219.69 201.39 217 229 217 C 242.26 217 254.98 217.63 264.36 218.76 C 273.73 219.88 279 221.41 279 223 L 279 261 C 279 264.31 256.61 267 229 267 C 201.39 267 179 264.31 179 261 Z" fill="rgb(255, 255, 255)" stroke="#666666" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
         <path d="M 279 223 C 279 226.31 256.61 229 229 229 C 201.39 229 179 226.31 179 223" fill="none" stroke="#666666" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 245px; margin-left: 180px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #333333; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Databases
                             </div>
                         </div>
@@ -21,13 +21,13 @@
         </g>
         <path d="M 114 129.75 L 167.63 129.75" fill="none" stroke="#666666" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
         <path d="M 172.88 129.75 L 165.88 133.25 L 167.63 129.75 L 165.88 126.25 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="4" y="105.25" width="110" height="49" rx="7.35" ry="7.35" fill="#ffffff" stroke="#666666" stroke-width="2" pointer-events="all"/>
+        <rect x="4" y="105.25" width="110" height="49" rx="7.35" ry="7.35" fill="rgb(255, 255, 255)" stroke="#666666" stroke-width="2" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 130px; margin-left: 5px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #333333; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Service/API
                                 <br/>
                                 Models
@@ -40,13 +40,13 @@
                 </text>
             </switch>
         </g>
-        <rect x="4" y="218" width="110" height="49" rx="7.35" ry="7.35" fill="#ffffff" stroke="#666666" stroke-width="2" pointer-events="all"/>
+        <rect x="4" y="218" width="110" height="49" rx="7.35" ry="7.35" fill="rgb(255, 255, 255)" stroke="#666666" stroke-width="2" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 243px; margin-left: 5px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #333333; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Domain
                                 <br/>
                                 Models
@@ -62,13 +62,13 @@
         <path d="M 229 168.87 L 229 210.63" fill="none" stroke="#666666" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 229 163.62 L 232.5 170.62 L 229 168.87 L 225.5 170.62 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10" pointer-events="all"/>
         <path d="M 229 215.88 L 225.5 208.88 L 229 210.63 L 232.5 208.88 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10" pointer-events="all"/>
-        <ellipse cx="394" cy="129.75" rx="50" ry="28.25" fill="#ffffff" stroke="#666666" stroke-width="2" pointer-events="all"/>
+        <ellipse cx="394" cy="129.75" rx="50" ry="28.25" fill="rgb(255, 255, 255)" stroke="#666666" stroke-width="2" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 130px; margin-left: 345px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #333333; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Domain
                                 <br/>
                                 Logic
@@ -84,18 +84,18 @@
         <path d="M 344 129.75 L 324 129.75" fill="none" stroke="#333333" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 284 129.75 L 311 129.75" fill="none" stroke="#333333" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 319 137.75 Q 311 137.75 311 129.75 Q 311 121.75 319 121.75" fill="none" stroke="#333333" stroke-miterlimit="10" pointer-events="all"/>
-        <ellipse cx="319" cy="129.75" rx="5" ry="5" fill="#ffffff" stroke="#333333" pointer-events="all"/>
+        <ellipse cx="319" cy="129.75" rx="5" ry="5" fill="rgb(255, 255, 255)" stroke="#333333" pointer-events="all"/>
         <path d="M 114 242.34 L 172.63 242.17" fill="none" stroke="#666666" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
         <path d="M 177.88 242.15 L 170.89 245.67 L 172.63 242.17 L 170.87 238.67 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10" pointer-events="all"/>
         <path d="M 229 51 L 229 90.63" fill="none" stroke="#666666" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 229 95.88 L 225.5 88.88 L 229 90.63 L 232.5 88.88 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10" pointer-events="all"/>
-        <ellipse cx="229" cy="26" rx="55" ry="25" fill="#ffffff" stroke="#666666" stroke-width="2" pointer-events="all"/>
+        <ellipse cx="229" cy="26" rx="55" ry="25" fill="rgb(255, 255, 255)" stroke="#666666" stroke-width="2" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 26px; margin-left: 175px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #333333; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Consumers
                             </div>
                         </div>
@@ -108,34 +108,32 @@
         </g>
         <path d="M 59 154.25 L 59 211.63" fill="none" stroke="#666666" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 59 216.88 L 55.5 209.88 L 59 211.63 L 62.5 209.88 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="174" y="97" width="110" height="65.5" fill="#ffffff" stroke="none" pointer-events="all"/>
-        <ellipse cx="229" cy="129.75" rx="55" ry="32.749999999999986" fill="#ffffff" stroke="#666666" stroke-width="2" pointer-events="all"/>
-        <path d="M 195.23 155.62 L 262.66 103.94" fill="none" stroke="#666666" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 195.89 103.68 L 264.09 155.82" fill="none" stroke="#666666" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
-        <ellipse cx="229" cy="129.75" rx="43.10200668896321" ry="22.615202702702703" fill="#ffffff" stroke="#666666" stroke-width="2" pointer-events="all"/>
+        <ellipse cx="229" cy="129.75" rx="55" ry="32.749999999999986" fill="rgb(255, 255, 255)" stroke="#666666" stroke-width="2" pointer-events="none"/>
+        <path d="M 195.23 155.62 L 262.66 103.94" fill="none" stroke="#666666" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 195.89 103.68 L 264.09 155.82" fill="none" stroke="#666666" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <ellipse cx="229" cy="129.75" rx="43.10200668896321" ry="22.615202702702703" fill="rgb(255, 255, 255)" stroke="#666666" stroke-width="2" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 84px; height: 1px; padding-top: 130px; margin-left: 187px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
                                 Services
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="229" y="133" fill="#000000" font-family="Avenir Next Medium" font-size="12px" text-anchor="middle">
+                <text x="229" y="133" fill="rgb(0, 0, 0)" font-family="Avenir Next Medium" font-size="12px" text-anchor="middle">
                     Services
                 </text>
             </switch>
         </g>
-        <rect x="4" y="311" width="109" height="30" fill="#ffffff" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 107px; height: 1px; padding-top: 326px; margin-left: 5px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #000000; line-height: 1.2; pointer-events: all; font-style: italic; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; font-style: italic; white-space: normal; overflow-wrap: normal;">
                                 CDS Models
                             </div>
                         </div>
@@ -146,13 +144,12 @@
                 </text>
             </switch>
         </g>
-        <rect x="177" y="311" width="106" height="30" fill="#ffffff" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 104px; height: 1px; padding-top: 326px; margin-left: 178px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #000000; line-height: 1.2; pointer-events: all; font-style: italic; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; font-style: italic; white-space: normal; overflow-wrap: normal;">
                                 Generic Providers
                             </div>
                         </div>
@@ -163,13 +160,12 @@
                 </text>
             </switch>
         </g>
-        <rect x="344" y="311" width="92" height="30" fill="#ffffff" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 90px; height: 1px; padding-top: 326px; margin-left: 345px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #000000; line-height: 1.2; pointer-events: all; font-style: italic; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; font-style: italic; white-space: normal; overflow-wrap: normal;">
                                 Custom Code
                             </div>
                         </div>
@@ -180,15 +176,15 @@
                 </text>
             </switch>
         </g>
-        <path d="M 0 314 C 0 310.13 3.13 307 7 307 L 58.5 307 C 62.37 307 65.5 303.87 65.5 300 C 65.5 303.87 68.63 307 72.5 307 L 124 307 C 127.87 307 131 310.13 131 314" fill="none" stroke="#999999" stroke-miterlimit="10" transform="rotate(-180,65.5,307)" pointer-events="all"/>
-        <path d="M 155 314 C 155 310.13 158.13 307 162 307 L 229 307 C 232.87 307 236 303.87 236 300 C 236 303.87 239.13 307 243 307 L 310 307 C 313.87 307 317 310.13 317 314" fill="none" stroke="#999999" stroke-miterlimit="10" transform="rotate(-180,236,307)" pointer-events="all"/>
-        <path d="M 340 314 C 340 310.13 343.13 307 347 307 L 381 307 C 384.87 307 388 303.87 388 300 C 388 303.87 391.13 307 395 307 L 429 307 C 432.87 307 436 310.13 436 314" fill="none" stroke="#999999" stroke-miterlimit="10" transform="rotate(-180,388,307)" pointer-events="all"/>
+        <path d="M 0 314 C 0 310.13 3.13 307 7 307 L 58.5 307 C 62.37 307 65.5 303.87 65.5 300 C 65.5 303.87 68.63 307 72.5 307 L 124 307 C 127.87 307 131 310.13 131 314" fill="none" stroke="#999999" stroke-miterlimit="10" transform="rotate(-180,65.5,307)" pointer-events="none"/>
+        <path d="M 155 314 C 155 310.13 158.13 307 162 307 L 229 307 C 232.87 307 236 303.87 236 300 C 236 303.87 239.13 307 243 307 L 310 307 C 313.87 307 317 310.13 317 314" fill="none" stroke="#999999" stroke-miterlimit="10" transform="rotate(-180,236,307)" pointer-events="none"/>
+        <path d="M 340 314 C 340 310.13 343.13 307 347 307 L 381 307 C 384.87 307 388 303.87 388 300 C 388 303.87 391.13 307 395 307 L 429 307 C 432.87 307 436 310.13 436 314" fill="none" stroke="#999999" stroke-miterlimit="10" transform="rotate(-180,388,307)" pointer-events="none"/>
     </g>
     <switch>
         <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
         <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
             <text text-anchor="middle" font-size="10px" x="50%" y="100%">
-                Viewer does not support full SVG 1.1
+                Text is not SVG - cannot display
             </text>
         </a>
     </switch>

--- a/guides/providing-services/assets/services-events.drawio.svg
+++ b/guides/providing-services/assets/services-events.drawio.svg
@@ -1,34 +1,33 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="484px" height="68px" viewBox="-0.5 -0.5 484 68" content="&lt;mxfile&gt;&lt;diagram id=&quot;QQJxv4aCTC7ZgE7HHOvM&quot; name=&quot;Page-1&quot;&gt;zVlLc+I4EP41HOPSW/IxJJnNYWdranPY3aNjC6OJsRhbJGR+/Uq2jJ8EB5iqMa4Ctd7dX3d/Egt8t9n/UUTb9VedyGyBQLJf4PsFQhCF3H45yXstYQzXgrRQiW/UCp7UT+mFwEt3KpFlr6HROjNq2xfGOs9lbHqyqCj0W7/ZSmf9WbdR6mcEreApjjI5avaPSsy6lgrEW/mjVOm6mRmysK7ZRE1jP3C5jhL91hHhhwW+K7Q29a/N/k5mTnmNXup+X47UHhZWyNzM6UD9Ol6jbOc35xdm3pvdpoXebRd4udK5efJi4Moqy+50pouqGV5Vj5X7EWVh5H7KHNFzNtRuu1x4UIJFj9QbaYp328QPdONH8rhBwo/w1loBNiBZdyzAaEC9+b3p08PYrXbsD6+gI8qCp5Vle1gU2sLyba2MfNpGsat5s45gZWuzsYPfQ/uzNIV+OcAHHSQdjbLqsTVpESXKquheFVZ/Sue2vtQ717OyypdoozKnk9tXmavCrugvuTf266tM1G7jxn6RJl57wx01UNcQFExbYoaqSdh5+BX0jk7r3WI0T2Tid6gLs9apzqPsT623XuPfpTHvPphEO6P79pB5cutCgy3mOpe15Ityi6qGHNvLqqp4/9dVBwKwRvBfJYCt4H7vR6hL701pr0zdGYbYl+u+IqS+3HZ1habn0O9ELOP4Q/xUM3+ThbKql0VnzKHsbDDJJB3GxiGUrLn0rohl35dMVKTSdGXHnR8FgiDIQUgwIPYD5Q0kvYAAAiKYQARXLwEIfwA/P9E3rXLTzgIhDXjIGOIAE45DwXozQCECLAjDyDYCCJDBBPUe/ZjdwDucJsQB5QJzFDKKGBgENkwCDgBELGTYLoKg/iy11kazVI50UNw838K/vW/BsO9bIhSf8K2w51sQoGv71oQbTfrb7+1bVAQEYAABwJgQIvp+dcMQDKw/ECEgp8y+n3YrACyiESQMAcTpYHwIYSAwgwIQiq030HO9itttEGq3EQoueEO7GprpUhOnhFoEgRCE9Jc5FRk51ZMsXlVsSesVCcNMRB2F7pDQHcgoGALRuUXTstSZ2+dlLOIQbK038zDE2HIJzDjvh0FoHdYG4dAGSfdigUZ0T7AAuVSAMechYk2g7DISQgPkEgZt3g/AO5uS0JGFH15lBcUFYpmdeflsjcFSU2mqlpTbKP9I9hjlSSaLsqmzi5jqMhJfhqgpZJyNtR5obJfO4PUzgt0cFH0cuyBHg1MBadh+l6yCCbJK2VXOBex3yKFd1ft42WQgBwGVp77Sx7npyr7l4URKpO5zfvQ5wGBGcoMTuY1O5DYxjY9CZpFRr/3x56cs3M8eyDI2NEDLkbx0TsrgIww9av0yzhfXBNI6ylZ3qoizMZw6BIz26VddbG5lxtECTiWP8wHUcDnY43Efn5CuDropQnUEdP0o1iQyD6ULEcnPRmQ7VNNQr1alvBi14nTkm52Ookyl7mYjtqZwrHkZldv69m6l9g7xy0KW6qe/PnJ23ro9VfuhywW9d/6wM5nKrembi79xaBwHuFk4PJbNTmHtstSG+zwZAx7wqdw2Tm2N7KLEFk6YtyYh256R2Y+du7FcOt3fNKu4tU1AELa1HSITbZzx8+dyW5XB3/LHTpamPE6exhJ1EDyghT2mh26pFQvrMig1QZ+2R7nTxdF1fv6cz8vnA9QvC6Ih6rPoWWbLKH5Jqx02s3omcV5UZGAiKp44ZoIAsJBcJRjSwRGyuSX87JnxJsR9H4Po4GMnjoa/KKqy8aW8DWjlblOdDc5m+0Nu/nlIzY6BJw4SDbjRdaLkzSHYHU4AePIEwCZOAOKME4Attn/R1AZu/+jCD/8D&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="484px" height="68px" viewBox="-0.5 -0.5 484 68" content="&lt;mxfile&gt;&lt;diagram id=&quot;QQJxv4aCTC7ZgE7HHOvM&quot; name=&quot;Page-1&quot;&gt;zVlLc6M4EP41PobSG3GMk8zmsLM1tTns7pGAbGuCkQfkxJ5fvxKIhwAnxPZUDaYSq/Xu/rr7k7zAd9vDH0W823xVqcgWCKSHBb5fIBQhbv5awbEWUE5rwbqQaS2CneBJ/hROCJx0L1NReg21UpmWO1+YqDwXifZkcVGoN7/ZSmX+rLt47WYEneApiTMxavaPTPWmlnIUdvJHIdebZmbIorpmGzeN3cDlJk7VW0+EHxb4rlBK19+2hzuRWd01eqn7fTlR2y6sELme04G6dbzG2d5tzi1MH5vdrgu13y3wcqVy/eTEwJZllt2pTBWmnKvciJfj6d2KXkWhxWHKOPFzJob7N7gRait0cTTtXK8b181BBnG38rfOALDBx6anfEYDB67YWX3djt0pxnxxujmhJ/ixnkwPA0CrhreN1OJpFye25s24gJFt9NYMfg/N11IX6qVFDmoljTIXCLPqMTXrIk6l0ea9LIyypMpNfan2tmdlkC/xVmZWJ7evIpeFWdFf4qDNv68ilfutHftF6GTjbDY2UIuAoYXGlpihahL1nvAKekcf693AM09F6naoCr1Ra5XH2Z9K7ZzGvwutjy6OxHutfHuIPL21UaHDsZF8kXZR1ZBjexntFcd/bXXAAWsE/1UC2AnuD26EunRsSgep684wwq5c9+URdeWuqy00PfsuZ1Cy4olIknfxU838TRTSqF4UvTGHsquCySC0SITvOjou1kL7MpGuxbuQa5wfBZwgGIKIYEDMB4obSLyAAALCGUcEVy8BCL8DPzfRNyVz3c0CIQ3CiDEUAkxCHHHmzQA5DzAnDCPTCCBABhPUm3Zj9mPucJoIBzTkOEQRo4iBQWDDJAgBgIhFDJtFEOTPUqtxNEvlSK3i5vkW/u19C0a+b/GIf8K3Is+3IEDX9q0JN5r0t9/btygPCMAAAoAxIYT7fnXDEAyMPxDOYUiZeT/tVgAYRCNIGAIopIPxIYQBxwxyQCg23kDP9arQbINQs42IhzxsGNexl5pCSqhBEIhARH+ZU5GRUz2J4lUmhq9ekTDMRNRJ6A65XMtDwRCI1i2alqXK7D4vYxFtsDXeHEYRxoZLYBaGfhiExmFNEI5MkLQv5mhE9zgLkE0FGIdhhFgTKPuMhNAA2YRBm/cd8M6mJHRk4YdXUUFxgVhmZl4+G2Owta40VUvKXZy/J3uM8zQTRdnUmUVMdRmJL0PUFDLOxpoHGtOlN3j9jGA3+7BwGkQhGpwKSMP2+2QVTJBVyq5yLmC/Qw7tq97FyyYDWQjIfO0qXZybrvQtDydSIrWf86NPC4OTlvdyG53IbXxmbitEFmv56p/X56cs7GcPZBgbGqDlRF46J2WEIww9KvUyzhfXBNImzlZ3skiyMZx6BIz69KsuNhcy42gBp5LH+QBquBz0eNz7J6RLQTdFqOaCzr/faBKZg9KFiAzPRmQ3VNNQrValuBi1/OPINzsdxZlc25uNxNjGsuZlXO7qi7uVPFjELwtRyp/ursjaeWf3VO2HLhf03vrDXmcyN6Zv7vzGoXEc4Gbh8FQ2OwNrn0ht2OfJGIRBOJXbxqmtkV2U2KIJ89YkZOcZmf3Y28vKpdX9TbOKW9MEBFFX2yMy8dYaP38ud1UZ/C1+7EWpy9PkaSyRreABLcwxPbJLrVhYn0HJCfq0O8mdLo6u8/PnfF4+H6BuWRANUZ/FzyJbxsnLutrh3BvbflRkYCIqfvaYCQLAInKVYEgHR8jmlvCzZ8abCPs+BlHrYx8cDX9RVGXj+3gT0Mr9tjobnM32h9z885CaHQM/OEg04EbXiZI3bbBrTwB48gTAJk4A/IwTgCl2v87UBu5+4sIP/wM=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <rect x="210" y="1" width="110" height="65.5" fill="#ffffff" stroke="none" pointer-events="all"/>
-        <ellipse cx="265" cy="33.75" rx="55" ry="32.749999999999986" fill="#ffffff" stroke="#666666" stroke-width="2" pointer-events="all"/>
-        <path d="M 231.23 59.62 L 298.66 7.94" fill="none" stroke="#666666" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 231.89 7.68 L 300.09 59.82" fill="none" stroke="#666666" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
-        <ellipse cx="265" cy="33.75" rx="43.10200668896321" ry="22.615202702702703" fill="#ffffff" stroke="#666666" stroke-width="2" pointer-events="all"/>
+        <ellipse cx="265" cy="33.75" rx="55" ry="32.749999999999986" fill="rgb(255, 255, 255)" stroke="#666666" stroke-width="2" pointer-events="none"/>
+        <path d="M 231.23 59.62 L 298.66 7.94" fill="none" stroke="#666666" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 231.89 7.68 L 300.09 59.82" fill="none" stroke="#666666" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <ellipse cx="265" cy="33.75" rx="43.10200668896321" ry="22.615202702702703" fill="rgb(255, 255, 255)" stroke="#666666" stroke-width="2" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 84px; height: 1px; padding-top: 34px; margin-left: 223px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
                                 Services
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="265" y="37" fill="#000000" font-family="Avenir Next Medium" font-size="12px" text-anchor="middle">
+                <text x="265" y="37" fill="rgb(0, 0, 0)" font-family="Avenir Next Medium" font-size="12px" text-anchor="middle">
                     Services
                 </text>
             </switch>
         </g>
-        <ellipse cx="433" cy="33.75" rx="50" ry="28.25" fill="#ffffff" stroke="#666666" stroke-width="2" pointer-events="all"/>
+        <ellipse cx="433" cy="33.75" rx="50" ry="28.25" fill="rgb(255, 255, 255)" stroke="#666666" stroke-width="2" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 98px; height: 1px; padding-top: 34px; margin-left: 384px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #333333; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
                                 Event
                                 <br/>
                                 <span>
@@ -45,34 +44,34 @@
                 </text>
             </switch>
         </g>
-        <path d="M 383 33.75 L 355 33.75" fill="none" stroke="#333333" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 320 33.75 L 342 33.75" fill="none" stroke="#333333" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 350 41.75 Q 342 41.75 342 33.75 Q 342 25.75 350 25.75" fill="none" stroke="#333333" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 383 33.75 L 355 33.75" fill="none" stroke="#333333" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 320 33.75 L 342 33.75" fill="none" stroke="#333333" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 350 41.75 Q 342 41.75 342 33.75 Q 342 25.75 350 25.75" fill="none" stroke="#333333" stroke-miterlimit="10" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 15px; margin-left: 350px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 11px; font-family: Avenir Next Medium; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
                                 Hooks
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="350" y="18" fill="#000000" font-family="Avenir Next Medium" font-size="11px" text-anchor="middle">
+                <text x="350" y="18" fill="rgb(0, 0, 0)" font-family="Avenir Next Medium" font-size="11px" text-anchor="middle">
                     Hooks
                 </text>
             </switch>
         </g>
-        <ellipse cx="350" cy="33.75" rx="5" ry="5" fill="#ffffff" stroke="#333333" pointer-events="all"/>
-        <path d="M 107 33.75 L 203.63 33.75" fill="none" stroke="#666666" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 208.88 33.75 L 201.88 37.25 L 203.63 33.75 L 201.88 30.25 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="350" cy="33.75" rx="5" ry="5" fill="rgb(255, 255, 255)" stroke="#333333" pointer-events="none"/>
+        <path d="M 107 33.75 L 203.63 33.75" fill="none" stroke="#666666" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 208.88 33.75 L 201.88 37.25 L 203.63 33.75 L 201.88 30.25 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 34px; margin-left: 155px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #000000; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
                                 <p style="line-height: 0.9">
                                     Requests
                                     <br/>
@@ -85,18 +84,18 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="155" y="37" fill="#000000" font-family="Avenir Next Medium" font-size="12px" text-anchor="middle">
+                <text x="155" y="37" fill="rgb(0, 0, 0)" font-family="Avenir Next Medium" font-size="12px" text-anchor="middle">
                     Requests...
                 </text>
             </switch>
         </g>
-        <ellipse cx="54" cy="33.75" rx="53" ry="29.25" fill="#ffffff" stroke="#666666" stroke-width="2" pointer-events="all"/>
+        <ellipse cx="54" cy="33.75" rx="53" ry="29.25" fill="rgb(255, 255, 255)" stroke="#666666" stroke-width="2" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 104px; height: 1px; padding-top: 34px; margin-left: 2px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Avenir Next Medium; color: #333333; line-height: 1.2; pointer-events: all; font-style: italic; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: &quot;Avenir Next Medium&quot;; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: none; font-style: italic; white-space: normal; overflow-wrap: normal;">
                                 Consumers
                             </div>
                         </div>
@@ -112,7 +111,7 @@
         <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
         <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
             <text text-anchor="middle" font-size="10px" x="50%" y="100%">
-                Viewer does not support full SVG 1.1
+                Text is not SVG - cannot display
             </text>
         </a>
     </switch>


### PR DESCRIPTION
If not necessary, we shouldn't use white background colors in graphics, as the automatic dark mode hue rotation doesn't exactly match the dark background color. 

Have a look at the rectangle behind "Services" and the bottom labels:

Before:

<img width="485" alt="Screenshot 2023-06-01 at 01 25 32" src="https://github.com/cap-js/docs/assets/24377039/59a547d6-b7c1-4d95-8e23-c60180c2d53b">

After:

<img width="616" alt="Screenshot 2023-06-01 at 01 26 00" src="https://github.com/cap-js/docs/assets/24377039/17e9b662-b731-4c65-b8dd-fc7709a710e4">
