### PR TITLE
Fix orphaned "Overview" in /guides

### DIFF
--- a/.vitepress/theme/components/indexFilter.js
+++ b/.vitepress/theme/components/indexFilter.js
@@ -1,7 +1,7 @@
 const { base, themeConfig: { sidebar }} = global.VITEPRESS_CONFIG.site
 import { join } from 'node:path'
 
-export default (pages, basePath) => {
+export default (pages, basePath, _filter) => {
   let items = findInItems(basePath, sidebar) || []
   items = items.map(item => { return { ...item, link: item.link?.replace(/\.md$/, '') }})
   const itemLinks = items.map(item => join(base, item.link||''))
@@ -17,6 +17,7 @@ export default (pages, basePath) => {
       if (item)  p.title = item.text
       return !!item
     })
+    .filter(_filter)
     .sort((p1, p2) => itemLinks.indexOf(p1.url) - itemLinks.indexOf(p2.url))
     .map(p => {
       // this data is inlined in each index page, so sparsely construct the final object

--- a/.vitepress/theme/components/indexFilter.js
+++ b/.vitepress/theme/components/indexFilter.js
@@ -1,7 +1,7 @@
 const { base, themeConfig: { sidebar }} = global.VITEPRESS_CONFIG.site
 import { join } from 'node:path'
 
-export default (pages, basePath, _filter) => {
+export default (pages, basePath) => {
   let items = findInItems(basePath, sidebar) || []
   items = items.map(item => { return { ...item, link: item.link?.replace(/\.md$/, '') }})
   const itemLinks = items.map(item => join(base, item.link||''))
@@ -17,7 +17,7 @@ export default (pages, basePath, _filter) => {
       if (item)  p.title = item.text
       return !!item
     })
-    .filter(_filter)
+    .filter(p => !p.url.endsWith(basePath))
     .sort((p1, p2) => itemLinks.indexOf(p1.url) - itemLinks.indexOf(p2.url))
     .map(p => {
       // this data is inlined in each index page, so sparsely construct the final object

--- a/guides/index.data.js
+++ b/guides/index.data.js
@@ -6,6 +6,6 @@ const basePath = basename(__dirname)
 
 export default createContentLoader(`**/${basePath}/**/*.md`, {
   transform(rawData) {
-    return filter(rawData, `/${basePath}/`)
+    return filter(rawData, `/${basePath}/`, p => p.title !== 'Overview')
   }
 })

--- a/guides/index.data.js
+++ b/guides/index.data.js
@@ -6,6 +6,6 @@ const basePath = basename(__dirname)
 
 export default createContentLoader(`**/${basePath}/**/*.md`, {
   transform(rawData) {
-    return filter(rawData, `/${basePath}/`, p => p.title !== 'Overview')
+    return filter(rawData, `/${basePath}/`)
   }
 })


### PR DESCRIPTION
This orphaned "Overview" re-appeared from a side-effect of a different fix:

<img width="895" alt="Screenshot 2024-01-10 at 15 50 02" src="https://github.com/cap-js/docs/assets/24377039/805cc796-1d25-481f-b3db-d5cccae081bb">

First I let consumers pass in a `_filter` method, but I like this generic solution even better – just make sure the site doesn't end with the base path for ToC generation.

This variant also preserves the "Overview" entry in the top nav bar.