### PR TITLE
Fix review script

### DIFF
--- a/.github/etc/create-review.cjs
+++ b/.github/etc/create-review.cjs
@@ -125,7 +125,7 @@ module.exports = async ({ github, require, exec, core }) => {
             }
 
             if (rule === 'MD042/no-empty-links') {
-                const link = context.match(/\[Context: "(\[.*?\]\(\))"/)[1]
+                const link = context.match(/\[Context: "(\[.*?)"\]/)[1]
 
                 contextText = `[Context: "${escapeMarkdownlink(link)}"]`
 

--- a/.github/etc/create-review.cjs
+++ b/.github/etc/create-review.cjs
@@ -76,7 +76,7 @@ module.exports = async ({ github, require, exec, core }) => {
     })
 
     const diffs = {}
-    data.filter(obj => extname(obj.filename.endsWith) === '.md')
+    data.filter(obj => extname(obj.filename) === '.md')
         .forEach(obj => {
             diffs[obj.filename.replace('./', '')] = obj.patch.split('\n')
         })

--- a/.github/etc/create-review.cjs
+++ b/.github/etc/create-review.cjs
@@ -125,7 +125,12 @@ module.exports = async ({ github, require, exec, core }) => {
             }
 
             if (rule === 'MD042/no-empty-links') {
-                const link = context.match(/\[Context: "(\[.*?)"\]/)[1]
+                let link = context.match(/\[Context: "(\[.*?)"\]/)[1]
+
+                // if the context is too long, markdownlint-cli will truncate the string and append "..." at the end
+                if (link.endsWith('...')) {
+                    link = link.substring(0, link.length - 3)
+                }
 
                 contextText = `[Context: "${escapeMarkdownlink(link)}"]`
 

--- a/.github/etc/create-review.cjs
+++ b/.github/etc/create-review.cjs
@@ -77,6 +77,7 @@ module.exports = async ({ github, require, exec, core }) => {
 
     const diffs = {}
     data.forEach(obj => {
+        console.log(obj)
         diffs[obj.filename.replace('./', '')] = obj.patch.split('\n')
     })
 

--- a/.github/etc/create-review.cjs
+++ b/.github/etc/create-review.cjs
@@ -39,7 +39,7 @@ const createSuggestContainerTypeText = (suggestion) => createSuggestionText(sugg
 
 module.exports = async ({ github, require, exec, core }) => {
     const { readFileSync, existsSync } = require('fs')
-    const { join } = require('path')
+    const { join, extname } = require('path')
     const { SHA, BASE_DIR, BASE_SHA, PULL_NUMBER, HEAD_SHA, REPO, REPO_OWNER } = process.env
 
     const cspellLogFile = join(BASE_DIR, 'CSPELL.log')
@@ -76,10 +76,10 @@ module.exports = async ({ github, require, exec, core }) => {
     })
 
     const diffs = {}
-    data.forEach(obj => {
-        console.log(obj)
-        diffs[obj.filename.replace('./', '')] = obj.patch.split('\n')
-    })
+    data.filter(obj => extname(obj.filename.endsWith) === '.md')
+        .forEach(obj => {
+            diffs[obj.filename.replace('./', '')] = obj.patch.split('\n')
+        })
 
     if (existsSync(markdownlintLogFile)) {
         const matches = readFileSync(markdownlintLogFile, 'utf-8')
@@ -290,7 +290,9 @@ module.exports = async ({ github, require, exec, core }) => {
     }
 
     function getDiff(file) {
-        return diffs[file.replace('./', '')]
+        const k = file.replace('./', '')
+        if (!(k in diffs)) throw new Error(`There is no diff for file ${file}.`)
+        return diffs[k]
     }
 
     async function findPositionInDiff(context, file) {


### PR DESCRIPTION
Fixes some issues:
* We now filter the diffs we receive from the GitHub REST API by `.md` file type, since we only check these files anyway
* the RegExp for extracting the context for empty links has become less restricted
* if the context is too long, markdownlint-cli will truncate the string and append "..." at the end -> We have to remove these three dots