### PR TITLE
Difference in support of incoming locale strings between Nodejs and Java

### DIFF
--- a/guides/i18n.md
+++ b/guides/i18n.md
@@ -224,6 +224,6 @@ In effect, this means:
 - We always normalize these to underscores, which is `en_GB`.
 - Always use underscores in filenames, for example, `i18n_en_GB.properties`
 
-<sup>1</sup> CAP Node.js also supports underscore separated tags, for example `en_GB`
+<sup>1</sup> CAP Node.js also supports underscore separated tags, for example `en_GB`.
 
 <div id="translation-sap" />


### PR DESCRIPTION
Noting that the support of both hyphens or underscore in incoming locales is only supported by CAP Node.js and that CAP Java only supports the hyphen variant.