### PR TITLE
Remove max-height property from `.VPImage`

### DIFF
--- a/.vitepress/theme/custom.scss
+++ b/.vitepress/theme/custom.scss
@@ -5,7 +5,7 @@
     .name { font-weight: 400; font-size: 55px }
     .text { font-weight: 400 }
     .tagline { font-weight: 400 }
-    .VPImage { max-width: 350px; max-height: 350px; }
+    .VPImage { max-width: 350px; }
     .VPButton { border: none; }
   }
   .VPFeatures .icon {


### PR DESCRIPTION
The logo is not sized correctly for small screens:
![Screenshot 2024-03-18 at 09 33 48](https://github.com/cap-js/docs/assets/24377039/515515a4-77b9-47cb-b9bd-96659ea59b94)

Removing the `max-height` property fixes the problem without any observable detrimental effects:
![Screenshot 2024-03-18 at 09 33 32](https://github.com/cap-js/docs/assets/24377039/963fba68-91f5-4068-bc02-d6df7440b76b)