### PR TITLE
Fix background color for brand-colored button

### DIFF
--- a/.vitepress/theme/custom.scss
+++ b/.vitepress/theme/custom.scss
@@ -8,6 +8,7 @@
     'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --vp-c-brand: #db8b0b;
   --vp-c-brand-dark: #9f660a;
+  --vp-button-brand-bg: #db8b0b;
   --vp-button-brand-border: #efbc6b;
   --vp-button-brand-hover-bg: #c37d0b;
   --vp-button-brand-hover-border: #f3b655;


### PR DESCRIPTION
Our current start page buttons look weird in light mode since the most recent VitePress color scheme changes:

<img width="1246" alt="Screenshot 2023-09-06 at 23 11 07" src="https://github.com/cap-js/docs/assets/24377039/76904ec0-928c-4684-8ee1-6270485e648f">
