### PR TITLE
Fix Navbar & link errors

### DIFF
--- a/menu.md
+++ b/menu.md
@@ -85,7 +85,7 @@
 - [Common Annotations](cds/annotations)
 - [Nature of Models](cds/models)
 
-### [Node.js](node.js/)
+### [Node](node.js/)
 
 - [The cds Facade](node.js/cds-facade)
 - [cds. Services](node.js/core-services)

--- a/menu.md
+++ b/menu.md
@@ -177,14 +177,15 @@
 
 ### [Tools](tools/)
 
-- [Command Line Interface (CLI)](tools/index#command-line-interface-cli)
+- [CDS Command Line Interface](tools/index#cli)
 - [SAP Business Application Studio](tools/index#bastudio)
 - [Visual Studio Code](tools/index#vscode)
-- [IntelliJ](tools/index#intellij)
-- [Docker](tools/index#docker)
+- [IntelliJ IDEA](tools/index#intellij)
 - [CDS Editors](tools/index#cds-editor)
 - [CDS Lint](tools/index#cds-lint)
 - [CDS Typer](tools/cds-typer)
+- [CAP Notebooks](tools/index#cap-notebooks-page)
+- [Using Docker](tools/index#docker)
 
 ### [Plugins](plugins/)
 

--- a/tools/index.md
+++ b/tools/index.md
@@ -660,7 +660,7 @@ Linting:
 
 
 
-## CAP Notebooks { #cap-notebooks }
+## CAP Notebooks { #cap-vscode-notebook }
 
 A **CAP Notebook** is a [Custom Notebook in Visual Studio Code](https://code.visualstudio.com/blogs/2021/11/08/custom-notebooks) that serves you as a guide on how to create, navigate, and monitor CAP projects. With this approach, we want to encourage the CAP community to work with CAP in the same explorative manner that scientists work with their data, namely by:
 

--- a/tools/index.md
+++ b/tools/index.md
@@ -444,7 +444,7 @@ Enable to get quickfix proposals for artifact names, like entities, that aren't 
 
 If there are new release notes, this page opens on startup. You can disable this behavior using the *CDS > Release Notes: Show Automatically* (`cds.releaseNotes.showAutomatically`) setting.
 
-##### CAP Notebooks Page { #cap-notebooks-page}
+##### CAP Notebooks Page { #cap-notebooks-page }
 
 1. Press <kbd>F1</kbd>
 1. Open *CDS: Open CAP Notebooks Page*
@@ -660,7 +660,7 @@ Linting:
 
 
 
-## CAP Notebooks { #cap-vscode-notebook}
+## CAP Notebooks { #cap-notebooks }
 
 A **CAP Notebook** is a [Custom Notebook in Visual Studio Code](https://code.visualstudio.com/blogs/2021/11/08/custom-notebooks) that serves you as a guide on how to create, navigate, and monitor CAP projects. With this approach, we want to encourage the CAP community to work with CAP in the same explorative manner that scientists work with their data, namely by:
 
@@ -686,7 +686,7 @@ The cell inputs/outputs are especially useful at later points in time when the p
 
 
 
-## Using Docker
+## Using Docker { #docker }
 
 Prerequisite: You have installed [Docker](https://docs.docker.com/get-started/).
 


### PR DESCRIPTION
- Fixes build issue which currently makes build pipeline fail
- However, with this fix in, more errors are uncovered (missing _#cap-notebooks_ refs?)