### PR TITLE
chore(CDL): Remove snippet-checker skips after compiler v4 release

### DIFF
--- a/.github/cds-snippet-checker/package.json
+++ b/.github/cds-snippet-checker/package.json
@@ -12,6 +12,6 @@
     "check": "node check-cds-snippets.js"
   },
   "dependencies": {
-    "@sap/cds-compiler": "^4.2.0"
+    "@sap/cds-compiler": "^4.4"
   }
 }

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -704,7 +704,7 @@ entity Orders {
     product : Association to Products;
     quantity : Integer;
   }
-}
+};
 ```
 
 Managed Compositions are mostly syntactical sugar: Behind the scenes, they are unfolded to the [unmanaged equivalent as shown above](#compositions)
@@ -714,7 +714,10 @@ You can safely use this name at other places, for example to define an associati
 
 <!-- cds-mode: ignore -->
 ```cds
+entity Orders { 
+  // …
   specialItem : Association to Orders.Items;
+};
 ```
 
 
@@ -940,7 +943,6 @@ Parameters in view definitions:
 
 Actions/functions including their parameters and result:
 
-<!-- cds-mode: upcoming, cds-compiler v4 -->
 ```cds
 @before action doSomething @inner (
   @before param @(inner) : String @after
@@ -949,9 +951,8 @@ Actions/functions including their parameters and result:
 
 Or in case of a structured result:
 
-<!-- cds-mode: upcoming, cds-compiler v4 -->
 ```cds
-action doSomething returns @before {
+action doSomething() returns @before {
   @before resultElem @inner : String @after;
 };
 ```
@@ -1075,7 +1076,6 @@ annotate Foo:nestedStructField.existingField @title:'Nested Field';
 Actions, functions, their parameters and `returns` can be annotated:
 
 
-<!-- cds-mode: upcoming, cds-compiler v4 -->
 ```cds
 service SomeService {
   entity SomeEntity { key id: Integer } actions

--- a/guides/providing-services.md
+++ b/guides/providing-services.md
@@ -502,7 +502,7 @@ You can configure default and maximum page size limits in your [project configur
 
 You can override the defaults by applying the `@cds.query.limit` annotation on the service or entity level, as follows:
 
-<!-- cds-mode: ignore -->
+<!-- cds-mode: ignore, because it shows expected format, not CDS snippet -->
 ```cds
 @cds.query.limit: { default?, max? } | Number
 ```

--- a/guides/using-services.md
+++ b/guides/using-services.md
@@ -355,11 +355,10 @@ cds import ~/Downloads/API_BUSINESS_PARTNER.edmx --keep-namespace \
 
 Add an `on` condition to express the relation:
 
-<!-- cds-mode: ignore -->
 ::: code-group
 ```cds [srv/external/API_BUSINESS_PARTNER-new.cds]
 entity API_BUSINESS_PARTNER.A_BusinessPartner {
-  ...
+  // ...
   to_BusinessPartnerAddress :
       Association to many API_BUSINESS_PARTNER.A_BusinessPartnerAddress
       on to_BusinessPartnerAddress.BusinessPartner = BusinessPartner;


### PR DESCRIPTION
We had a few places that were skipped using the "upcoming" marker. Since cds-compiler v4 is available and used in the checker, we can now remove those skip-comments.