### PR TITLE
Update cds-utils.md

### DIFF
--- a/node.js/cds-utils.md
+++ b/node.js/cds-utils.md
@@ -37,8 +37,8 @@ let id = uuid() // generates a new UUID
 
 
 
-### decodeURI() {.method}
-### decodeURIComponent() {.method}
+### decodeURI (*uri*) {.method}
+### decodeURIComponent (*uri*) {.method}
 
 These are 'safe' variants for `decodeURI` and `decodeURIComponent` which in case of non-decodable input return the input string instead of throwing `URIErrors`. This allows simplifying our code.
 

--- a/node.js/cds-utils.md
+++ b/node.js/cds-utils.md
@@ -40,7 +40,7 @@ let id = uuid() // generates a new UUID
 ### decodeURI (*uri*) {.method}
 ### decodeURIComponent (*uri*) {.method}
 
-These are 'safe' variants for `decodeURI` and `decodeURIComponent` which in case of non-decodable input return the input string instead of throwing `URIErrors`. This allows simplifying our code.
+These are 'safe' variants for [`decodeURI`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURI) and [`decodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent) which in case of non-decodable input return the input string instead of throwing `URIErrors`. This allows simplifying our code.
 
 For example given we have to handle input like this:
 ```js


### PR DESCRIPTION
`decodeURI` and `decodeURIComponent` were missing the parameter in their heading, which other methods with parameters were more explicit about. Also, I think it would be helpful to link to the original `decodeURI` and `decodeURIComponent` documentation. Do we have goto-documentation for native functions? MDN maybe?

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURI and
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent respectively