### PR TITLE
cds.test with authentication

### DIFF
--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -83,7 +83,7 @@ await POST (`/browse/submitOrder`, { book: 201, quantity: 5 })
 
 
 #### Authenticated Endpoints
-`cds.test()` uses the standard authentication strategy in development mode, which is the [mocked authentication](../node.js/authentication#mocked). To configure it, use `cds.requires.auth` in the `package.json` file or directly in your test file like so:
+`cds.test()` uses the standard authentication strategy in development mode, which is the [mocked authentication](../node.js/authentication#mocked). To configure it, use `cds.requires.auth` in the _package.json_ file or directly in your test file as follows:
 
 ```js
 cds.env.requires.auth.users.foo = {

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -83,7 +83,7 @@ await POST (`/browse/submitOrder`, { book: 201, quantity: 5 })
 
 
 #### Authenticated Endpoints
-`cds.test()` uses the standard authentication strategy in development mode, which is the [mocked authentication](../node.js/authentication#mocked). To configure it, use `cds.requires.auth` in the _package.json_ file as described in the documenation for the mocked authentication.
+`cds.test()` uses the standard authentication strategy in development mode, which is the [mocked authentication](../node.js/authentication#mocked). To configure it, use `cds.requires.auth` in the _package.json_ file as described in the documentation for the mocked authentication.
 
 After configuring the authentication, you can set the user for an authenticated request like this:
 

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -86,7 +86,7 @@ await POST (`/browse/submitOrder`, { book: 201, quantity: 5 })
 `cds.test()` uses the standard authentication strategy in development mode, which is the [mocked authentication](../node.js/authentication#mocked). To configure it, use `cds.requires.auth` in the `package.json` file or directly in your test file like so:
 
 ```js
-cds.requires.auth.users.foo = {
+cds.env.requires.auth.users.foo = {
   password: 'bar',
   roles: { admin: true, ['cds.Subscriber']: true },
   attr: { name: 'Foo' }

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -91,7 +91,7 @@ You can set the user for an authenticated request like this:
 await GET('/admin/Books', { auth: { username: 'alice', password: '' } })
 ```
 
-[Learn how to explicitly configure mock user in your _package.json_ file.](../node.js/authentication#mocked){.learn-more}
+[Learn how to explicitly configure mock users in your _package.json_ file.](../node.js/authentication#mocked){.learn-more}
 
 ### Using Jest or Mocha
 

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -83,7 +83,7 @@ await POST (`/browse/submitOrder`, { book: 201, quantity: 5 })
 
 
 #### Authenticated Endpoints
-`cds.test()` uses [mocked authentication](https://pages.github.tools.sap/cap/docs/node.js/authentication#mocked). To configure authentication, you can utilize `cds.requires.auth` in the `package.json` file or directly in your test file like so:
+`cds.test()` uses the standard authentication strategy in development mode, which is the [mocked authentication](../node.js/authentication#mocked). To configure it, use `cds.requires.auth` in the `package.json` file or directly in your test file like so:
 
 ```js
 cds.requires.auth.users.foo = {

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -83,14 +83,15 @@ await POST (`/browse/submitOrder`, { book: 201, quantity: 5 })
 
 
 #### Authenticated Endpoints
-`cds.test()` uses the standard authentication strategy in development mode, which is the [mocked authentication](../node.js/authentication#mocked). To configure it, use `cds.requires.auth` in the _package.json_ file as described in the documentation for the mocked authentication.
+`cds.test()` uses the standard authentication strategy in development mode, which is the [mocked authentication](../node.js/authentication#mocked). This also includes the usage of [pre-definded mock users](../node.js/authentication#mock-users)
 
-After configuring the authentication, you can set the user for an authenticated request like this:
+You can set the user for an authenticated request like this:
 
 ```js
-await GET('/admin/Books', { auth: { username: 'foo', password: 'bar' } })
+await GET('/admin/Books', { auth: { username: 'alice', password: '' } })
 ```
 
+[Learn how to explicitly configure mock user in your _package.json_ file.](../node.js/authentication#mocked){.learn-more}
 
 ### Using Jest or Mocha
 

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -82,6 +82,23 @@ await POST (`/browse/submitOrder`, { book: 201, quantity: 5 })
 [Learn more in GET/PUT/POST.](#http-bound) {.learn-more}
 
 
+#### Authenticated Endpoints
+`cds.test()` uses [mocked authentication](https://pages.github.tools.sap/cap/docs/node.js/authentication#mocked). To configure authentication, you can utilize `cds.requires.auth` in the `package.json` file or directly in your test file like so:
+
+```js
+cds.requires.auth.users.foo = {
+  password: 'bar',
+  roles: { admin: true, ['cds.Subscriber']: true },
+  attr: { name: 'Foo' }
+}
+```
+
+After configuring the authentication, you can set the user for an authenticated request like this:
+
+```js
+await GET('/admin/Books', { auth: { username: 'foo', password: 'bar' } })
+```
+
 
 ### Using Jest or Mocha
 

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -83,15 +83,7 @@ await POST (`/browse/submitOrder`, { book: 201, quantity: 5 })
 
 
 #### Authenticated Endpoints
-`cds.test()` uses the standard authentication strategy in development mode, which is the [mocked authentication](../node.js/authentication#mocked). To configure it, use `cds.requires.auth` in the _package.json_ file or directly in your test file as follows:
-
-```js
-cds.env.requires.auth.users.foo = {
-  password: 'bar',
-  roles: { admin: true, ['cds.Subscriber']: true },
-  attr: { name: 'Foo' }
-}
-```
+`cds.test()` uses the standard authentication strategy in development mode, which is the [mocked authentication](../node.js/authentication#mocked). To configure it, use `cds.requires.auth` in the _package.json_ file as described in the documenation for the mocked authentication.
 
 After configuring the authentication, you can set the user for an authenticated request like this:
 


### PR DESCRIPTION
Our documentation nicely explains how to use service APIs and HTTP APIs with cds.test.

We should add a link to the authentication configuration and explain which kind is used for cds.test. In addition, we should add samples how to set a user for the above mentioned APIs.