### PR TITLE
hello-world: `cds add samples` is deprecated

### DIFF
--- a/get-started/hello-world.md
+++ b/get-started/hello-world.md
@@ -28,7 +28,7 @@ Let's create a simple _Hello World_ OData service using the SAP Cloud Applicatio
 <div class="impl node">
 
 ```sh
-cds init hello-world --add samples
+cds init hello-world --add tiny-sample
 cd hello-world
 ```
 


### PR DESCRIPTION
`@sap/cds@7.0.3` informs me that:

!['cds add samples' is deprecated and will be removed in future versions. Please use 'cds add tiny-sample' instead.](https://github.com/cap-js/docs/assets/10234267/ca9c9e86-89ec-4e55-850b-3ac520332fb5)
