### PR TITLE
Remove concept section "Free Subselects" from authorization guide

### DIFF
--- a/guides/security/authorization.md
+++ b/guides/security/authorization.md
@@ -630,10 +630,8 @@ service ProductsService @(requires: 'authenticated-user') {
 Here, the authorization of `Products` is derived from `Divisions` by leveraging the _n:m relationship_ via entity `ProducingDivisions`. Note that the path `producers.division` in the `exists` predicate points to target entity `Divisions`, where the filter with the user-dependent attribute `$user.division` is applied.
 
 ::: warning Consider Access Control Lists
-Be aware that deep paths might introduce a performance bottleneck. Access Control List (ACL) tables, managed by the application, allow efficient queries and might be the better option in this case. <span id="tip-efficient-queries" />
+Be aware that deep paths might introduce a performance bottleneck. Access Control List (ACL) tables, managed by the application, allow efficient queries and might be the better option in this case.
 :::
-
-<div id="beforeassociationpaths" />
 
 ### Association Paths { #association-paths}
 


### PR DESCRIPTION
Discussed in spec meeting 2024-03-18
* We don't plan to implement this
* If we do implement it, the rules will be different from what is written here

There is an related change in "internal" where the fragment definitions are deleted