### PR TITLE
Troubleshooting no space left error

### DIFF
--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -593,7 +593,7 @@ Use `cf create-service-push --push-as-subprocess` to execute `cf push` in a sub-
 
 [See `cf create-service-push --help` for further CLI details or visit the Create-Service-Push GitHub repository.](https://github.com/dawu415/CF-CLI-Create-Service-Push-Plugin){.learn-more}
 
-### Deployment crashes with no space left on device error
+### Deployment Crashes With "No space left on device" Error
 
 If on deployment to Cloud Foundry, a module crashes with the error message `Cannot mkdir: No space left on device` then the solution is to adjust the space available to that module in the `mta.yaml` file. Adjust the `disk-quota` parameter. 
 
@@ -602,6 +602,7 @@ If on deployment to Cloud Foundry, a module crashes with the error message `Cann
       disk-quota: 512M
       memory: 256M
 ```
+[Learn more about this error in KBA 3310683](https://userapps.support.sap.com/sap/support/knowledge/en/3310683){.learn-more}
 
 ### How Can I Get Logs From My Application in Cloud Foundry? { #cflogs-recent}
 

--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -593,6 +593,16 @@ Use `cf create-service-push --push-as-subprocess` to execute `cf push` in a sub-
 
 [See `cf create-service-push --help` for further CLI details or visit the Create-Service-Push GitHub repository.](https://github.com/dawu415/CF-CLI-Create-Service-Push-Plugin){.learn-more}
 
+### Deployment crashes with no space left on device error
+
+If on deployment to Cloud Foundry, a module crashes with the error message `Cannot mkdir: No space left on device` then the solution is to adjust the space available to that module in the `mta.yaml` file. Adjust the `disk-quota` parameter. 
+
+```sh
+    parameters:
+      disk-quota: 512M
+      memory: 256M
+```
+
 ### How Can I Get Logs From My Application in Cloud Foundry? { #cflogs-recent}
 
 The SAP BTP cockpit is not meant to analyze a huge amount of logs. You should use the Cloud Foundry CLI.


### PR DESCRIPTION
A brief section in troubleshooting to explain what to do if your module crashes due to lack of disk space