### PR TITLE
Document limitations for Select ... lock()

### DIFF
--- a/java/query-api.md
+++ b/java/query-api.md
@@ -764,7 +764,7 @@ There are few notable examples of such restrictions:
 
 * You cannot use `lock()` and `distinct()` in the same statement.
 * Localized entities can be locked only if you manually reset the locale via dedicated request context without the locale as described here [Modifying Request Context](./request-contexts#modifying-requestcontext). 
-* Entities that contains "on-read" caclulated elements can't be locked when the statement contains statement that references them. Only non-calculated part of the entity can be used in the statement.
+* Entities that contains "on-read" calculated elements can't be locked when the statement contains statement that references them. Only non-calculated part of the entity can be used in the statement.
 
 As a general rule, prefer the statements that select primary keys with a simple conditions, such as `byId` or `matching`, to select the target entity set for locking.
 

--- a/java/query-api.md
+++ b/java/query-api.md
@@ -758,13 +758,13 @@ import static com.sap.cds.ql.cqn.CqnLock.Mode.SHARED;
 Select.from("bookshop.Books").byId(1).lock(SHARED);
 ```
 
-Not every database entity exposed via the CDS entity can be locked with the `lock()` clause. Databases require that the target of such statements is represented by a single table or a view that is based on a single table without aggregation, joining or coalescence of values and the statement itself must not introduce aggregations, for example, by adding `groupBy()` clauses. Some databases might have additional restrictions or limitations specific to them.  
+Not every entity exposed via the CDS entity can be locked with the `lock()` clause. Databases require that the target of such statements is represented by a single table or by a view that is simple enough so that the database can unambiguously identify which rows must be locked. Views that use joins, aggregate data, include calculated or coalesced fields cannot be locked. Some databases might have additional restrictions or limitations specific to them.
 
-There are few notable examples of such restrictions: 
+There are few notable examples of such restrictions:
 
-* You cannot use `lock()` and `distinct()` in the same statement.
-* Localized entities can be locked only if you manually reset the locale via dedicated request context without the locale as described in the chapter [Modifying Request Context](./request-contexts#modifying-requestcontext). 
-* Entities that contains "on-read" calculated elements can't be locked when the statement references them in the select list or a filter. 
+* You cannot use `lock()` together with `distinct()` or `groupBy()`.
+* Localized entities can be locked only if you query is executed without a locale as described in the chapter [Modifying Request Context](./request-contexts#modifying-requestcontext).
+* Entities that contains "on-read" calculated elements can't be locked when the statement references them in the select list or a filter.
 
 As a general rule, prefer the statements that select primary keys with a simple conditions, such as `byId` or `matching`, to select the target entity set for locking.
 

--- a/java/query-api.md
+++ b/java/query-api.md
@@ -762,7 +762,8 @@ Not every entity exposed via the CDS entity can be locked with the `lock()` clau
 
 There are few notable examples of such restrictions:
 
-* You cannot use `lock()` together with `distinct()` or `groupBy()`.
+* You cannot use the `lock()` together with a `distinct()` or a `groupBy()`.
+* You cannot use the `lock()` in a statement with the subquery as a source.
 * Localized entities can be locked only if you query is executed without a locale as described in the chapter [Modifying Request Context](./request-contexts#modifying-requestcontext).
 * Entities that contains "on-read" calculated elements can't be locked when the statement references them in the select list or a filter.
 

--- a/java/query-api.md
+++ b/java/query-api.md
@@ -758,6 +758,16 @@ import static com.sap.cds.ql.cqn.CqnLock.Mode.SHARED;
 Select.from("bookshop.Books").byId(1).lock(SHARED);
 ```
 
+Not every database entity exposed via the CDS entity can be locked with the `lock()` clause. Databases require that the target of such statements is represented by a single table or a view that is based on a single table without aggregation, joining or coalescence of values and the statement itself must not introduce aggregations, for example, by adding `groupBy()` clauses. Some databases might have additional restrictions or limitations specific to them.  
+
+There are few notable examples of such restrictions: 
+
+* You cannot use `lock()` and `distinct()` in the same statement.
+* Localized entities can be locked only if you manually reset the locale via dedicated request context without the locale as described here [Modifying Request Context](./request-contexts#modifying-requestcontext). 
+* Entities that contains "on-read" caclulated elements can't be locked when the statement contains statement that references them. Only non-calculated part of the entity can be used in the statement.
+
+As a general rule, prefer the statements that select primary keys with a simple conditions, such as `byId` or `matching`, to select the target entity set for locking.
+
 ## Insert
 
 The [Insert](../cds/cqn#insert) statement inserts new data into a target entity set.

--- a/java/query-api.md
+++ b/java/query-api.md
@@ -764,7 +764,7 @@ There are few notable examples of such restrictions:
 
 * You cannot use `lock()` and `distinct()` in the same statement.
 * Localized entities can be locked only if you manually reset the locale via dedicated request context without the locale as described in the chapter [Modifying Request Context](./request-contexts#modifying-requestcontext). 
-* Entities that contains "on-read" calculated elements can't be locked when the statement references them in the select list or filter.
+* Entities that contains "on-read" calculated elements can't be locked when the statement references them in the select list or a filter. 
 
 As a general rule, prefer the statements that select primary keys with a simple conditions, such as `byId` or `matching`, to select the target entity set for locking.
 

--- a/java/query-api.md
+++ b/java/query-api.md
@@ -750,7 +750,7 @@ Select.from("bookshop.Books").byId(1).lock(5);
 Update.entity("bookshop.Books").data("price", 18).byId(1);
 ```
 
-To set a _shared_ (read) lock specify the lock mode `SHARED` in the lock method:
+To set a _shared_ (read) lock, specify the lock mode `SHARED` in the lock method:
 
 ```java
 import static com.sap.cds.ql.cqn.CqnLock.Mode.SHARED;
@@ -758,16 +758,20 @@ import static com.sap.cds.ql.cqn.CqnLock.Mode.SHARED;
 Select.from("bookshop.Books").byId(1).lock(SHARED);
 ```
 
-Not every entity exposed via the CDS entity can be locked with the `lock()` clause. Databases require that the target of such statements is represented by a single table or by a view that is simple enough so that the database can unambiguously identify which rows must be locked. Views that use joins, aggregate data, include calculated or coalesced fields cannot be locked. Some databases might have additional restrictions or limitations specific to them.
+Not every entity exposed via a CDS entity can be locked with the `lock()` clause. To use the `lock()` clause, databases require that the target of such statements is represented by one of the following:
+- a single table 
+- a simple view, so that the database can unambiguously identify which rows to lock
+
+Views that use joins, aggregate data, include calculated or coalesced fields cannot be locked. Some databases might have additional restrictions or limitations specific to them.
 
 There are few notable examples of such restrictions:
 
 * You cannot use the `lock()` together with a `distinct()` or a `groupBy()`.
 * You cannot use the `lock()` in a statement with the subquery as a source.
-* Localized entities can be locked only if you query is executed without a locale as described in the chapter [Modifying Request Context](./request-contexts#modifying-requestcontext).
-* Entities that contains "on-read" calculated elements can't be locked when the statement references them in the select list or a filter.
+* Localized entities can be locked only if your query is executed without a locale, as described in the chapter [Modifying Request Context](./request-contexts#modifying-requestcontext).
+* Entities that contain "on-read" calculated elements can't be locked when the statement references them in the select list or a filter.
 
-As a general rule, prefer the statements that select primary keys with a simple conditions, such as `byId` or `matching`, to select the target entity set for locking.
+As a general rule, prefer the statements that select primary keys with a simple condition, such as `byId` or `matching`, to select the target entity set that is locked.
 
 ## Insert
 

--- a/java/query-api.md
+++ b/java/query-api.md
@@ -763,7 +763,7 @@ Not every database entity exposed via the CDS entity can be locked with the `loc
 There are few notable examples of such restrictions: 
 
 * You cannot use `lock()` and `distinct()` in the same statement.
-* Localized entities can be locked only if you manually reset the locale via dedicated request context without the locale as described here [Modifying Request Context](./request-contexts#modifying-requestcontext). 
+* Localized entities can be locked only if you manually reset the locale via dedicated request context without the locale as described in the chapter [Modifying Request Context](./request-contexts#modifying-requestcontext). 
 * Entities that contains "on-read" calculated elements can't be locked when the statement references them in the select list or filter.
 
 As a general rule, prefer the statements that select primary keys with a simple conditions, such as `byId` or `matching`, to select the target entity set for locking.

--- a/java/query-api.md
+++ b/java/query-api.md
@@ -764,7 +764,7 @@ There are few notable examples of such restrictions:
 
 * You cannot use `lock()` and `distinct()` in the same statement.
 * Localized entities can be locked only if you manually reset the locale via dedicated request context without the locale as described here [Modifying Request Context](./request-contexts#modifying-requestcontext). 
-* Entities that contains "on-read" calculated elements can't be locked when the statement contains statement that references them. Only non-calculated part of the entity can be used in the statement.
+* Entities that contains "on-read" calculated elements can't be locked when the statement references them in the select list or filter.
 
 As a general rule, prefer the statements that select primary keys with a simple conditions, such as `byId` or `matching`, to select the target entity set for locking.
 

--- a/node.js/cds-serve.md
+++ b/node.js/cds-serve.md
@@ -86,14 +86,14 @@ app.listen()
 
 This uses these defaults for all options:
 
-| Option | Description | Default |
-| ------ | ----------- | ------- |
-| cds.serve ... | which services to construct |  `'all'` services
-| <i>&#8627;</i>.from  | models to load definitions from | `'./srv'` folder
-| <i>&#8627;</i>.in  | express app to mount to | — none —
-| <i>&#8627;</i>.to  | client protocol to serve to | `'fiori'`
-| <i>&#8627;</i>.at  | endpoint path to serve at | [`@path`](#path) or `.name`
-| <i>&#8627;</i>.with  | implementation function | `@impl` or `._source`.js
+| Option               | Description                     | Default                     |
+|----------------------|---------------------------------|-----------------------------|
+| cds.serve ...        | which services to construct     | `'all'` services            |
+| <i>&#8627;</i> .from | models to load definitions from | `'./srv'` folder            |
+| <i>&#8627;</i> .in   | express app to mount to         | — none —                    |
+| <i>&#8627;</i> .to   | client protocol to serve to     | `'fiori'`                   |
+| <i>&#8627;</i> .at   | endpoint path to serve at       | [`@path`](#path) or `.name` |
+| <i>&#8627;</i> .with | implementation function         | `@impl` or `._source`.js    |
 
 Alternatively you can construct services individually, also from other models, and also mount them yourself, as document in the subsequent sections on individual fluent API options.
 


### PR DESCRIPTION
Add a summary and some examples of the cases when the `Select` statement with the `lock()` clause does not work. 