### PR TITLE
Expressions as annotation values

### DIFF
--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -356,7 +356,7 @@ table row. Therefore, such an expression must not contain subqueries, aggregate 
 
 No restrictons apply for reading a calculated element on-write.
 
-#### Association-like calculated elements (beta)
+#### Association-like calculated elements (beta) {#association-like-calculated-elements}
 
 A calculated element can also define a refined association, like in this example:
 

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1047,7 +1047,7 @@ is checked by the compiler.
 In CSN, the expression is represented as a record with two properties:
 * A string representation of the expression is stored in property `=`.
 * A tokenized representation of the expression is stored in one of the properties
-`xpr`, `ref`, `val`, `func`, or `list` (like if the expression was written in a query).
+`xpr`, `ref`, `val`, `func`, etc. (like if the expression was written in a query).
 
 ```json
 {

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -993,7 +993,7 @@ As described in the [CSN spec](./csn#literals), the previously mentioned annotat
 ```
 
 ::: tip
-In contrast to references in expressions (see next section), plain references aren't checked or resolved
+In contrast to references in [expressions](#expressions-as-annotation-values), plain references aren't checked or resolved
 by CDS parsers or linkers. They're interpreted and evaluated only on consumption-specific modules.
 For example, for SAP Fiori models, it's the _4odata_ and _2edm(x)_ processors.
 :::
@@ -1026,8 +1026,8 @@ except subqueries. The expression can of course also be a single reference or a 
 Some advantage of using expressions as "first class" annotation values are:
 * syntax and references are checked by the compiler
 * code completion
-* (planned for a later release) automatic path rewriting in propagated annotations (see below)
-* (planned for a later release) automatic translation of expressions in OData annotations (see below)
+* (planned) [automatic path rewriting in propagated annotations](#propagation)
+* (planned) [automatic translation of expressions in OData annotations](#odata-annotations)
 
 #### Name resolution
 
@@ -1066,7 +1066,7 @@ In CSN, the expression is represented as a record with two properties:
 }
 ```
 
-Note the different CSN representations for a plain value `"@anInteger": 11` and a value written
+Note the different CSN representations for a [plain value `"@anInteger": 11`](#annotation-values) and a value written
 as expression `@aValueExpr: ( 11 )`, respectively.
 
 #### Propagation
@@ -1100,10 +1100,12 @@ The propagated annotation `@Foo3` is invalid, as element `c` of `E` has not been
 This results in a compiler error. To make it work, you would have to explicitly overwrite annotations
 `@Foo2` and `@Foo3` at `P`.
 
+::: details Outlook on future releases
 The compiler is going to take care of renamed elements and rewrites references in propagated annotations
 in a later release. The CSN representation of propagated annotation expressions may change even
 if today no error is issued. Propagated annotation expressions that today are accepted may lead
 to an error in the future when the implementation is improved.
+:::
 
 #### CDS Annotations
 

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -963,7 +963,7 @@ action doSomething returns @before {
 Values can be literals, references, or expressions. Expressions are explained in more detail in the next section.
 If no value is given, the default value is `true` as for `@aFlag` in the following example:
 
-<!-- cds-mode: ignore -->
+<!-- cds-mode: upcoming, cds-compiler v4.5 -->
 ```cds
 @aFlag //= true, if no value is given
 @aBoolean: false
@@ -1010,14 +1010,14 @@ and the behavior of expressions in OData annotations will change.
 :::
 
 In order to use an expression as an annotation value, it must be enclosed in parentheses:
-<!-- cds-mode: ignore -->
+<!-- cds-mode: upcoming, cds-compiler v4.5 -->
 ```cds
 @anExpression: ( foo.bar * 11 )
 ```
 
 Syntactically, the same expressions are supported as in a select item or in the where clause of a query,
 except subqueries. The expression can of course also be a single reference or a simple value:
-<!-- cds-mode: ignore -->
+<!-- cds-mode: upcoming, cds-compiler v4.5 -->
 ```cds
 @aRefExpr: ( foo.bar )
 @aValueExpr: ( 11 )
@@ -1077,7 +1077,7 @@ all elements used in an annotation expression must be projected without renaming
 Thus, for the time being we recommend to use the feature mainly in top-level projections.
 
 Example:
-<!-- cds-mode: ignore -->
+<!-- cds-mode: upcoming, cds-compiler v4.5 -->
 ```cds
 @Foo1 : (a)
 @Foo2 : (a + b)
@@ -1111,7 +1111,7 @@ Using an expression as annotation value only makes sense if the evaluator of the
 prepared to deal with the new CSN representation.
 Currently the CAP runtimes only support expressions in the `where` property of the `@restrict` annotation.
 
-<!-- cds-mode: ignore -->
+<!-- cds-mode: upcoming, cds-compiler v4.5 -->
 ```cds
 entity Orders @(restrict: [
     { grant: 'READ', to: 'Auditor', where: (AuditBy = $user.id) }

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -963,7 +963,6 @@ action doSomething returns @before {
 Values can be literals, references, or expressions. Expressions are explained in more detail in the next section.
 If no value is given, the default value is `true` as for `@aFlag` in the following example:
 
-<!-- cds-mode: ignore -->
 ```cds
 @aFlag //= true, if no value is given
 @aBoolean: false
@@ -1010,14 +1009,14 @@ and the behavior of expressions in OData annotations will change.
 :::
 
 In order to use an expression as an annotation value, it must be enclosed in parentheses:
-<!-- cds-mode: ignore -->
+
 ```cds
 @anExpression: ( foo.bar * 11 )
 ```
 
 Syntactically, the same expressions are supported as in a select item or in the where clause of a query,
 except subqueries. The expression can of course also be a single reference or a simple value:
-<!-- cds-mode: ignore -->
+
 ```cds
 @aRefExpr: ( foo.bar )
 @aValueExpr: ( 11 )
@@ -1077,7 +1076,7 @@ all elements used in an annotation expression must be projected without renaming
 Thus, for the time being we recommend to use the feature mainly in top-level projections.
 
 Example:
-<!-- cds-mode: ignore -->
+
 ```cds
 @Foo1 : (a)
 @Foo2 : (a + b)
@@ -1111,7 +1110,7 @@ Using an expression as annotation value only makes sense if the evaluator of the
 prepared to deal with the new CSN representation.
 Currently the CAP runtimes only support expressions in the `where` property of the `@restrict` annotation.
 
-<!-- cds-mode: ignore -->
+
 ```cds
 entity Orders @(restrict: [
     { grant: 'READ', to: 'Auditor', where: (AuditBy = $user.id) }

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1079,26 +1079,26 @@ Thus, for the time being we recommend to use the feature mainly in top-level pro
 Example:
 <!-- cds-mode: upcoming, cds-compiler v4.5 -->
 ```cds
-@Foo1 : (a)
-@Foo2 : (a + b)
-@Foo3 : (a + c)
-entity E {
-  a : Integer;
-  b : Integer;
-  c : Integer;
+@MyLength : (length)
+@MyArea : (length * depth)
+@MyHeight : (height)
+entity Block {
+  length : Integer;
+  depth : Integer;
+  height : Integer;
 }
 
-entity P as projection on E {
-  a,
-  b as x
+entity Rectangle as projection on Block {
+  length,
+  depth as width
 }
 ```
 
-All three annotations are propagated to the projection `P`. The propagated `@Foo1` is still valid.
-The propagated annotation `@Foo2` is invalid, as the referenced element `b` has been renamed to `x`.
-The propagated annotation `@Foo3` is invalid, as element `c` of `E` has not been projected at all.
+All three annotations are propagated to the projection `Rectangle`. The propagated `@MyLength` is still valid.
+The propagated annotation `MyArea` is invalid, as the referenced element `depth` has been renamed to `width`.
+The propagated annotation `MyHeight` is invalid, as element `height` of `Block` has not been projected at all.
 This results in a compiler error. To make it work, you would have to explicitly overwrite annotations
-`@Foo2` and `@Foo3` at `P`.
+`@MyArea` and `@MyHeight` at `Rectangle`.
 
 ::: details Outlook on future releases
 The compiler is going to take care of renamed elements and rewrites references in propagated annotations

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -963,6 +963,7 @@ action doSomething returns @before {
 Values can be literals, references, or expressions. Expressions are explained in more detail in the next section.
 If no value is given, the default value is `true` as for `@aFlag` in the following example:
 
+<!-- cds-mode: ignore -->
 ```cds
 @aFlag //= true, if no value is given
 @aBoolean: false
@@ -1009,14 +1010,14 @@ and the behavior of expressions in OData annotations will change.
 :::
 
 In order to use an expression as an annotation value, it must be enclosed in parentheses:
-
+<!-- cds-mode: ignore -->
 ```cds
 @anExpression: ( foo.bar * 11 )
 ```
 
 Syntactically, the same expressions are supported as in a select item or in the where clause of a query,
 except subqueries. The expression can of course also be a single reference or a simple value:
-
+<!-- cds-mode: ignore -->
 ```cds
 @aRefExpr: ( foo.bar )
 @aValueExpr: ( 11 )
@@ -1076,7 +1077,7 @@ all elements used in an annotation expression must be projected without renaming
 Thus, for the time being we recommend to use the feature mainly in top-level projections.
 
 Example:
-
+<!-- cds-mode: ignore -->
 ```cds
 @Foo1 : (a)
 @Foo2 : (a + b)
@@ -1110,7 +1111,7 @@ Using an expression as annotation value only makes sense if the evaluator of the
 prepared to deal with the new CSN representation.
 Currently the CAP runtimes only support expressions in the `where` property of the `@restrict` annotation.
 
-
+<!-- cds-mode: ignore -->
 ```cds
 entity Orders @(restrict: [
     { grant: 'READ', to: 'Auditor', where: (AuditBy = $user.id) }

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1100,7 +1100,7 @@ The propagated annotation `@Foo3` is invalid, as element `c` of `E` has not been
 This results in a compiler error. To make it work, you would have to explicitly overwrite annotations
 `@Foo2` and `@Foo3` at `P`.
 
-The compiler is going to take care of renamings and rewrite references in propagated annotations
+The compiler is going to take care of renamed elements and rewrites references in propagated annotations
 in a later release. The CSN representation of propagated annotation expressions may change even
 if today no error is issued. Propagated annotation expressions that today are accepted may lead
 to an error in the future when the implementation is improved.

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -963,6 +963,7 @@ action doSomething returns @before {
 Values can be literals, references, or expressions. Expressions are explained in more detail in the next section.
 If no value is given, the default value is `true` as for `@aFlag` in the following example:
 
+<!-- cds-mode: ignore -->
 ```cds
 @aFlag //= true, if no value is given
 @aBoolean: false
@@ -1009,12 +1010,14 @@ and the behavior of expressions in OData annotations will change.
 :::
 
 In order to use an expression as an annotation value, it must be enclosed in parentheses:
+<!-- cds-mode: ignore -->
 ```cds
 @anExpression: ( foo.bar * 11 )
 ```
 
 Syntactically, the same expressions are supported as in a select item or in the where clause of a query,
 except subqueries. The expression can of course also be a single reference or a simple value:
+<!-- cds-mode: ignore -->
 ```cds
 @aRefExpr: ( foo.bar )
 @aValueExpr: ( 11 )
@@ -1074,6 +1077,7 @@ all elements used in an annotation expression must be projected without renaming
 Thus, for the time being we recommend to use the feature mainly in top-level projections.
 
 Example:
+<!-- cds-mode: ignore -->
 ```cds
 @Foo1 : (a)
 @Foo2 : (a + b)
@@ -1107,6 +1111,7 @@ Using an expression as annotation value only makes sense if the evaluator of the
 prepared to deal with the new CSN representation.
 Currently the CAP runtimes only support expressions in the `where` property of the `@restrict` annotation.
 
+<!-- cds-mode: ignore -->
 ```cds
 entity Orders @(restrict: [
     { grant: 'READ', to: 'Auditor', where: (AuditBy = $user.id) }

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1031,13 +1031,13 @@ Some advantage of using expressions as "first class" annotation values are:
 
 #### Name resolution
 
-Each path in the expression is checked. For an annotation assigned to an entity,
-the first path step is resolved as element of the entity. For an annotation assigned
-to an entity element, the first path step is resolved as the annotated element or its siblings.
-If the annotation is assigned to a subelement of a structured element, the top level
-elements of the entity can be accessed via `$self`.
-A parameter `par` of a parametrized entity can be accessed like in a query with `:par`.
-If a path cannot be resolved successfully, compilation fails with an error.
+Each path in the expression is checked:
+* For an annotation assigned to an entity, the first path step is resolved as element of the entity.
+* For an annotation assigned to an entity element, the first path step is resolved as the annotated element or its siblings.
+* If the annotation is assigned to a subelement of a structured element, the top level
+  elements of the entity can be accessed via `$self`.
+* A parameter `par` of a parametrized entity can be accessed like in a query with `:par`.
+* If a path cannot be resolved successfully, compilation fails with an error.
 
 In contrast to `@aReference: foo.bar`, a single reference written as expression `@aRefExpr: ( foo.bar )`
 is checked by the compiler.

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1019,7 +1019,7 @@ the first path step is resolved as element of the entity. For an annotation assi
 to an entity element, the first path step is resolved as the annotated element or its siblings.
 If the annotation is assigned to a subelement of a structured element, the top level
 elements of the entity can be accessed via `$self`.
-A parameter `par` of a parmetrized entity can be accessed like in a query with `:par`.
+A parameter `par` of a parametrized entity can be accessed like in a query with `:par`.
 If a path cannot be resolved successfully, compilation fails with an error.
 
 In contrast to `@aReference: foo.bar`, a single reference written as expression `@aRefExpr: ( foo.bar )`

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -834,8 +834,9 @@ This section describes how to add Annotations to model definitions written in CD
 - [Annotation Syntax](#annotation-syntax)
 - [Annotation Targets](#annotation-targets)
 - [Annotation Values](#annotation-values)
-- [Annotation Propagation](#annotation-propagation)
+- [Expressions as Annotation Values](#expressions-as-annotation-values)
 - [Records as Syntax Shortcuts](#records-as-syntax-shortcuts)
+- [Annotation Propagation](#annotation-propagation)
 - [The `annotate` Directive](#annotate)
 - [Extend Array Annotations](#extend-array-annotations)
 
@@ -945,7 +946,8 @@ action doSomething returns @before {
 
 ### Annotation Values
 
-Values can be literals or references. If no value is given, the default value is `true` as for `@aFlag` in the following example:
+Values can be literals, references, or expressions. Expressions are explained in more detail in the next section.
+If no value is given, the default value is `true` as for `@aFlag` in the following example:
 
 ```cds
 @aFlag //= true, if no value is given
@@ -956,6 +958,7 @@ Values can be literals or references. If no value is given, the default value is
 @aSymbol: #foo
 @aReference: foo.bar
 @anArray: [ /* can contain any kind of value */ ]
+@anExpression: ( foo.bar * 17 )  // expression, see next section
 ```
 
 As described in the [CSN spec](./csn#literals), the previously mentioned annotations would compile to CSN as follows:
@@ -969,13 +972,137 @@ As described in the [CSN spec](./csn#literals), the previously mentioned annotat
   "@aDecimal": 11.1,
   "@aSymbol": {"#":"foo"},
   "@aReference": {"=":"foo.bar"},
-  "@anArray": [ /* … */ ]
+  "@anArray": [ /* … */ ],
+  "@anExpression": { /* see next section */ }
 }
 ```
 
 ::: tip
-References (and expressions in general) aren't checked or resolved by CDS parsers or linkers. They're interpreted and evaluated only on consumption-specific modules. For example, for SAP Fiori models, it's the _4odata_ and _2edm(x)_ processors.
+In contrast to references in expressions (see next section), plain references aren't checked or resolved
+by CDS parsers or linkers. They're interpreted and evaluated only on consumption-specific modules.
+For example, for SAP Fiori models, it's the _4odata_ and _2edm(x)_ processors.
 :::
+
+
+### Expressions as Annotation Values (beta) {#expressions-as-annotation-values}
+
+::: warning
+Expressions in annotation values are released as beta feature.
+We provide an early preview for the functionality to allow you to experiment with it and provide feedback.
+The behavior may change in later releases, in particular:
+the behavior and the CSN representation of paths in propagated annotations will change,
+and the behavior of expressions in OData annotations will change.
+:::
+
+In order to use an expression as an annotation value, it must be enclosed in parentheses:
+```cds
+@anExpression: ( foo.bar * 11 )
+```
+
+Syntactically, the same expressions are supported as in a select item or in the where clause of a query,
+except subqueries. The expression can of course also be a single reference or a simple value:
+```cds
+@aRefExpr: ( foo.bar )
+@aValueExpr: ( 11 )
+```
+
+Some advantage of using expressions as "first class" annotation values are:
+* syntax and references are checked by the compiler
+* code completion
+* (planned for a later release) automatic path rewriting in propagated annotations (see below)
+* (planned for a later release) automatic translation of expressions in OData annotations (see below)
+
+#### Name resolution
+
+Each path in the expression is checked. For an annotation assigned to an entity,
+the first path step is resolved as element of the entity. For an annotation assigned
+to an entity element, the first path step is resolved as the annotated element or its siblings.
+If the annotation is assigned to a subelement of a structured element, the top level
+elements of the entity can be accessed via `$self`.
+A parameter `par` of a parmetrized entity can be accessed like in a query with `:par`.
+If a path cannot be resolved successfully, compilation fails with an error.
+
+In contrast to `@aReference: foo.bar`, a single reference written as expression `@aRefExpr: ( foo.bar )`
+is checked by the compiler.
+
+#### CSN Representation
+
+In CSN, the expression is represented as a record with two properties:
+* A string representation of the expression is stored in property `=`.
+* A tokenized representation of the expression is stored in one of the properties
+`xpr`, `ref`, `val`, `func`, or `list` (like if the expression was written in a query).
+
+```json
+{
+  "@anExpression": {
+    "=": "foo.bar * 11",
+    "xpr": [ {"ref": ["foo", "bar"]}, "*", {"value": 11} ]
+  },
+  "@aRefExpr": {
+    "=": "foo.bar",
+    "ref": ["foo", "bar"]
+  },
+  "@aValueExpr": {
+    "=": "11",
+    "val": 11
+  }
+}
+```
+
+Note the different CSN representations for a plain value `"@anInteger": 11` and a value written
+as expression `@aValueExpr: ( 11 )`, respectively.
+
+#### Propagation
+
+[Annotations are propagated](#annotation-propagation) in views/projections, in includes, or along type references.
+Currently, paths are not rewritten in propagated annotations. In a projection, for example,
+all elements used in an annotation expression must be projected without renaming.
+Thus, for the time being we recommend to use the feature mainly in top-level projections.
+
+Example:
+```cds
+@Foo1 : (a)
+@Foo2 : (a + b)
+@Foo3 : (a + c)
+entity E {
+  a : Integer;
+  b : Integer;
+  c : Integer;
+}
+
+entity P as projection on E {
+  a,
+  b as x
+}
+```
+
+All three annotations are propagated to the projection `P`. The propagated `@Foo1` is still valid.
+The propagated annotation `@Foo2` is invalid, as the referenced element `b` has been renamed to `x`.
+The propagated annotation `@Foo3` is invalid, as element `c` of `E` has not been projected at all.
+This results in a compiler error. To make it work, you would have to explicitly overwrite annotations
+`@Foo2` and `@Foo3` at `P`.
+
+The compiler is going to take care of renamings and rewrite references in propagated annotations
+in a later release. The CSN representation of propagated annotation expressions may change even
+if today no error is issued. Propagated annotation expressions that today are accepted may lead
+to an error in the future when the implementation is improved.
+
+#### CDS Annotations
+
+Using an expression as annotation value only makes sense if the evaluator of the annotation is
+prepared to deal with the new CSN representation.
+Currently the CAP runtimes only support expressions in the `where` property of the `@restrict` annotation.
+More annotations are going to follow in upcoming releases.
+
+Of course you can use this feature also in your custom annotations, where you control the code that evaluates
+the annotations.
+
+#### OData Annotations
+
+The OData backend of CAP doesn't yet support expression valued annotations. This is planned for
+a later release.
+If you use the new expression syntax for OData annotations, the expression and contained references
+are not correctly translated, and the resulting EDMX will change once the OData support is available.
 
 
 ### Records as Syntax Shortcuts

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1003,7 +1003,7 @@ For example, for SAP Fiori models, it's the _4odata_ and _2edm(x)_ processors.
 
 ::: warning
 Expressions in annotation values are released as beta feature.
-We provide an early preview for the functionality to allow you to experiment with it and provide feedback.
+We provide an early preview of this functionality to allow you to experiment with it and provide feedback.
 The behavior may change in later releases, in particular:
 the behavior and the CSN representation of paths in propagated annotations will change,
 and the behavior of expressions in OData annotations will change.
@@ -1109,7 +1109,7 @@ to an error in the future when the implementation is improved.
 
 Using an expression as annotation value only makes sense if the evaluator of the annotation is
 prepared to deal with the new CSN representation.
-Currently the CAP runtimes only support expressions in the `where` property of the `@restrict` annotation.
+Currently, the CAP runtimes only support expressions in the `where` property of the `@restrict` annotation.
 
 <!-- cds-mode: upcoming, cds-compiler v4.5 -->
 ```cds
@@ -1120,7 +1120,7 @@ entity Orders @(restrict: [
 
 More annotations are going to follow in upcoming releases.
 
-Of course you can use this feature also in your custom annotations, where you control the code that evaluates
+Of course, you can use this feature also in your custom annotations, where you control the code that evaluates
 the annotations.
 
 #### OData Annotations

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1106,6 +1106,13 @@ to an error in the future when the implementation is improved.
 Using an expression as annotation value only makes sense if the evaluator of the annotation is
 prepared to deal with the new CSN representation.
 Currently the CAP runtimes only support expressions in the `where` property of the `@restrict` annotation.
+
+```cds
+entity Orders @(restrict: [
+    { grant: 'READ', to: 'Auditor', where: (AuditBy = $user.id) }
+  ]) {/*...*/}
+```
+
 More annotations are going to follow in upcoming releases.
 
 Of course you can use this feature also in your custom annotations, where you control the code that evaluates


### PR DESCRIPTION
Unrelated: in TOC, changed the order of items so that it matches the order of the corresponding sections in the text below