### PR TITLE
ci(snippet checker): Always enable beta features

### DIFF
--- a/.github/cds-snippet-checker/check-cds-snippets.js
+++ b/.github/cds-snippet-checker/check-cds-snippets.js
@@ -136,7 +136,7 @@ function printErrorForSnippet(snippet, messages) {
  * @param {object} snippet
  */
 function compileSnippet(snippet) {
-  const options = { messages: snippet.messages };
+  const options = { messages: snippet.messages, betaMode: true };
 
   const compile = () => {
     try {


### PR DESCRIPTION
There may be beta features in the cds-compiler that we document on CAPire.  We should enable all beta features during syntax check.