### PR TITLE
Potential fix for Resolve Binding in Hybrid Mode

### DIFF
--- a/advanced/hybrid-testing.md
+++ b/advanced/hybrid-testing.md
@@ -239,10 +239,6 @@ Example output:
 }
 ```
 
-::: warning
-Only `cds watch` and `cds env` (the latter with the `--resolve-bindings` option) resolve cloud bindings. Bindings are not resolved by `cds serve` or `cds exec`.
-:::
-
 ### Run Arbitrary Commands with Service Bindings
 
 With `cds bind` you avoid storing credentials on your hard disk. If you need to start other applications with cloud service bindings from local, then you can use the [`exec` sub command](#cds-bind-exec) of `cds bind`.

--- a/advanced/hybrid-testing.md
+++ b/advanced/hybrid-testing.md
@@ -240,7 +240,7 @@ Example output:
 ```
 
 ::: warning
-Only `cds watch` and `cds env` (the latter with the `--resolve-bindings` option) resolve cloud bindings. Bindings are resolved by `cds serve` or `cds exec`.
+Only `cds watch` and `cds env` (the latter with the `--resolve-bindings` option) resolve cloud bindings. Bindings are not resolved by `cds serve` or `cds exec`.
 :::
 
 ### Run Arbitrary Commands with Service Bindings


### PR DESCRIPTION
If I understand the first sentence of the warning correctly, cloud bindings are only resolved by cds watch and cds env. This means, the seconds sentence is missing a "not". If I understood the warning wrong, could you please provide a better explanation what information the second sentence is intended to add?