### PR TITLE
Typer docs: add missing comma

### DIFF
--- a/tools/cds-typer.md
+++ b/tools/cds-typer.md
@@ -22,11 +22,11 @@ The following chapter describes the [`cds-typer` package](https://www.npmjs.com/
 ```js
 //  without cds-typer
 const { Books } = cds.entities(…)
-service.before('CREATE' Books, ({ data }) => { /* data is of type any */})
+service.before('CREATE', Books, ({ data }) => { /* data is of type any */})
 
 // ✨ with cds-typer
-const { Books } = require('#cds-models/…')
-service.before('CREATE' Books, ({ data }) => { /* data is of type Books */})
+const { Books } = require('#cds-models/myService')
+service.before('CREATE', Books, ({ data }) => { /* data is of type Books */})
 ```
 
 

--- a/tools/cds-typer.md
+++ b/tools/cds-typer.md
@@ -21,7 +21,7 @@ The following chapter describes the [`cds-typer` package](https://www.npmjs.com/
 
 ```js
 //  without cds-typer
-const { Books } = cds.entities(…)
+const { Books } = cds.entities('bookshop')
 service.before('CREATE', Books, ({ data }) => { /* data is of type any */})
 
 // ✨ with cds-typer

--- a/tools/cds-typer.md
+++ b/tools/cds-typer.md
@@ -25,7 +25,7 @@ const { Books } = cds.entities('bookshop')
 service.before('CREATE', Books, ({ data }) => { /* data is of type any */})
 
 // ✨ with cds-typer
-const { Books } = require('#cds-models/myService')
+const { Books } = require('#cds-models/bookshop')
 service.before('CREATE', Books, ({ data }) => { /* data is of type Books */})
 ```
 


### PR DESCRIPTION
- Added a missing comma in a snippet
- specified what comes after the `#cds-models` as it may be not 100% clear to people working with the cds-typer for the first time