### PR TITLE
Remove SAP Cloud Business Application Tools for Eclipse

### DIFF
--- a/about/features.md
+++ b/about/features.md
@@ -61,14 +61,14 @@ Following is an index of the features currently covered by CAP, with status and 
 
 <br>
 
-| Editors/IDE Support      | Application Studio | VS Code | Eclipse |
-|--------------------------|:------------------:|:-------:|:-------:|
-| CDS Syntax Highlighting  |        <X/>        |  <X/>   |  <X/>   |
-| CDS Code Completion      |        <X/>        |  <X/>   |  <X/>   |
-| CDS Prettifier           |        <X/>        |  <X/>   |  <X/>   |
-| Advanced Debug/Run Tools |        <X/>        |         |         |
-| Project Explorer         |        <X/>        |         |         |
-| ...                      |                    |         |         |
+| Editors/IDE Support      | Application Studio | VS Code |
+|--------------------------|:------------------:|:-------:|
+| CDS Syntax Highlighting  |        <X/>        |  <X/>   |
+| CDS Code Completion      |        <X/>        |  <X/>   |
+| CDS Prettifier           |        <X/>        |  <X/>   |
+| Advanced Debug/Run Tools |        <X/>        |         |
+| Project Explorer         |        <X/>        |         |
+| ...                      |                    |         |
 
 
 ### CDS Language & Compiler

--- a/about/index.md
+++ b/about/index.md
@@ -86,7 +86,7 @@ That might sound like a contradiction, but isn't: While CAP certainly gives *opi
 | **Higher-level concepts and APIs** abstracting from and avoiding lock-ins to low-level platform features and protocols | All abstractions follow a glass-box pattern that allows unrestricted access to lower-level things, if required |
 | **Best Practices served out of the box** with generic solutions for many recurring tasks | You can always handle things your way in [custom handlers](../guides/providing-services#custom-logic), decide whether to adopt [CQRS](./related#cqrs) or [Event Sourcing](./related#event-sourcing), for example ... while CAP simply tries to get the tedious tasks out of your way. |
 | **Out-of-the-box support** for <br> **[SAP Fiori](https://developers.sap.com/topics/ui-development.html)** and **[SAP HANA](https://developers.sap.com/topics/hana.html)** | You can also choose other UI technologies, like [Vue.js](../get-started/in-a-nutshell#vue), or databases, by providing new database integrations. |
-| **Dedicated tools support** provided in [SAP Business Application Studio](../tools/#bastudio), and [Visual Studio Code](../tools/#vscode) or [Eclipse](../java/getting-started#eclipse). | CAP doesn't depend on those tools. Everything in CAP can be done using the [`@sap/cds-dk`](../get-started/jumpstart) CLI and any editor or IDE of your choice. |
+| **Dedicated tools support** provided in [SAP Business Application Studio](../tools/#bastudio) or [Visual Studio Code](../tools/#vscode). | CAP doesn't depend on those tools. Everything in CAP can be done using the [`@sap/cds-dk`](../get-started/jumpstart) CLI and any editor or IDE of your choice. |
 
 
 ### Key Concepts & Paradigms

--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -236,7 +236,7 @@ In addition you might want to remove the H2 dependency, which is included in the
 
 If you don't want to exclude dependencies completely, but make sure that an in-memory H2 database **isn't** used, you can disable Spring Boot's `DataSource` auto-configuration, by annotating the `Application.java` class with `@SpringBootApplication(exclude = org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration.class)`. In that mode CAP Java however can still react on explicit data source configurations or database bindings.
 
-### What to Do About Maven-Related Errors in Eclipse's Problems View? { #eclipse}
+### What to Do About Maven-Related Errors in Eclipse's Problems View?
 
 - In _Problems_ view, execute _Quick fix_ from the context menu if available. If Eclipse asks you to install additional Maven Eclipse plug-ins to overcome the error, do so.
 - Errors like _'Plugin execution not covered by lifecycle configuration: org.codehaus.mojo:exec-maven-plugin)_ can be ignored. Do so in _Problems_ view > _Quick fix_ context menu > _Mark goal as ignored in Eclipse preferences_.

--- a/java/getting-started.md
+++ b/java/getting-started.md
@@ -21,7 +21,7 @@ status: released
 ## Introduction
 <!--Used as link target from Help Portal: https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html -->
 
-The CAP Java SDK enables developing CAP applications in Java. While the [SAP Business Application Studio](https://help.sap.com/products/SAP%20Business%20Application%20Studio/9d1db9835307451daa8c930fbd9ab264/84be8d91b3804ab5b0581551d99ed24c.html) provides excellent support to develop CAP Java applications, you can also develop locally with your tool of choice, for example Eclipse or Visual Studio Code.
+The CAP Java SDK enables developing CAP applications in Java. While the [SAP Business Application Studio](https://help.sap.com/products/SAP%20Business%20Application%20Studio/9d1db9835307451daa8c930fbd9ab264/84be8d91b3804ab5b0581551d99ed24c.html) provides excellent support to develop CAP Java applications, you can also develop locally with Visual Studio Code.
 
 The CAP Java SDK supports lean application design by its modular architecture, that means you pick the required features and add them to your application dependencies on demand.
 
@@ -196,31 +196,9 @@ mvn spring-boot:run
 To test whether the started application is up and running, open [http://localhost:8080](http://localhost:8080) in your browser.
 :::
 
-## Using Eclipse { #eclipse}
-<!--Used as link target from Help Portal: https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html -->
-
-### Install Eclipse
-
-Install the [Eclipse IDE for Enterprise Java developers](https://www.eclipse.org/downloads/packages/release/2020-03/r/eclipse-ide-enterprise-java-developers-includes-incubating-components).
-
-
 ### Add *Spring Tools 4*
 
 Install the [*Spring Tools 4*](https://spring.io/tools) Eclipse plugin, that makes development of Spring applications more convenient. From the Eclipse Marketplace (*Help > Eclipse Marketplace...*), search and install *Spring Tools 4*.
-
-### Add the *SAP Cloud Business Application Tools for Eclipse*
-
-Install the Eclipse plugin called _SAP Cloud Business Application Tools for Eclipse_ that supports convenient editing of CDS files.
-
-1. In Eclipse open *Help > Install New Software...*.
-
-1. From [SAP Development Tools > Getting Started with the Eclipse Tools for SAP Cloud Application Programming Model](https://tools.hana.ondemand.com/#cloud-eclipsecds), add the URL of the tools update site for your Eclipse release.
-
-1. Select *SAP Cloud Business Application Tools* > *SAP Cloud Business Application Tools for Eclipse*.
-
-1. Click *Next* and *Finish*, accept the license agreement and warning about unsigned content, restart Eclipse.
-
-<div id="eclipse-sap" />
 
 ### Import the Project
 

--- a/menu.md
+++ b/menu.md
@@ -63,7 +63,6 @@
 - [Command Line Interface (CLI)](tools/index#command-line-interface-cli)
 - [SAP Business Application Studio](tools/index#bastudio)
 - [Visual Studio Code](tools/index#vscode)
-- [Eclipse](tools/index#eclipse)
 - [IntelliJ](tools/index#intellij)
 - [Docker](tools/index#docker)
 - [CDS Editors](tools/index#cds-editor)

--- a/tools/index.md
+++ b/tools/index.md
@@ -263,14 +263,6 @@ The cell inputs/outputs are especially useful at later points in time when the p
 
 > Provided that the [**CDS Editor**](#cds-editor) is installed, the CAP Notebook will be rendered automatically as the file is selected.
 
-
-## Eclipse
-
-### Prerequisites
-
-* You have followed the instructions in [Local Setup](../get-started/jumpstart).
-* You have installed Eclipse, Spring Tools, and our Eclipse plugin, see [Add the SAP Cloud Business Application Tools for Eclipse](../java/getting-started#eclipse).
-
 <div id="beforedocker" />
 
 ## Docker
@@ -333,7 +325,7 @@ cds run
 The editor powered by the CDS language server implementation, provides source code validation including diagnostics, like error messages and warnings.
 
 The following features are available for all editors based on our language server implementation for CDS in
-SAP Business Application Studio, Visual Studio Code, and Eclipse. The plugins are available for download for Visual Studio Code at [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=SAPSE.vscode-cds#overview) and for Eclipse at [SAP Development Tools](https://tools.hana.ondemand.com/#cloud-vscodecds).
+SAP Business Application Studio and Visual Studio Code. The plugins are available for download for Visual Studio Code at [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=SAPSE.vscode-cds#overview).
 
 [Short video about the **SAP CDS language support** extension for VS Code in action by DJ Adams.](https://www.youtube.com/watch?v=eY7BTzch8w0){.learn-more}
 
@@ -374,7 +366,7 @@ Use...
 - many options, configurable using
   - settings file
   - command line switches
-  - config UI with simulation of options for VS Code and Eclipse
+  - config UI with simulation of options for VS Code
   - JSON schema for textual support
 - also for markdown in doc comments
 


### PR DESCRIPTION
The SAP Cloud Business Application Tools for Eclipse are no longer maintained and the last available version will be removed from the external Eclipse Update site: https://tools.hana.ondemand.com/

For René:

- [ ] Remove also from Help Portal to avoid dead links