### PR TITLE
improve log language

### DIFF
--- a/.vitepress/syntaxes/log.tmLanguage.json
+++ b/.vitepress/syntaxes/log.tmLanguage.json
@@ -1,7 +1,9 @@
 {
   "name": "log syntax",
   "scopeName": "text.log",
-  "fileTypes": ["log"],
+  "fileTypes": [
+    "log"
+  ],
   "patterns": [
     {
       "name": "comment.indented",
@@ -12,6 +14,9 @@
       "end": "\\}",
       "patterns": [
         {
+          "include": "$self"
+        },
+        {
           "name": "string.quoted.single",
           "match": "('.*?')"
         },
@@ -20,19 +25,52 @@
           "match": "\\b(\\d+)\\b"
         },
         {
-          "name": "constant.boolean",
+          "name": "constant.language",
           "match": "\\b(true|false)\\b"
         }
       ]
+    },
+    {
+      "match": "([\\w]+\\.)*[\\w]+ = (\\d*)(true|false)?(.*)",
+      "captures": {
+        "2": {
+          "name": "constant.numeric"
+        },
+        "3": {
+          "name": "constant.language"
+        },
+        "4": {
+          "name": "string.quoted.single"
+        }
+      }
+    },
+    {
+      "match": "^(?:\\[.*?\\]|\\$) (cds) (.*)$",
+      "captures": {
+        "1": {
+          "name": "constant.other.key"
+        },
+        "2": {
+          "name": "string"
+        }
+      }
     }
   ],
   "repository": {
     "main": {
       "patterns": [
-        { "include": "#comment.indented" },
-        { "include": "#string.quoted.single" },
-        { "include": "#constant.numeric" },
-        { "include": "#constant.boolean" }
+        {
+          "include": "#comment.indented"
+        },
+        {
+          "include": "#string.quoted.single"
+        },
+        {
+          "include": "#constant.numeric"
+        },
+        {
+          "include": "#constant.boolean"
+        }
       ]
     }
   }


### PR DESCRIPTION
Provides following improvements for the `log` language tag:

- highlights cds commands starting with `$` or `[*]` correctly  (see first and second picture)
- highlights string, number and boolean values in log outputs JSON-like (see second picture)


![Screenshot 2023-06-22 at 15 35 45](https://github.com/cap-js/docs/assets/127967727/c15328d7-b3f7-41e6-93ff-c9449e64195a)
![Screenshot 2023-06-22 at 15 35 34](https://github.com/cap-js/docs/assets/127967727/7e07d3ff-664b-420e-92b6-656317f169f2)
