### PR TITLE
Document matchesPattern implementation in CQL

### DIFF
--- a/java/query-api.md
+++ b/java/query-api.md
@@ -1733,6 +1733,37 @@ ENDS WITH
 </tr>
 </table>
 
+#### `matchesPattern` Predicate {#matches-pattern}
+
+The `matchesPattern` predicate is applied to a column and test if the string value or an element of an entity matches the given regular expression.
+
+The regular expressions are pushed down to the database, so the supported syntax of the regular expression and the options you can use depends on the database you are using.
+For example, the SAP HANA uses the Perl Compatible Regular Expressions and the embedded databases like SQLite and H2 use the Java implementation of regular expressions. They are compatible with regard to the most of the features, but you may still discover some differences.
+
+For example, following code matches title of the book that contains word "CAP" in the title:
+
+```java
+Select.from("bookshop.Books").where(t -> t.get("title").matchesPattern("CAP"));
+```
+
+::: tip
+As a general rule, consider regular expressions as a last resort. They are powerful, but also complex and hard to read. For simple string operations, prefer other simpler functions like `contains`.
+::::
+
+In the following example, the title of the book must start with the letter `C` and end with the letter `e` and contains any number of letters in between: 
+
+```java
+Select.from("bookshop.Books").where(t -> t.get("title").matchesPattern("^C\w*e$"));
+```
+
+The behavior of the regular expression can be customized with the options that can be passed as a second argument of the predicate. The set of the supported options and their semantics depends on the underlying database.  
+
+For example, the following code matches that the title of the book begins with the word "CAP" while ignoring the case of the letters:
+
+```java
+Select.from("bookshop.Books").where(t -> t.get("title").matchesPattern(CQL.val("^CAP.+$"), CQL.val("i")));
+```
+
 #### `anyMatch/allMatch` Predicate {#any-match}
 
 The `anyMatch` and `allMatch` predicates are applied to an association and test if _any_ instance/_all_ instances of the associated entity set match a given filter condition. They are supported in filter conditions of [Select](#select), [Update](#update) and [Delete](#delete) statements.


### PR DESCRIPTION
The new `matchesPattern` predicate enables the application developers to match the elements with a regular expression.