### PR TITLE
Fix copy button position

### DIFF
--- a/.vitepress/theme/custom.scss
+++ b/.vitepress/theme/custom.scss
@@ -85,7 +85,7 @@ main {
 
     // Fix for copy button position
     [class*='language-'] > button.copy {
-      top: 7px;
+      top: 4px;
     }
 
     pre.log {


### PR DESCRIPTION
The copy button position isn't ideal for single-line code blocks:
![Screenshot 2023-12-11 at 16 50 06](https://github.com/cap-js/docs/assets/24377039/fcaae54f-9a55-4237-ac35-ef43233c34f0)

This PR corrects it:
![Screenshot 2023-12-11 at 16 47 02](https://github.com/cap-js/docs/assets/24377039/905dbdf0-d117-4dd7-8270-a1b14f7f342d)

For the record, the default (no custom CSS) is even worse, as the copy button is so far down it shows a scroll bar:
![Screenshot 2023-12-11 at 16 46 52](https://github.com/cap-js/docs/assets/24377039/111b61c9-54f8-4586-8c9f-6ab8e3c9e08d)

