### PR TITLE
Add `.caption` class

### DIFF
--- a/.vitepress/theme/custom.scss
+++ b/.vitepress/theme/custom.scss
@@ -54,6 +54,10 @@ main {
     ul {
       padding-left: 2.2em;
     }
+    .caption {
+      text-align: center;
+      color: #888;
+    }
     div.language-zsh pre code {
       line-height: 1.4em
     }

--- a/about/index.md
+++ b/about/index.md
@@ -104,13 +104,10 @@ CAP places **primary focus on domain**, by capturing _domain knowledge_ and _int
 
 The figure below illustrates the prevalent use of CDS models (in the left column), which fuel generic runtimes, like the CAP service runtimes or databases.
 
-<figure>
-  <img src="../assets/core-concepts.drawio.svg" width="650px" >
-  <figcaption>Anatomy of a Typical Application</figcaption>
-</figure>
-<br >
+![](../assets/core-concepts.drawio.svg)
+Anatomy of a Typical Application{.caption}
 
-<br><br>
+<br>
 
 ###### Core Data Services (CDS)
 


### PR DESCRIPTION
Added a `.caption` class to display (visible) image descriptions. Normal left-aligned text looks a bit out of place.

Before:
![Screenshot 2023-07-03 at 11 34 36](https://github.com/cap-js/docs/assets/24377039/679d095d-e476-451c-b4ef-5f0b623f3190)


After:
![Screenshot 2023-07-03 at 11 34 23](https://github.com/cap-js/docs/assets/24377039/422ce8a9-c577-4fca-a609-eef9b5c6cbb5)

