### PR TITLE
Use `console` lang instead of `sh` for colored logs

### DIFF
--- a/get-started/in-a-nutshell.md
+++ b/get-started/in-a-nutshell.md
@@ -91,7 +91,7 @@ cd srv && mvn cds:watch
 
 ::: details `cds watch` is waiting for things to come...
 
-```sh
+```console
 [dev] cds w
 
 cds serve all --with-mocks --in-memory?
@@ -499,7 +499,7 @@ In Node.js, the easiest way to provide implementations for services is through e
 
 <div class="impl node">
 
-```sh
+```console
 ./srv
   - cat-service.cds  # service definitions
   - cat-service.js   # service implementation

--- a/get-started/jumpstart.md
+++ b/get-started/jumpstart.md
@@ -175,7 +175,7 @@ cd srv && mvn cds:watch
 
 ::: details From the log output we see  `cds watch` is waiting for things to come...
 
-```sh
+```console
 [dev] cds w
 
 cds serve all --with-mocks --in-memory?

--- a/node.js/cds-facade.md
+++ b/node.js/cds-facade.md
@@ -10,7 +10,7 @@ status: released
 
 The `cds` facade object provides access to all CAP Node.js APIs. Use it like that:
 
-```sh
+```js
 const cds = require('@sap/cds')
 let csn = cds.compile(`entity Foo {}`)
 ```
@@ -19,7 +19,7 @@ let csn = cds.compile(`entity Foo {}`)
 
 Use `cds repl` to try out things, for example like this to :
 
-```sh
+```console
 [dev] cds repl
 Welcome to cds repl v6.8.0
 > cds.compile(`entity Foo { key ID : UUID }`)
@@ -117,7 +117,7 @@ if (cds.version[0] < 6) // code for pre cds6 usage
 
 Returns the pathname of the `@sap/cds` installation folder from which the current instance of the `cds` facade module was loaded.
 
-```sh
+```console
 [dev] cds repl
 > cds.home // [!code focus]
 ~/.npm/lib/node_modules/@sap/cds
@@ -164,7 +164,7 @@ For example, [`cds-plugins`](cds-serve) can use that to plugin to different part
 
 Provides access to the effective configuration of the current process, transparently from various sources, including the local _package.json_ or _.cdsrc.json_, service bindings and process environments.
 
-```js
+```console
 [dev] cds repl
 > cds.env.requires.auth // [!code focus]
 {
@@ -173,7 +173,7 @@ Provides access to the effective configuration of the current process, transpare
   users: {
     alice: { tenant: 't1', roles: [ 'cds.Subscriber', 'admin' ] },
     bob: { tenant: 't1', roles: [ 'cds.ExtensionDeveloper' ] },
-    // ...,
+    # ...,
     '*': true
   },
   tenants: {
@@ -191,12 +191,12 @@ Provides access to the effective configuration of the current process, transpare
 
 ... is a convenience shortcut to [`cds.env.requires`](#cds-env).
 
-```js
+```console
 [dev] cds repl
 > cds.requires.auth // [!code focus]
 {
   kind: 'basic-auth',
-  // ... as above
+  # ... as above
 }
 ```
 

--- a/node.js/cds-utils.md
+++ b/node.js/cds-utils.md
@@ -69,7 +69,7 @@ We commonly use that in CAP implementations to print filenames to stdout that yo
 
 For example, if we run bookshop from the parent folder, filenames are correctly printed with a `bookshop/` prefix:
 
-```sh
+```console
 [samples] cds run bookshop
 [cds] - loaded model from 5 file(s):
 
@@ -77,13 +77,12 @@ For example, if we run bookshop from the parent folder, filenames are correctly 
   bookshop/srv/cat-service.cds
   bookshop/srv/admin-service.cds
   bookshop/db/schema.cds
-
 ...
 ```
 
 If we run it from within the *bookshop* folder, no prefixes show up:
 
-```sh
+```console
 [bookshop] cds run
 [cds] - loaded model from 5 file(s):
 
@@ -91,7 +90,6 @@ If we run it from within the *bookshop* folder, no prefixes show up:
   srv/cat-service.cds
   srv/admin-service.cds
   db/schema.cds
-
 ...
 ```
 


### PR DESCRIPTION
For especially colorful logs, where we used `sh` as language, use `console` instead.  Being an alias for `sh`, this provides the exact same output, but makes clearer it's an output rather than an input shell command.

This is nice for notbooks as they can render it as an output cell w/o additional configuration.