### PR TITLE
`null` is not a legal annotation value and not rendered

### DIFF
--- a/advanced/odata.md
+++ b/advanced/odata.md
@@ -256,10 +256,7 @@ Primitive annotation values, meaning Strings, Numbers, `true`, and `false` are m
 <Annotation Term="Some.String" String="foo"/>
 ```
 
-#### Primitive Null
-
-The annotation value `null` has a special semantics in CDL: it removes an existing annotation assignment. Rendering a `null` value
-must be done as dynamic expression:
+Rendering a `null` value must be done as dynamic expression:
 
 ```cds
 @Some.Null: { $edmJson: { $Null } }


### PR DESCRIPTION
Use dynamic OData `Null` expression instead: ` { $edmJson: { $Null } }`