### PR TITLE
Update i18n.md

### DIFF
--- a/guides/i18n.md
+++ b/guides/i18n.md
@@ -165,7 +165,7 @@ Upon incoming requests at runtime, the user's preferred language is determined a
    4. The `default_language` configured on the app level.
 2. Narrow to normalized locales as described below.
 ::: tip
-CAP also accepts formats following the available standards of POSIX and RFC 1766, and transforms them into normalized locales.
+CAP Node.js accepts formats following the available standards of POSIX and RFC 1766, and transforms them into normalized locales. CAP Java only accepts language codes following the standard of RFC 1766 (or [IETF's BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)).
 :::
 
 ## Normalized Locales { #normalized-locales}


### PR DESCRIPTION
Clarifying that CAP Java only accepts language codes/tags following the [BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) standard.