### PR TITLE
install dependencies after cds init

### DIFF
--- a/get-started/in-a-nutshell.md
+++ b/get-started/in-a-nutshell.md
@@ -73,6 +73,23 @@ Users on macOS must first run a command (*Shell Command: Install 'code' command 
 
 :::
 
+2.5 Initialise dependencies in an [*Integrated Terminal*](https://code.visualstudio.com/docs/terminal/basics) 
+
+Install all the dependencies into your system. 
+
+::: code-group
+
+```sh [Node.js]
+npm install
+```
+
+```sh [Java]
+/shrug
+```
+
+:::
+
+
 3. Run `cds watch` in an [*Integrated Terminal*](https://code.visualstudio.com/docs/terminal/basics)
 
 ::: code-group


### PR DESCRIPTION
This needs some more thought but if you don't add this step when you start on 2. capture domain models your terminal will go berserk with errors and it is because the db dependencies are not yet installed. 

I don't know java developers need to do here /shrug 

