### PR TITLE
Search: don't split at `[-_.@]`, optimise index

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -43,7 +43,22 @@ const config:UserConfig<CapireThemeConfig> = {
       options: {
         miniSearch: {
           options: {
-            tokenize: text => text.split( /[\n\r #%*,/:;?[\]{}()&]+/u ) // simplified charset: removed [-_.@] and non-english chars (diacritics etc.)
+            tokenize: text => text.split( /[\n\r #%*,=/:;?[\]{}()&]+/u ), // simplified charset: removed [-_.@] and non-english chars (diacritics etc.)
+            processTerm: (term, fieldName) => {
+              term = term.trim().toLowerCase().replace(/^\.+/, '').replace(/\.+$/, '')
+              const stopWords = ['and', 'the', 'com', 'sap', 'cds', 'java', 'json', 'node', 'node.js', 'frontmatter', '$frontmatter.synopsis']
+              if (term.length < 3 || stopWords.includes(term))  return false
+
+              if (fieldName === 'text') {
+                // as we don't tokenize along . to keep expressions like `cds.requires.db`, split and add the single parts as extra terms
+                const parts = term.split('.')
+                if (parts.length > 1) {
+                  const newTerms = [term, ...parts].filter(t => t.length >= 3).filter(t => !stopWords.includes(t))
+                  return newTerms
+                }
+              }
+              return term
+            },
           }
         }
       }

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -39,7 +39,14 @@ const config:UserConfig<CapireThemeConfig> = {
       ] },
     ]},
     search: {
-      provider: 'local'
+      provider: 'local',
+      options: {
+        miniSearch: {
+          options: {
+            tokenize: text => text.split( /[\n\r #%*,/:;?@[\]{}]+/u ) // simplified charset: removed [-_.] and non-english chars (diacritics etc.)
+          }
+        }
+      }
     },
     footer: {
       message: '<a href="https://www.sap.com/about/legal/impressum.html" target="_blank">Legal Disclosure</a> | <a href="https://www.sap.com/corporate/en/legal/terms-of-use.html" target="_blank">Terms of Use</a> | <a href="https://www.sap.com/about/legal/privacy.html" target="_blank">Privacy</a>',

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -43,7 +43,7 @@ const config:UserConfig<CapireThemeConfig> = {
       options: {
         miniSearch: {
           options: {
-            tokenize: text => text.split( /[\n\r #%*,/:;?@[\]{}]+/u ) // simplified charset: removed [-_.] and non-english chars (diacritics etc.)
+            tokenize: text => text.split( /[\n\r #%*,/:;?@[\]{}()&]+/u ) // simplified charset: removed [-_.] and non-english chars (diacritics etc.)
           }
         }
       }

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -43,7 +43,7 @@ const config:UserConfig<CapireThemeConfig> = {
       options: {
         miniSearch: {
           options: {
-            tokenize: text => text.split( /[\n\r #%*,/:;?@[\]{}()&]+/u ) // simplified charset: removed [-_.] and non-english chars (diacritics etc.)
+            tokenize: text => text.split( /[\n\r #%*,/:;?[\]{}()&]+/u ) // simplified charset: removed [-_.@] and non-english chars (diacritics etc.)
           }
         }
       }


### PR DESCRIPTION
Also simplify tokenizer by removing the many unicode chars that target non-English language.

Fixes #270 