### PR TITLE
Notebooks: minor fixes in 'Getting stared' guide

### DIFF
--- a/get-started/in-a-nutshell.md
+++ b/get-started/in-a-nutshell.md
@@ -287,7 +287,7 @@ As you can see in the log output, the two service definitions have been compiled
 Both services defined above contain security annotations that restrict access to certain endpoints. Please add the dependency to spring-boot-security-starter to the srv/pom.xml in order to activate mock user and authentication support:
 :::
 
-// TODO Notebooks: can't be automated yet as it requires insert in pom.xml
+<!-- TODO Notebooks: can't be automated yet as it requires insert in pom.xml -->
 ```xml
 <dependency>
   <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
- As discussed, fixes for "Getting Stared in a Nutshell" Tutorial which make the workflow run without errors