### PR TITLE
Reword folder structure comments in Get Started

### DIFF
--- a/get-started/jumpstart.md
+++ b/get-started/jumpstart.md
@@ -117,10 +117,10 @@ The default project structure of CAP projects is as follows:
 
 ```zsh
 bookshop/        # Your project's root folder
-├─ app /         # UI-related content goes here
-├─ srv/          # Service-related content goes here
-├─ db/           # Domain models and database-related content goes here
-├─ package.json  # Contains configuration for cds-dk
+├─ app/          # UI-related content
+├─ srv/          # Service-related content
+├─ db/           # Domain models and database-related content
+├─ package.json  # Configuration for cds + cds-dk
 └─ readme.md     # A readme placeholder
 ```
 


### PR DESCRIPTION
The "goes here" takes up additional horizontal space and lets the scroll bar appear before it needs to. We can just remove it without really losing information.