### PR TITLE
Set GH link to `docs` repo, remove internal link

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -50,7 +50,7 @@ const config:UserConfig<CapireThemeConfig> = {
     },
     externalLinkIcon: true,
     socialLinks: [
-      {icon: 'github', link: 'https://github.com/cap-js/'}
+      {icon: 'github', link: 'https://github.com/cap-js/docs'}
     ],
     outline: [1,3],
     capire: { versions: latestVersions, gotoLinks: [] }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,5 @@
     "**/CONTRIBUTING.md": true,
     "**/LICENSE*": true,
     "**/node_modules/": true
-  },
-  "github-enterprise.uri": "https://github.tools.sap"
+  }
 }


### PR DESCRIPTION
Using a link to the repo instead of to the org makes more sense I think.

See #291