### PR TITLE
Drop italic font styling for `.learn-more`

### DIFF
--- a/.vitepress/theme/custom.scss
+++ b/.vitepress/theme/custom.scss
@@ -252,7 +252,6 @@ kbd {
 
 .learn-more {
   color: var(--vp-c-gray);
-  font-style: italic;
   margin-top: -5px;
   margin-bottom: 5px;
   display: block;


### PR DESCRIPTION
Using italic by default has the problem that emphasized parts are not distinguishable any more:

<img width="574" alt="Screenshot 2023-08-15 at 20 22 08" src="https://github.com/cap-js/docs/assets/24377039/a91c6fdf-5394-41af-830c-20f54a1defe8">

<img width="622" alt="Screenshot 2023-08-15 at 20 22 31" src="https://github.com/cap-js/docs/assets/24377039/3d146af0-6d25-4ef9-9a6c-9638d71ad32c">

Alternatively, if you want to keep the italic font we could look for other ways to emphasize here (e.g. boldness).