### PR TITLE
format path properly

### DIFF
--- a/.github/etc/create-review.cjs
+++ b/.github/etc/create-review.cjs
@@ -189,7 +189,7 @@ module.exports = async ({ github, require, exec, core }) => {
                 continue
             }
 
-            // Github required that no path starts with './', but cspell provides the paths exactly in this format
+            // Github requires that no path starts with './', but cspell provides the paths exactly in this format
             const properlyStructuredPath = path.replace(/^\.\//, '')
 
             if (suggestions.length > 0) {

--- a/.github/etc/create-review.cjs
+++ b/.github/etc/create-review.cjs
@@ -189,15 +189,18 @@ module.exports = async ({ github, require, exec, core }) => {
                 continue
             }
 
+            // Github required that no path starts with './', but cspell provides the paths exactly in this format
+            const properlyStructuredPath = path.replace(/^\.\//, '')
+
             if (suggestions.length > 0) {
                 // replace word with first suggestions and remove first "+" sign
                 const suggestion = line.replace(word, suggestions[0]).replace('+', '')
 
                 const commentBody = createCspellSuggestionText(suggestion, suggestions.slice(1))
 
-                comments.push({ path, position, body: commentBody })
+                comments.push({ path: properlyStructuredPath, position, body: commentBody })
             } else {
-                comments.push({ path, position, body: createUnknownWordComment(word) })
+                comments.push({ path: properlyStructuredPath, position, body: createUnknownWordComment(word) })
 
                 wordsWithoutSuggestions.push(word)
             }
@@ -205,11 +208,11 @@ module.exports = async ({ github, require, exec, core }) => {
             spellingMistakesText += `* **${path}**${pointer} Unknown word "**${word}**"\n`
         }
 
-        if (wordsWithoutSuggestions.length > 0) {
+        if (wordsWithoutSuggestions.length > 0 && comments.length > 0) {
             spellingMistakesText += `\n${createWordsWithoutSuggestionsText(wordsWithoutSuggestions)}\n`
         }
 
-        if (matches.length > 0) {
+        if (matches.length > 0 && comments.length > 0) {
             spellingMistakesText += `${getSpellingCorrectionTip()}\n`
         }
 


### PR DESCRIPTION
Github requires that no path starts with `./`, but `cspell` provides the paths exactly in this format, so we have to format the path string properly.
The pipeline now also only creates a review, if any errors/mistakes can be found in the current diff, currently, a review without errors is created if there is an error in the edited file, but it is not in the current diff.