### PR TITLE
Update Typer Section

### DIFF
--- a/tools/cds-typer.md
+++ b/tools/cds-typer.md
@@ -74,7 +74,7 @@ Note that your entities will expose additional capabilities in the context of CQ
 The CRUD handlers `before`, `on`, and `after` accept generated types:
 
 ```js
-// the paylod is known to contain Books inside the respective handlers
+// the payload is known to contain Books inside the respective handlers
 service.before('READ', Books, req => { … }
 service.on('READ', Books, req => { … }
 service.after('READ', Books, req => { … }

--- a/tools/cds-typer.md
+++ b/tools/cds-typer.md
@@ -327,7 +327,7 @@ OPTIONS
 ### Version Control
 The generated types _are meant to be ephemeral_. We therefore recommend that you do not add them to your version control system. Adding the typer [as facet](#typer-facet){.learn-more} will therefore generate an appropriate entry in your project's `.gitignore` file.
 You can safely remove and recreate the types at any time.
-We especially suggest deleting all generated types when switching between development branches to avoid unexpected behaviour from lingering types.
+We especially suggest deleting all generated types when switching between development branches to avoid unexpected behavior from lingering types.
 
 ## Integrate Into TypeScript Projects
 The types emitted by `cds-typer` can be used in TypeScript projects as well! Depending on your project setup you may have to do some manual configuration.

--- a/tools/cds-typer.md
+++ b/tools/cds-typer.md
@@ -249,7 +249,7 @@ This will consider referencing properties in generated types that are not explic
 
 ## Usage Options
 
-Besides using the [SAP CDS Language Support extension for VS Code](https://marketplace.visualstudio.com/items?itemName=SAPSE.vscode-cds), you have the option to use `cds-typer` on the command line and programmatically.
+Besides using the [SAP CDS Language Support extension for VS Code](https://marketplace.visualstudio.com/items?itemName=SAPSE.vscode-cds), you have the option to use `cds-typer` on the command line.
 
 ### Command Line Interface (CLI) {#typer-cli}
 
@@ -315,16 +315,6 @@ OPTIONS
 
     Prints the version of this tool.
 ```
-:::
-
-### Programmatically
-
-`cds-typer` can also be used programmatically in your Node.js app to consume CSN from either an in-memory structure (`compileFromCSN(…)`) or from _.cds_ files (`compileFromFile(…)`). Refer to the [source code](https://github.com/cap-js/cds-typer/blob/main/lib/compile.js) for more information on the API.
-
-::: warning Could alter CSN!
-
-Applying `cds-typer` to an in-memory CSN structure may be impure, meaning that it could alter the CSN. If you use the type generator this way, you may want to apply it as last step of your tool chain.
-
 :::
 
 ## Integrate Into TypeScript Projects

--- a/tools/cds-typer.md
+++ b/tools/cds-typer.md
@@ -144,6 +144,10 @@ type Priority: String enum {
 
 entity Tickets {
   priority: Priority;
+  status: String enum {
+    ASSIGNED = 'A';
+    UNASSIGNED = 'U';
+  }
   …
 }
 ```
@@ -154,7 +158,10 @@ const { Ticket, Priority } = require('…')
 service.before('CREATE', Ticket, (req) => {
   req.data.priority = Priority.LOW  // [!code focus]
   //         /                 \  // [!code focus]
-  // inferred type: Priority    suggests LOW, MEDIUM, HIGH  // [!code focus]
+  // inferred as: Priority      suggests LOW, MEDIUM, HIGH  // [!code focus]
+  req.data.status = Ticket.status.UNASSIGNED  // [!code focus]
+  //         /                   \  // [!code focus]
+  // inferred as: Tickets_status  suggests ASSIGNED, UNASSIGNED  // [!code focus]
 })
 
 ```
@@ -316,6 +323,11 @@ OPTIONS
     Prints the version of this tool.
 ```
 :::
+
+### Version Control
+The generated types _are meant to be ephemeral_. We therefore recommend that you do not add them to your version control system. Adding the typer [as facet](#typer-facet){.learn-more} will therefore generate an appropriate entry in your project's `.gitignore` file.
+You can safely remove and recreate the types at any time.
+We especially suggest deleting all generated types when switching between development branches to avoid unexpected behaviour from lingering types.
 
 ## Integrate Into TypeScript Projects
 The types emitted by `cds-typer` can be used in TypeScript projects as well! Depending on your project setup you may have to do some manual configuration.


### PR DESCRIPTION
- Removed a subsection describing an API that has been removed
- Added a section about using the generated types with version control
- Extended the section on enums to include the use of anonymous enums as well