### PR TITLE
fix code issue in otel custom instrumentation sample

### DIFF
--- a/java/observability.md
+++ b/java/observability.md
@@ -372,7 +372,7 @@ Similarly, you can record metrics during execution of, for example, a custom eve
 @Component
 @ServiceName(CatalogService_.CDS_NAME)
 class CatalogServiceHandler implements EventHandler {
-  Metric tracer = GlobalOpenTelemetry.getTracerProvider().tracerBuilder("RatingCalculator").build();
+  Meter meter = GlobalOpenTelemetry.getMeterProvider().meterBuilder("RatingCalculator").build();
 
   @After(entity = Books_.CDS_NAME)
   public void afterAddReview(AddReviewContext context) {


### PR DESCRIPTION
Fixes a copy and paste issue in one of the open telemetry code samples which results in non-compilable code.