### PR TITLE
Fiori Draft: add info on switching on fiori-draft-enabled

### DIFF
--- a/advanced/fiori.md
+++ b/advanced/fiori.md
@@ -416,6 +416,11 @@ annotate sap.capire.bookshop.Books with @fiori.draft.enabled;
 
 > Background: SAP Fiori drafts require single keys of type `UUID`, which isn’t the case by default for the automatically generated `_texts` entities (&rarr; [see the _Localized Data_ guide for details](../guides/localized-data#behind-the-scenes)). The `@fiori.draft.enabled` annotation tells the compiler to add such a technical primary key element named `ID_texts`.
 
+::: warning
+Adding the annotation `@fiori.draft.enabled` only works as long as the corresponding `_texts` entities
+don't yet contain any entries.
+:::
+
 ![An SAP Fiori UI showing how a book is edited in the bookshop sample and that the translations tab is used for non-standard languages.](../assets/draft-for-localized-data.png){style="margin:0"}
 [See it live in **cap/samples**.](https://github.com/sap-samples/cloud-cap-samples/tree/main/fiori/app/admin-books/fiori-service.cds#L50){.learn-more}
 

--- a/advanced/fiori.md
+++ b/advanced/fiori.md
@@ -418,7 +418,7 @@ annotate sap.capire.bookshop.Books with @fiori.draft.enabled;
 
 ::: warning
 Adding the annotation `@fiori.draft.enabled` only works as long as the corresponding `_texts` entities
-don't yet contain any entries.
+don't yet contain any entries, because existing entries don't have a value for the new key field `ID_texts`.
 :::
 
 ![An SAP Fiori UI showing how a book is edited in the bookshop sample and that the translations tab is used for non-standard languages.](../assets/draft-for-localized-data.png){style="margin:0"}


### PR DESCRIPTION
Can only be switched on if texts entities don't contain entries.

