### PR TITLE
Update `mvn cds:watch`

### DIFF
--- a/get-started/hello-world.md
+++ b/get-started/hello-world.md
@@ -142,8 +142,7 @@ cds watch
 <div class="impl java">
 
 ```sh
-cd srv
-mvn cds:watch
+mvn com.sap.cds:cds-maven-plugin:watch
 ```
 
 </div>

--- a/java/development/index.md
+++ b/java/development/index.md
@@ -392,7 +392,7 @@ In addition to the previously mentioned build tasks, the CDS Maven plugin can al
 1. Build and run your application.
 1. Test your changes.
 
-To automate and accelerate these steps, the `cds-maven-plugin` offers the goal `watch`, that can be executed from the command line in the service module folder by using Maven:
+To automate and accelerate these steps, the `cds-maven-plugin` offers the goal `watch`, that can be executed from the command line by using Maven:
 
 ```sh
 mvn com.sap.cds:cds-maven-plugin:watch

--- a/java/development/index.md
+++ b/java/development/index.md
@@ -392,7 +392,7 @@ In addition to the previously mentioned build tasks, the CDS Maven plugin can al
 1. Build and run your application.
 1. Test your changes.
 
-To automate and accelerate these steps, the `cds-maven-plugin` offers the goal `watch`, that can be executed from the command line by using Maven:
+To automate and accelerate these steps, the `cds-maven-plugin` offers the goal `watch`, which can be executed from the command line by using Maven:
 
 ```sh
 mvn com.sap.cds:cds-maven-plugin:watch

--- a/java/development/index.md
+++ b/java/development/index.md
@@ -395,8 +395,7 @@ In addition to the previously mentioned build tasks, the CDS Maven plugin can al
 To automate and accelerate these steps, the `cds-maven-plugin` offers the goal `watch`, that can be executed from the command line in the service module folder by using Maven:
 
 ```sh
-cd srv
-mvn cds:watch
+mvn com.sap.cds:cds-maven-plugin:watch
 ```
 
 It builds and starts the application and looks for changes in the CDS model. If you change the CDS model, these are recognized and a restart of the application is initiated to make the changes effective.


### PR DESCRIPTION
As of release 2.8.0 of the `cds-maven-plugin`, the watch goal can be executed in project's root folder.