### PR TITLE
comma in script causes deploy to fail

### DIFF
--- a/guides/databases-postgres.md
+++ b/guides/databases-postgres.md
@@ -406,7 +406,7 @@ The shell script specified in the previous step is a simple combination of all t
     echo - copy .csv files -
     cp -r db/data gen/pg/db/data
 
-    echo '{"dependencies": { "@sap/cds": "*", "@cap-js/postgres": "*"},  "scripts": {    "start": "cds-deploy",}}' > gen/pg/package.json
+    echo '{"dependencies": { "@sap/cds": "*", "@cap-js/postgres": "*"},  "scripts": {    "start": "cds-deploy"}}' > gen/pg/package.json
 
     ```
 


### PR DESCRIPTION
Ok this is a small one but because I am using this letter for letter pretty much I noticed it.

This comma that I have removed in the script that is echoed for postres deployment caused the deployment to fail. 

The extra comma shouldn't be at the end of the json. 

