### PR TITLE
Revert "default pool config not applicable for @cap-js databases"

### DIFF
--- a/node.js/databases.md
+++ b/node.js/databases.md
@@ -66,10 +66,6 @@ By default, the following [pool configuration](https://www.npmjs.com/package/gen
 }
 ```
 
-::: warning
-This default pool configuration does not apply to `@cap-js` database implementations.
-:::
-
 The _generic-pool_ has a built-in pool evictor, which inspects idle database connections in the pool and destroys them if they are too old.
 
 The following parameters are provided in the pool configuration:
@@ -108,7 +104,6 @@ Pool configuration can be adjusted by setting the `pool` option as shown in the 
   }
 }
 ```
-
 ::: warning _❗ Warning_
 The parameters are very specific to the current technical setup, such as the application environment and database location.
 Even though we provide a default pool configuration, we expect that each application provides its own configuration based on its specific needs.
@@ -158,4 +153,4 @@ In contrast to the Java runtime, deep upserts and delta payloads are not yet sup
 ##  <i>  More to Come </i>
 
 This documentation is not complete yet, or the APIs are not released for general availability.
-Stay tuned to upcoming releases for further updates.
+There's more to come in this place in upcoming releases.


### PR DESCRIPTION
Reverts cap-js/docs#314