### PR TITLE
Expected format of language codes in locale column

### DIFF
--- a/guides/localized-data.md
+++ b/guides/localized-data.md
@@ -363,7 +363,7 @@ Content-Type: application/json
 ```
 
 ::: warning *Note:* <!--  -->
-Accepted language codes in the `locale` property need to follow the [BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) standard but use __underscore__ (`_`) instead of __hyphen__ (`-`), for example `en_GB` instead of `en-GB`.
+Accepted language codes in the `locale` property need to follow the [BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) standard but use __underscore__ (`_`) instead of __hyphen__ (`-`), for example `en_GB`.
 :::
 
 ### Delete Operations


### PR DESCRIPTION
Clarifying the expected format of language codes used in the locale column when writing to the database.