### PR TITLE
fix(CDL): Be more specific about parameter-refs in annotations

### DIFF
--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1040,7 +1040,7 @@ Each path in the expression is checked:
 * For an annotation assigned to an entity element, the first path step is resolved as the annotated element or its siblings.
 * If the annotation is assigned to a subelement of a structured element, the top level
   elements of the entity can be accessed via `$self`.
-* A parameter `par` of a parametrized entity can be accessed like in a query with `:par`.
+* A parameter `par` can be accessed via `:par`, just like parameters of a parametrized entity in queries.
 * If a path cannot be resolved successfully, compilation fails with an error.
 
 In contrast to `@aReference: foo.bar`, a single reference written as expression `@aRefExpr: ( foo.bar )`


### PR DESCRIPTION
It's not only entity parameters that can be accessed, but action/function parameters as well.