### PR TITLE
Fix layout for samples page

### DIFF
--- a/get-started/samples.md
+++ b/get-started/samples.md
@@ -30,37 +30,17 @@ We're just getting started with this page. Please help us in that endeavour by [
     display: inline-block;
   }
 
-  .dark h3.github::before, .dark li._nodejs a::before, .dark li._java a::before {
-    filter: brightness(.884) invert(1) hue-rotate(177deg);
-  }
-
-  li._nodejs {
-    display: inline;
-    margin-right: 2em;
-  }
-  li._nodejs a::before {
-    content: "";
-    background: url(../assets/logos/nodejs.svg) no-repeat 0 0;
-    background-size: 4em;
-    height: 4em;
-    width: 4em;
-    vertical-align: middle;
-    display: inline-block;
-  }
-
-  li._java {
-    display: inline;
-    margin-right: 2em;
-  }
-  li._java a::before {
-    content: "";
-    background: url(../assets/logos/java.svg) no-repeat 0 0;
-    background-size: 5.5em;
-    height: 5.5em;
-    width: 5.5em;
-    vertical-align: middle;
-    display: inline-block;
-  }
+  main .vp-doc a:has(> img) {
+    display: inline-flex;
+    align-items: center;
+    transition: opacity 0.2s;
+   }
+   main .vp-doc a:has(> img):hover {
+      opacity: 0.7;
+   }
+   main .vp-doc a:has(> img):not(:last-child) {
+      margin-right: 1em;
+   }
 
 </style>
 
@@ -73,9 +53,8 @@ It is available in both Node.js and Java. The Node.js variant contains additiona
 
 Available for:
 
-- [](https://github.com/sap-samples/cloud-cap-samples) {._nodejs}
-- [](https://github.com/sap-samples/cloud-cap-samples-java) {._java}
-
+[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" />](https://github.com/sap-samples/cloud-cap-samples)
+[<img src="../assets/logos/java.svg" style="height:3em; display:inline; margin:0 0.2em;" />](https://github.com/sap-samples/cloud-cap-samples-java)
 
 
 
@@ -85,7 +64,7 @@ A reference sample application for CAP and the SAP BTP Developer Guide.
 
 Available for:
 
-- [](https://github.com/cap-js/incidents-app) {._nodejs}
+[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" />](https://github.com/cap-js/incidents-app)
 
 
 
@@ -95,8 +74,8 @@ This sample is a CAP adaptation of the popular [SFLIGHT](https://blog.sap-press.
 
 Available for:
 
-- [](https://github.com/sap-samples/cap-sflight) {._nodejs}
-- [](https://github.com/sap-samples/cap-sflight) {._java}
+[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" />](https://github.com/sap-samples/cap-sflight)
+[<img src="../assets/logos/java.svg" style="height:3em; display:inline; margin:0 0.2em;" />](https://github.com/sap-samples/cap-sflight)
 
 
 
@@ -108,7 +87,7 @@ The projects described above have fallen out of maintenance but still offered th
 
 Available for:
 
-- [](https://github.com/SAP-samples/cloud-cap-hana-swapi) {._nodejs}
+[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" />](https://github.com/SAP-samples/cloud-cap-hana-swapi)
 
 
 
@@ -116,4 +95,6 @@ Available for:
 
 The Sustainable SaaS (SusaaS) sample application has been built in a partner collaboration to help interested developers, partners, and customers in developing multitenant Software as a Service applications using CAP and deploying them to the SAP Business Technology Platform (SAP BTP).
 
-- [](https://github.com/SAP-samples/btp-cap-multitenant-saas) {._nodejs}
+Available for:
+
+[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" />](https://github.com/SAP-samples/btp-cap-multitenant-saas)

--- a/get-started/samples.md
+++ b/get-started/samples.md
@@ -53,8 +53,8 @@ It is available in both Node.js and Java. The Node.js variant contains additiona
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" />](https://github.com/sap-samples/cloud-cap-samples)
-[<img src="../assets/logos/java.svg" style="height:3em; display:inline; margin:0 0.2em;" />](https://github.com/sap-samples/cloud-cap-samples-java)
+[<img src="../assets/logos/nodejs.svg" title="Link to the cloud-cap-samples repository." style="height:2.5em; display:inline; margin:0 0.2em;"  alt="Node.js logo"/>](https://github.com/sap-samples/cloud-cap-samples)
+[<img src="../assets/logos/java.svg" title="link to the cloud-cap-samples-java repository." style="height:3em; display:inline; margin:0 0.2em;" alt="Java logo" />](https://github.com/sap-samples/cloud-cap-samples-java)
 
 
 
@@ -64,7 +64,7 @@ A reference sample application for CAP and the SAP BTP Developer Guide.
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" />](https://github.com/cap-js/incidents-app)
+[<img src="../assets/logos/nodejs.svg" title="Link to the incident-app repository." style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js logo"/>](https://github.com/cap-js/incidents-app)
 
 
 
@@ -74,8 +74,8 @@ This sample is a CAP adaptation of the popular [SFLIGHT](https://blog.sap-press.
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" />](https://github.com/sap-samples/cap-sflight)
-[<img src="../assets/logos/java.svg" style="height:3em; display:inline; margin:0 0.2em;" />](https://github.com/sap-samples/cap-sflight)
+[<img src="../assets/logos/nodejs.svg" title="Link to the cap-sflight repository." style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js logo"/>](https://github.com/sap-samples/cap-sflight)
+[<img src="../assets/logos/java.svg" title="Link to the cap-sflight repository." style="height:3em; display:inline; margin:0 0.2em;" alt="Java logo"/>](https://github.com/sap-samples/cap-sflight)
 
 
 
@@ -87,7 +87,7 @@ The projects described above have fallen out of maintenance but still offered th
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" />](https://github.com/SAP-samples/cloud-cap-hana-swapi)
+[<img src="../assets/logos/nodejs.svg" title="Link to the Star Wars app repository." style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js logo"/>](https://github.com/SAP-samples/cloud-cap-hana-swapi)
 
 
 
@@ -97,4 +97,4 @@ The Sustainable SaaS (SusaaS) sample application has been built in a partner col
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" />](https://github.com/SAP-samples/btp-cap-multitenant-saas)
+[<img src="../assets/logos/nodejs.svg" title="Link to the Sustainable SaaS (SusaaS) repository." style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js logo"/>](https://github.com/SAP-samples/btp-cap-multitenant-saas)

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -135,7 +135,7 @@ Features:
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" alt="link to the repository for cap-js attachments"/>](https://github.com/cap-js/attachments#readme)
+[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" Title="Link to the repository for cap-js attachments." alt="Node.js logo"/>](https://github.com/cap-js/attachments#readme)
 
 
 ## Audit Logging
@@ -162,7 +162,7 @@ Features:
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js"/>](https://github.com/cap-js/audit-logging#readme)
+[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js" title="Link to the plugins repository."/>](https://github.com/cap-js/audit-logging#readme)
 <img src="../assets/logos/java.svg" style="height:3em; display:inline; margin:0 0.2em;" alt="Java"/>
 
 Learn more about audit logging in [Node.js](../guides/data-privacy/audit-logging) and in [Java](../java/auditlog) {.learn-more}
@@ -185,8 +185,8 @@ annotate my.Incidents {
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js"/>](https://github.com/cap-js/change-tracking#readme)
-[<img src="../assets/logos/java.svg" style="height:3em; display:inline; margin:0 0.2em;" alt="Java"/>](../java/change-tracking)
+[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js" title="Link to the plugins repository."/>](https://github.com/cap-js/change-tracking#readme)
+[<img src="../assets/logos/java.svg" title="Link to the documentation of the change-tracking feature." style="height:3em; display:inline; margin:0 0.2em;" alt="Java"/>](../java/change-tracking)
 
 
 
@@ -200,7 +200,7 @@ The GraphQL Adapter is a protocol adapter that generically generates a GraphQL s
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js" />](https://github.com/cap-js/graphql#readme)
+[<img src="../assets/logos/nodejs.svg" title="Link to the plugins repository." style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js" />](https://github.com/cap-js/graphql#readme)
 
 
 
@@ -231,7 +231,7 @@ Features:
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js"/>](https://github.com/cap-js/notifications#readme)
+[<img src="../assets/logos/nodejs.svg" title="Link to the plugins repository." style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js"/>](https://github.com/cap-js/notifications#readme)
 
 
 
@@ -243,8 +243,8 @@ The OData v2 Proxy is a protocol adapter that allows you to expose your services
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js" />](https://github.com/cap-js-community/odata-v2-adapter#readme)
-[<img src="../assets/logos/java.svg" style="height:3em; display:inline; margin:0 0.2em;" alt="Java"/>](../java/migration#v2adapter)
+[<img src="../assets/logos/nodejs.svg" title="Link to the plugins repository." style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js" />](https://github.com/cap-js-community/odata-v2-adapter#readme)
+[<img src="../assets/logos/java.svg" title="Link to the documentation of the OData feature." style="height:3em; display:inline; margin:0 0.2em;" alt="Java"/>](../java/migration#v2adapter)
 
 See also [Cookbook > Protocols/APIs > OData APIs > V2 Support](../advanced/odata#v2-support) {.learn-more}
 
@@ -273,8 +273,8 @@ Telemetry data can be exported to [SAP Cloud Logging](https://help.sap.com/docs/
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js"/>](https://github.com/cap-js/telemetry#readme)
-[<img src="../assets/logos/java.svg" style="height:3em; display:inline; margin:0 0.2em;" alt="Java"/>](../java/operating-applications/observability#open-telemetry)
+[<img src="../assets/logos/nodejs.svg" title="Link to the plugins repository." style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js"/>](https://github.com/cap-js/telemetry#readme)
+[<img src="../assets/logos/java.svg" title="Link to the documentation of the telemetry feature." style="height:3em; display:inline; margin:0 0.2em;" alt="Java"/>](../java/operating-applications/observability#open-telemetry)
 
 
 
@@ -285,7 +285,7 @@ The UI5 Dev Server is a CDS server plugin that enables the integration of UI5 (U
 
 Available for:
 
-[<img src="../assets/logos/nodejs.svg" style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js"/>](https://github.com/ui5-community/ui5-ecosystem-showcase/tree/main/packages/cds-plugin-ui5#cds-plugin-ui5)
+[<img src="../assets/logos/nodejs.svg" title="Link to the plugins repository." style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js"/>](https://github.com/ui5-community/ui5-ecosystem-showcase/tree/main/packages/cds-plugin-ui5#cds-plugin-ui5)
 
 
 


### PR DESCRIPTION
Styling on _Samples_ is not as nice as on _Plugins_, as we've noticed recently:
https://cap.cloud.sap/docs/get-started/samples
https://cap.cloud.sap/docs/plugins/

This PR applies the same CSS to the Node.js/Java images as we've used on _Plugins_.