### PR TITLE
Release: Restore order in index page (#391)

### DIFF
--- a/.vitepress/theme/components/indexFilter.js
+++ b/.vitepress/theme/components/indexFilter.js
@@ -1,4 +1,5 @@
-const { themeConfig: { sidebar }} = global.VITEPRESS_CONFIG.site
+const { base, themeConfig: { sidebar }} = global.VITEPRESS_CONFIG.site
+import { join } from 'node:path'
 
 export default (pages, basePath) => {
   let items = findInItems(basePath, sidebar) || []

--- a/.vitepress/theme/components/indexFilter.js
+++ b/.vitepress/theme/components/indexFilter.js
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 export default (pages, basePath) => {
   let items = findInItems(basePath, sidebar) || []
   items = items.map(item => { return { ...item, link: item.link.replace(/\.md$/, '') }})
-  const itemLinks = items.map(item => item.link)
+  const itemLinks = items.map(item => join(base, item.link))
 
   return pages
     .map(p => {


### PR DESCRIPTION
This got broken with 98e4566, so that during sorting, we compared paths with and without base paths.