### PR TITLE
Update odata.md

### DIFF
--- a/advanced/odata.md
+++ b/advanced/odata.md
@@ -436,7 +436,7 @@ Arrays are mapped to `<Collection>` nodes in EDMX and if primitives show up as d
 
 ```cds
 @Some.Collection: [
-  true, 1, 3.14, 'foo',
+  null,true, 1, 3.14, 'foo',
   { $Type:'UI.DataField', Label:'Whatever', Hidden }
 ]
 ```

--- a/advanced/odata.md
+++ b/advanced/odata.md
@@ -436,7 +436,7 @@ Arrays are mapped to `<Collection>` nodes in EDMX and if primitives show up as d
 
 ```cds
 @Some.Collection: [
-  null,true, 1, 3.14, 'foo',
+  null, true, 1, 3.14, 'foo',
   { $Type:'UI.DataField', Label:'Whatever', Hidden }
 ]
 ```


### PR DESCRIPTION
@Some.Collection: [
  true, 1, 3.14, 'foo',
  { $Type:'UI.DataField', Label:'Whatever', Hidden }
]

For the above collection example, in the documentation, i think we are missing the first entry as null. There are five elements in the @Some.Collection array, but we have 6 in the xml annotation

<Annotation Term="Some.Collection">
  <Collection>
    <Null/>
    <Bool>true</Bool>
    <Int>1</Int>
    <Decimal>3.14</Decimal>
    <String>foo</String>
    <Record Type="UI.DataField">
      <PropertyValue Property="Label" String="Whatever"/>
      <PropertyValue Property="Hidden" Bool="True"/>
    </Record>
  </Collection>
</Annotation>