### PR TITLE
Clean up Node/Java scoping in Hello World

### DIFF
--- a/get-started/hello-world.md
+++ b/get-started/hello-world.md
@@ -66,8 +66,6 @@ service say {
 
 ... for example, using [Node.js](../node.js/) express.js handlers style.
 
-</div>
-
 ::: code-group
 
 ```js [srv/world.js]
@@ -88,7 +86,9 @@ module.exports = class say {
 ```
 :::
 
-> That has limited flexibility, for example, you can register only one handler per event. { .impl .node}
+> That has limited flexibility, for example, you can register only one handler per event.
+
+</div>
 
 <div class="impl java">
 
@@ -126,21 +126,26 @@ public class HelloHandler implements EventHandler {
 
 
 ## Run it
+
 ... for example, from your command line in the root directory of your "Hello World":
 
-::: code-group
 
-```sh [Node.js]
+<div class="impl node">
+
+```sh
 cds watch
 ```
 
-```sh [Java]
+</div>
+
+<div class="impl java">
+
+```sh
 cd srv
 mvn cds:watch
 ```
 
-:::
-
+</div>
 
 ## Consume it
 ... for example, from your browser:<br>


### PR DESCRIPTION
Currently showing a lot of irrelevant Node content with the Java toggle enabled and vice versa.