### PR TITLE
update color for cds commands

### DIFF
--- a/.vitepress/syntaxes/log.tmLanguage.json
+++ b/.vitepress/syntaxes/log.tmLanguage.json
@@ -48,7 +48,7 @@
       "match": "^(?:\\[.*?\\]|\\$) (cds) (.*)$",
       "captures": {
         "1": {
-          "name": "constant.other.key"
+          "name": "entity.name.type"
         },
         "2": {
           "name": "string"


### PR DESCRIPTION
Commands like `cds watch` are now uniformly colored in `log` and `sh` code blocks.