### PR TITLE
Fix toggling for code fences

### DIFF
--- a/.vitepress/lib/md-attrs-propagate.ts
+++ b/.vitepress/lib/md-attrs-propagate.ts
@@ -60,21 +60,20 @@ export function install(md: MarkdownRenderer, classRegex=/impl (node|java)/) {
       const [tokens, idx] = args
       const token = tokens[idx]
       if (token.meta?.classes) {
-        const classes = token.meta?.classes as string
         // delete classes in token.attrs as these would be rendered in addition,
         // leading to 'Duplicate attribute' errors
         deleteAttr('class', token.attrs)
 
         let result:string = original(...args)
-        const classExistsInResult = (classes: any, result: any) => {
-          const resultClasses = result.match(/class="([^"]*)"/)
-          if (!resultClasses || resultClasses.length < 2) return false
-          const resultClassList = resultClasses[1].split(/\s+/)
-          return classes.split(' ').some((cls: any) => resultClassList.includes(cls))
+        const hasClass = (classes: any, result: any) => {
+          const match = result.match(/class="([^"]*)"/)
+          if (!match || match.length < 2) return false
+          const existing = match[1].split(/\s+/)
+          return classes.split(' ').some((cls: any) => existing.includes(cls))
         }
 
         // Usage in your code
-        if (!classExistsInResult(token.meta.classes, result)) {
+        if (!hasClass(token.meta.classes, result)) {
           if (result.includes(' class="')) { // `class` attribute existing -> augment
             result = result.replace(' class="', ` class="${token.meta.classes} `)
           } else { // no `class` attribute -> set one

--- a/.vitepress/lib/md-attrs-propagate.ts
+++ b/.vitepress/lib/md-attrs-propagate.ts
@@ -45,7 +45,7 @@ export function install(md: MarkdownRenderer, classRegex=/impl (node|java)/) {
     })
   })
 
-  // intercept all container open renderes, like `container_tip_open`
+  // intercept all container open renderers, like `container_tip_open`
   // because these add additional divs, which need to be instrumented as well
   const { rules } = md.renderer
   // console.log('rules', rules)
@@ -66,7 +66,15 @@ export function install(md: MarkdownRenderer, classRegex=/impl (node|java)/) {
         deleteAttr('class', token.attrs)
 
         let result:string = original(...args)
-        if (!classes.split(' ').some(cls => result.includes(cls))) { // some of classes already set?
+        const classExistsInResult = (classes: any, result: any) => {
+          const resultClasses = result.match(/class="([^"]*)"/)
+          if (!resultClasses || resultClasses.length < 2) return false
+          const resultClassList = resultClasses[1].split(/\s+/)
+          return classes.split(' ').some((cls: any) => resultClassList.includes(cls))
+        }
+
+        // Usage in your code
+        if (!classExistsInResult(token.meta.classes, result)) {
           if (result.includes(' class="')) { // `class` attribute existing -> augment
             result = result.replace(' class="', ` class="${token.meta.classes} `)
           } else { // no `class` attribute -> set one


### PR DESCRIPTION
Currently code fences need an additional and explicit `<div class="impl java">` wrapped around them to properly be hidden in `{ .impl .java }` blocks, as the classes are not fully propagated. We only check for `includes` for `java|node` in the propagator, so the Vitepress-assigned `language-java` is also matched.

This can be seen for example on https://cap.cloud.sap/docs/guides/using-services#introduction: stay on the Node.js toggle and search for "DestinationConfiguration.java".