### PR TITLE
add link for Node.js Lifecycle Events in cds-facade

### DIFF
--- a/node.js/cds-facade.md
+++ b/node.js/cds-facade.md
@@ -336,7 +336,7 @@ cds.exit() //> will rune above handlers before stopping the server
 
 ## Lifecycle Events
 
-
+[Learn more about Lifecycle Events in `cds.server`](cds-server#lifecycle-events){.learn-more}
 
 #### cds. once '*bootstrap*' {.event}
 


### PR DESCRIPTION
There are currently two places, where Lifecycle Events are mentioned. Only the second place (cds-server) contains the actual description.
Hence I included added a link.
- https://cap.cloud.sap/docs/node.js/cds-facade#lifecycle-events
- https://cap.cloud.sap/docs/node.js/cds-server#lifecycle-events