### PR TITLE
Fix padding for opened `<details>` blocks.

### DIFF
--- a/.vitepress/theme/custom.scss
+++ b/.vitepress/theme/custom.scss
@@ -192,6 +192,9 @@ main {
       font-style: italic;
       a { color: darkcyan }
     }
+    &[open] {
+      padding: 11px 14px 11px;
+    }
   }
 
   img:not(.avatar-img) {


### PR DESCRIPTION
We currently adjust the padding of `<details>` blocks to decrease its size a little bit. This PR adjusts the bottom padding when this block is opened.

Before:
<img width="642" alt="Screenshot 2024-01-29 at 12 14 20" src="https://github.com/cap-js/docs/assets/24377039/35ae72ca-a29d-44d1-a91d-787dfd837e7c">

After:
<img width="687" alt="Screenshot 2024-01-29 at 12 13 54" src="https://github.com/cap-js/docs/assets/24377039/50112410-12d5-474d-9867-f9ee882aa0fb">

