### PR TITLE
Fix markdownlinting errors

### DIFF
--- a/about/glossary.md
+++ b/about/glossary.md
@@ -12,13 +12,13 @@ CAP-related Terms and Acronyms {.subtitle}
 <!-- {{$frontmatter?.synopsis}} -->
 <br>
 
-[CAP]() — shorthand for "SAP Cloud Application Programming Model"
+[CAP](./glossary.md) — shorthand for "SAP Cloud Application Programming Model"
 : Not an official name, though.
 
-[capire]() — Italian for 'understand'
+[capire](./glossary.md) — Italian for 'understand'
 : ... and the title of these pages and documentation of CAP.
 
-[tl;dr]() — too long; didn't read
+[tl;dr](./glossary.md) — too long; didn't read
 : a common social phenomenon these days. Therefore, capire is rather meagre with text and greased with code. You have to read between the lines, sorry.
 
 ---

--- a/guides/databases-hana.md
+++ b/guides/databases-hana.md
@@ -415,7 +415,7 @@ There are cases where you have to resolve or refactor the generated statements, 
 
 Example:
 
-```
+```txt
 >>>> Manual resolution required - DROP statements causing data loss are disabled
 >>>> by default.
 >>>> You may either:
@@ -477,7 +477,7 @@ ALTER TABLE E ALTER (text NVARCHAR(100) FUZZY SEARCH INDEX ON);
 It's important to understand that during deployment new migration versions will be applied on the existing database schema. If the resulting schema doesn't match the schema as defined by the TABLE statement, deployment fails and any changes are rolled-back. In consequence, when removing or replacing an existing `@sql.append` annotation, the original ALTER statements need to be undone. As the required statements can't automatically be determined, manual resolution is required. The CDS build generates comments starting with `>>>>` in order to provide some guidance and enforce manual resolution.
 
 Generated file with comments:
-```
+```txt
 == migration=3
 >>>>> Manual resolution required - insert ALTER statement(s) as described below.
 >>>>> After manual resolution delete all lines starting with >>>>>

--- a/java/application-services.md
+++ b/java/application-services.md
@@ -44,7 +44,7 @@ To learn more about the entity data argument `List<Books> books` of the event ha
 
 Application Services are used by OData protocol adapters to expose the Application Service's API as an OData API on a path with the following pattern:
 
-```
+```txt
 http(s)://<application_url>/<base_path>/<service_name>
 ```
 

--- a/java/getting-started.md
+++ b/java/getting-started.md
@@ -122,7 +122,7 @@ CAP Java also provides a starter bundle for SAP BTP Kyma environment. See [CAP S
 
 The generated project has the following folder structure:
 
-```
+```txt
 <PROJECT-ROOT>/
 |-- db/
     `-- data-model.cds
@@ -172,7 +172,7 @@ mvn com.sap.cds:cds-maven-plugin:addIntegrationTest
 ```
 
 This command also creates a new folder *integration-tests/src/test/java*, which contains integration test classes:
-```
+```txt
 <PROJECT-ROOT>/
 `-- integration-tests/
     `-- src/test/java/

--- a/java/migration.md
+++ b/java/migration.md
@@ -71,9 +71,9 @@ CAP Java 2.0 itself requires updated [dependency versions](./development/#depend
 - Java Logging (replace `cf-java-logging-support-servlet` with `cf-java-logging-support-servlet-jakarta`)
 
 ::: warning
-The Cloud SDK BOM `sdk-bom` manages XSUAA until version 2.x, which isn't compatible with CAP Java 2.x. 
+The Cloud SDK BOM `sdk-bom` manages XSUAA until version 2.x, which isn't compatible with CAP Java 2.x.
 You have two options:
-* Replace `sdk-bom` with `sdk-modules-bom`, which [manages all Cloud SDK dependencies but not the transitive dependencies.](https://sap.github.io/cloud-sdk/docs/java/guides/manage-dependencies#the-sap-cloud-sdk-bill-of-material) 
+* Replace `sdk-bom` with `sdk-modules-bom`, which [manages all Cloud SDK dependencies but not the transitive dependencies.](https://sap.github.io/cloud-sdk/docs/java/guides/manage-dependencies#the-sap-cloud-sdk-bill-of-material)
 * Or, add [dependency management for XSUAA](https://github.com/SAP/cloud-security-services-integration-library#installation) before Cloud SDK's `sdk-bom`.
 :::
 
@@ -685,7 +685,7 @@ Also replace the classic handler return types with the corresponding new impleme
 There are numerous files in your classic project, which aren’t required and supported anymore in the new project.
 Don't copy any of the following files to the new project:
 
-```
+```txt
 <PROJECT-ROOT>/
 |-- db/
 |   |-- .build.js

--- a/java/persistence-services.md
+++ b/java/persistence-services.md
@@ -168,7 +168,7 @@ To generate a `schema.sql` for H2, use the dialect `h2` with the `cds deploy` co
 In Spring, H2 is automatically initialized in-memory when present on the classpath. See the official [documentation](http://www.h2database.com/html/features.html) for H2 for file-based database configuration.
 
 The `cds-maven-plugin` provides the goal `add` that can be used to add H2 support to the CAP Java project:
-```
+```sh
 mvn com.sap.cds:cds-maven-plugin:add -Dfeature=H2 -Dprofile=default
 ```
 
@@ -201,7 +201,7 @@ Also, you need to enable compiler support for session context variables in _.cds
 In addition, in the _application.yaml_ file, set `cds.sql.supportedLocales: "*"` to advise the runtime to use session context variables.
 
 The `cds-maven-plugin` provides the goal `add` that can be used to add Sqlite support to the CAP Java project:
-```
+```sh
 mvn com.sap.cds:cds-maven-plugin:add -Dfeature=SQLITE -Dprofile=default
 ```
 

--- a/java/query-introspection.md
+++ b/java/query-introspection.md
@@ -370,7 +370,7 @@ for (Map<String, Object> book : books) {
 
 The output will be:
 
-```
+```txt
 Catweazle	no match
 The Raven	match
 Dracula		no match

--- a/java/reflection-api.md
+++ b/java/reflection-api.md
@@ -192,7 +192,7 @@ CAP Java does not make any assumption _how_ the set of enabled features (_active
 
 Features are modeled in CDS by dividing up CDS code concerning separate features into separate subfolders of a common `fts` folder of your project, as shown by the following example:
 
-```
+```txt
 |-- [db]
 |   |-- my-model.cds
 |   `-- ...

--- a/java/remote-services.md
+++ b/java/remote-services.md
@@ -131,7 +131,7 @@ When loading destinations from SAP BTP Destination Service, you can specify a [d
 
 These strategies can be set in the destination configuration of the _Remote Service_:
 
-```
+```yml
 cds:
   remote.services:
   - name: "API_BUSINESS_PARTNER"

--- a/node.js/cds-facade.md
+++ b/node.js/cds-facade.md
@@ -35,13 +35,13 @@ Welcome to cds repl v6.8.0
 
 Many properties of cds are references to submodules, which are lazy-loaded on first access to minimize bootstrapping time and memory consumption. The submodules are documented in separate documents.
 
-- [cds. models]() {.property}
-  - [cds. resolve()]() {.method}
-  - [cds. load()]() {.method}
-  - [cds. parse()]() {.method}
+- [cds. models](./cds-facade.md) {.property}
+  - [cds. resolve()](./cds-compile.md#cds-resolve) {.method}
+  - [cds. load()](./cds-facade.md) {.method}
+  - [cds. parse()](./cds-compile.md#cds-parse) {.method}
   - [cds. compile](cds-compile) {.method}
   - [cds. linked()](cds-reflect) {.method}
-  - [cds. deploy()]() {.method}
+  - [cds. deploy()](./cds-facade.md) {.method}
 - [cds. server](cds-serve) {.property}
 - [cds. serve()](cds-serve) {.method}
   - cds. services {.property}

--- a/node.js/cds-i18n.md
+++ b/node.js/cds-i18n.md
@@ -1,6 +1,6 @@
 # Localization / i18n
 
-## 
+##
 
 ### Generic Errors
 
@@ -57,7 +57,7 @@ module.exports = (srv) => {
 
 Find the current list of generic runtime texts:
 
-```
+```txt
 400=Bad Request
 401=Unauthorized
 403=Forbidden

--- a/tools/cds-typer.md
+++ b/tools/cds-typer.md
@@ -359,7 +359,7 @@ _tsconfig.json_, as we do not want to interfere with your configuration.
 The emitted types are bundled into a directory which contains a nested directory structure that mimics the namespaces of your CDS model. For the sake of brevity, we will assume them to be in a directory called _@cds-models_ in your project's root in the following sections.
 For example, the sample model contains a namespace `sap.capire.bookshop`. You will therefore find the following file structure after the type generation has finished:
 
-```
+```txt
 @cds-models
 └───sap
     └───capire
@@ -388,7 +388,7 @@ Adding type support via `cds add typer` includes adding [subpath imports](https:
 
 Consider [the bookshop sample](https://github.com/SAP-samples/cloud-cap-samples/tree/main/bookshop) with the following structure with types already generated into _@cds-models_:
 
-```
+```txt
 bookstore
 │   package.json
 │


### PR DESCRIPTION
Adds some missing languages tags. 

Also found some markdown links without link value. For some I have found a matching link e.g.: `[cds. resolve()]()` &#8594; `[cds. resolve()](./cds-compile.md#cds-resolve)`, but for some there is no own section like `[tl;dr]()` in `about/glossary.md` or `[cds. load()]()` in `node.js/cds-facade.md`. In these cases, the link simply points to the current page.