### PR TITLE
Java: remove system user, user should not exist

### DIFF
--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -188,6 +188,16 @@ module.exports = cds.server
 
 A new option `privilegedUser()` can be leveraged when [defining](../java/request-contexts#defining-requestcontext) your own `RequestContext`. Adding this introduces a user, which passes all authorization restrictions. This is useful for scenarios, where a restricted service should be called through the [local service consumption API](../java/consumption-api) either in a request thread regardless of the original user's authorizations or in a background thread.
 
+### Why do I get a "User should not exist" error during build time?
+
+|  | Explanation |
+| --- | ---- |
+| _Root Cause_ | You've [explicitly configured a mock](../java/security#explicitly-defined-mock-users) user with a name that is already used by a [preconfigured mock user](../java/security#preconfigured-mock-users).
+| _Solution_ | Rename the mock user and build your project again.
+
+
+
+
 ### How can I expose custom REST APIs with CAP?
 
 From time to time you might want to expose additional REST APIs in your CAP application, that aren't covered through CAPs existing protocol adapters (for example, OData V4). A common example for this might be a CSV file upload or another type of custom REST endpoint.

--- a/java/security.md
+++ b/java/security.md
@@ -263,7 +263,7 @@ cds:
           additional:
             email: myviewer@crazycars.com
           features:
-	    - cruise
+	          - cruise
             - park
 
         - name: Privileged-User
@@ -271,17 +271,10 @@ cds:
           privileged: true
           features:
             - "*"
-
-        - name: System
-          password: system-pass
-          system-user: true
-          roles:
-            - mtcallback
 ```
 
 - Mock user with name `Viewer-User` is a typical business user with SaaS-tenant `CrazyCars` who has assigned role `Viewer` and user attribute `Country` (`$user.Country` evaluates to value list `[GER, FR]`). This user also has the additional attribute `email`, which can be retrieved with `UserInfo.getAdditionalAttribute("email")`. The [features](../java/reflection-api#feature-toggles) `cruise` and `park` are enabled for this mock user.
 - `Privileged-User` is a user running in privileged mode. Such a user is helpful in tests that bypasses all authorization handlers.
-- Technical user `System` can be used, for example, to simulate SaaS registry calls for tenant provisioning in a multitenancy scenario.
 
 Property `cds.security.mock.enabled = false` disables any mock user configuration.
 


### PR DESCRIPTION
If you add a user called System or system, you'll get a build error "User should not exist". Therefore I added a troubleshooting and removed the user from the sample.