### PR TITLE
Use `.mute-dark` instead of hue rotation for screenshot

### DIFF
--- a/guides/messaging/s4.md
+++ b/guides/messaging/s4.md
@@ -49,7 +49,7 @@ For example, using [SAP API Business Hub](https://api.sap.com/):
 4. Choose _Schema_ tab.
 5. Expand the `data` property.
 
-![business-partner-events](assets/business-partner-events.png)
+![business-partner-events](assets/business-partner-events.png){.mute-dark}
 
 The expanded part, highlighted in red, tells you all you need to know:
 


### PR DESCRIPTION
Looks kind of bad with inverted logo colors etc:

<img width="858" alt="Screenshot 2023-06-01 at 15 14 35" src="https://github.com/cap-js/docs/assets/24377039/0ae42639-63c5-434b-ab6b-da756b41b130">
