### PR TITLE
Search: boost or downrate pages (Java/Node)

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -41,6 +41,7 @@ const config:UserConfig<CapireThemeConfig> = {
     search: {
       provider: 'local',
       options: {
+        exclude: (relativePath) => relativePath.includes('/customization-old'),
         miniSearch: {
           options: {
             tokenize: text => text.split( /[\n\r #%*,=/:;?[\]{}()&]+/u ), // simplified charset: removed [-_.@] and non-english chars (diacritics etc.)

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -60,6 +60,18 @@ const config:UserConfig<CapireThemeConfig> = {
               }
               return term
             },
+          },
+          searchOptions: {
+            //@ts-ignore
+            boostDocument: (documentId, term, storedFields:Record<string, string|string[]>) => {
+              // downrate matches in archives, changelogs etc.
+              if (documentId.match(/\/archive|changelog|old-mtx-apis/)) return -5
+              // downrate Java matches if Node is toggled and vice versa
+              const toggled = localStorage.getItem('impl-variant')
+              if (toggled === 'node' && (documentId.includes('/java/')    || storedFields?.titles?.includes('Java')))    return -1
+              if (toggled === 'java' && (documentId.includes('/node.js/') || storedFields?.titles?.includes('Node.js'))) return -1
+              return 1
+            }
           }
         }
       }


### PR DESCRIPTION
Downrate Java pages if Node toggle is set and vice versa.
This does not address pages w/ mixed content, but improves the search
of pure Java/Node pages.

Example is search for `draft` that only shows the relevant pages.

Also downrate some archived/old pages.