### PR TITLE
docs(databases): Add link to PostgreSQL reserved keywords

### DIFF
--- a/guides/databases.md
+++ b/guides/databases.md
@@ -588,6 +588,7 @@ Find here a collection of resources on selected databases and their reference do
 * [SAP HANA SQL Reference Guide for SAP HANA Cloud](https://help.sap.com/docs/HANA_CLOUD_DATABASE/c1d3f60099654ecfb3fe36ac93c121bb/28bcd6af3eb6437892719f7c27a8a285.html)
 * [SQLite Keywords](https://www.sqlite.org/lang_keywords.html)
 * [H2 Keywords/Reserved Words](https://www.h2database.com/html/advanced.html#keywords)
+* [PostgreSQL SQL Key Words](https://www.postgresql.org/docs/current/sql-keywords-appendix.html)
 
 [There are also reserved words related to SAP Fiori.](../advanced/fiori#reserved-words){.learn-more}
 


### PR DESCRIPTION
Similar to H2, SAP HANA, etc., also add a link to reserved keywords of PostgreSQL.