### PR TITLE
Update CDS Lint docs

### DIFF
--- a/tools/cds-lint/[rules].paths.ts
+++ b/tools/cds-lint/[rules].paths.ts
@@ -34,10 +34,10 @@ They are used to enforce security, naming conventions, or other best practices.
 Note, that while all recommended (&nbsp;✅&nbsp;) model rules run with the CLI, only a number of them are
 enabled and visible in the editor by default (&nbsp;👀&nbsp;).
 ::: details
-* *Visible by default* rules: Rules that are enabled in the editor by default only rely on the current file as their rule context. These are quick to execute and
+* *Editor default* rules: Rules that are enabled in the editor by default only rely on the current file as their rule context. These are quick to execute and
 can react on file changes.
 * *Project-based* rules: Rules that are disabled in the editor by default usually rely on a series of (project) files for their rule context or include
-slow or expensive processes. These are slow to execute and only run with the CLI.
+slow or expensive processes. These are slow to execute and by default only run with the CLI.
 :::
 
 <RulesRefTable category="Model Validation"/>

--- a/tools/cds-lint/[rules].paths.ts
+++ b/tools/cds-lint/[rules].paths.ts
@@ -34,7 +34,7 @@ They are used to enforce security, naming conventions, or other best practices.
 Note, that while all recommended (&nbsp;✅&nbsp;) model rules run with the CLI, only a number of them are
 enabled and visible in the editor by default (&nbsp;👀&nbsp;).
 ::: details
-* *In Editor* rules: Rules that are enabled in the editor by default only rely on the current file as their rule context. These are quick to execute and
+* *Visible by default* rules: Rules that are enabled in the editor by default only rely on the current file as their rule context. These are quick to execute and
 can react on file changes.
 * *Project-based* rules: Rules that are disabled in the editor by default usually rely on a series of (project) files for their rule context or include
 slow or expensive processes. These are slow to execute and only run with the CLI.

--- a/tools/cds-lint/components/RulesRefTable.vue
+++ b/tools/cds-lint/components/RulesRefTable.vue
@@ -27,7 +27,7 @@
         </ul>
     </div>
     <table class="lint-ref-table">
-        <thead>
+        <thead hidden>
             <tr>
                 <th class="col-prop">Recommended</th>
                 <th class="col-prop">Fixable</th>

--- a/tools/cds-lint/components/RulesRefTable.vue
+++ b/tools/cds-lint/components/RulesRefTable.vue
@@ -23,7 +23,7 @@
             <li>✅ &nbsp; <b>Recommeded</b>: If the plugin's <i>recommended</i> configuration enables the rule</li>
             <li>🔧 &nbsp; <b>Fixable</b>: If problems reported by the rule are automatically fixable (<code>--fix</code>)</li>
             <li>💡 &nbsp; <b>Has Suggestions</b>: If problems reported by the rule are manually fixable</li>
-            <li v-if="category !== 'Environment'">👀 &nbsp; <b>Visible by default</b>: If the rule is shown in the editor by default</li>
+            <li v-if="category !== 'Environment'">👀 &nbsp; <b>Editor default</b>: If the rule is shown in the editor by default</li>
         </ul>
     </div>
     <table class="lint-ref-table">

--- a/tools/cds-lint/components/RulesRefTable.vue
+++ b/tools/cds-lint/components/RulesRefTable.vue
@@ -23,7 +23,7 @@
             <li>✅ &nbsp; <b>Recommeded</b>: If the plugin's <i>recommended</i> configuration enables the rule</li>
             <li>🔧 &nbsp; <b>Fixable</b>: If problems reported by the rule are automatically fixable (<code>--fix</code>)</li>
             <li>💡 &nbsp; <b>Has Suggestions</b>: If problems reported by the rule are manually fixable</li>
-            <li v-if="category !== 'Environment'">👀 &nbsp; <b>In Editor</b>: If the rule is shown in the VS Code editor and re-run on file changes</li>
+            <li v-if="category !== 'Environment'">👀 &nbsp; <b>Visible by default</b>: If the rule is shown in the editor by default</li>
         </ul>
     </div>
     <table class="lint-ref-table">

--- a/tools/cds-lint/examples/valid-csv-header/incorrect/db/data/sap.capire.bookshop-Books.csv
+++ b/tools/cds-lint/examples/valid-csv-header/incorrect/db/data/sap.capire.bookshop-Books.csv
@@ -1,3 +1,4 @@
-ID;tile;author_ID
+# Invalid column 'tile'. Did you mean 'title'?
+ID;tile;author_ID // [!code warning]
 201;Wuthering Heights;101
 207;Jane Eyre;107

--- a/tools/cds-lint/examples/valid-csv-header/incorrect/db/data/sap.capire.bookshop-Books.csv
+++ b/tools/cds-lint/examples/valid-csv-header/incorrect/db/data/sap.capire.bookshop-Books.csv
@@ -1,4 +1,3 @@
-# Invalid column 'tile'. Did you mean 'title'?
 ID;tile;author_ID // [!code warning]
 201;Wuthering Heights;101
 207;Jane Eyre;107

--- a/tools/cds-lint/index.md
+++ b/tools/cds-lint/index.md
@@ -48,7 +48,7 @@ By nature of its design, the plugin can also be run with the [ESLint CLI](#usage
 
 ### Setup {#cds-add-lint}
 
-The following command automatically installs ESLint, the CDS ESLint plugin, and adds the ESLint configuration as well as VS Code settings to your project to also be able to lint CDS alongside or Javascript or any other ESLint plugins you may have:
+The following command automatically installs ESLint, the CDS ESLint plugin, and adds the ESLint configuration. VS Code settings are added to your project as well, to also be able to lint CDS alongside Javascript or any other ESLint plugins you may have:
 
 ```sh
 cds add lint

--- a/tools/cds-lint/index.md
+++ b/tools/cds-lint/index.md
@@ -46,16 +46,33 @@ To catch issues in CDS models and the CDS environment early, CAP provides an [ES
 By nature of its design, the plugin can also be run with the [ESLint CLI](#usage-eslint-cli). However, we recommended using the [CDS Lint CLI](#usage-lint-cli) instead as it comes with all preconfigured settings.
 
 
+### Setup {#cds-add-lint}
 
-### CDS Lint Configuration {#cds-lint-config}
+The following command automatically installs ESLint, the CDS ESLint plugin, and adds the ESLint configuration as well as VS Code setting to your project to also be able to lint CDS alongside or Javascript or any other eslint plugins you may have:
 
-All CDS projects initiated with `cds init` come with CDS Lint preconfigured. **No setup is needed**.
+```sh
+cds add lint
+```
 
-For all other projects, you would like to have ESLint running within your VS Code editor. Run the dedicated [`cds add` commmand](#cds-add-lint) command to configure them.
+<pre class="log">
 
-> [!TIP]
-> To add lint checking to your VS Code Editor, follow the setup in [CDS Lint in VSCode](#cds-lint-vscode).
+Adding feature 'lint'...
 
+Successfully added features to your project.
+
+
+<span>Almost done - <text style="color: orange">you are missing 2 npm dependencies</text>:</span>
+
+(1) ESLint v>=7.0.0
+(2) ESLint plugin for CDS
+
+
+<text style="color: orange">Install dependencies now</text>? [y/n] y
+
+Successfully added features to your project.
+</pre>
+
+Given that either a _package.json_, _pom.xml_, or _.cdsrc.json_ file is found, a prompt appears on whether to install the ESLint dependencies. Once confirmed, this will install ESLint, the CDS plugin, as well as add the corresponding configuration for the CDS recommended rules into your project.
 
 
 ### CDS Lint CLI {#usage-lint-cli}
@@ -140,8 +157,6 @@ mocha .eslint/tests/no-entity-moo
 
 -->
 
-
-
 ### ESLint CLI (optional) {#usage-eslint-cli}
 
 To have more control over the linting process, you can also access the CDS ESLint plugin natively via the [ESLint CLI](https://eslint.org/docs/user-guide/command-line-interface). To determine the proper command line options, it can help to refer to output of the equivalent call using the [CDS Lint CLI](#usage-lint-cli) with `DEBUG="lint"`, which shows all of the options and flags applied:
@@ -156,39 +171,10 @@ Linting:
 </pre>
 
 
-### CDS configuration helper (optional) {#cds-add-lint}
-
-The following command automatically adds settings for the ESLint VS Code extension to the project's VS Code settings, installs the CDS ESLint plugin, and adds it to the ESLint configuration of your project:
-
-```sh
-cds add lint
-```
-
-<pre class="log">
-
-Adding feature 'lint'...
-
-Successfully added features to your project.
-
-
-<span>Almost done - <text style="color: orange">you are missing 2 npm dependencies</text>:</span>
-
-(1) ESLint v>=7.0.0
-(2) ESLint plugin for CDS
-
-
-<text style="color: orange">Install dependencies now</text>? [y/n] y
-
-Successfully added features to your project.
-</pre>
-
-Given that either a _package.json_, _pom.xml_, or _.cdsrc.json_ file is found, a prompt appears on whether to install the ESLint dependencies. Once confirmed, this will install ESLint, the CDS plugin, as well as add the corresponding configuration for the CDS recommended rules into your project.
-
-
 ### CDS Lint in VS Code (optional)  {#cds-lint-vscode}
 
 To turn on Lint checking your VS Code Editor, follow the steps below:
 
 1. Download the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for _Visual Studio Code_. CDS Lint seamlessly integrates with it. For _SAP Business Application Studio_ this comes preinstalled.
 
-2. Run the dedicated [`cds add` commmand](#cds-add-lint).
+2. Make sure you have ESLint and our CDS pluginf for ESLint installed via [`cds add` commmand](#cds-add-lint).

--- a/tools/cds-lint/index.md
+++ b/tools/cds-lint/index.md
@@ -48,7 +48,7 @@ By nature of its design, the plugin can also be run with the [ESLint CLI](#usage
 
 ### Setup {#cds-add-lint}
 
-The following command automatically installs ESLint, the CDS ESLint plugin, and adds the ESLint configuration as well as VS Code setting to your project to also be able to lint CDS alongside or Javascript or any other eslint plugins you may have:
+The following command automatically installs ESLint, the CDS ESLint plugin, and adds the ESLint configuration as well as VS Code settings to your project to also be able to lint CDS alongside or Javascript or any other ESLint plugins you may have:
 
 ```sh
 cds add lint

--- a/tools/cds-lint/index.md
+++ b/tools/cds-lint/index.md
@@ -72,7 +72,7 @@ Successfully added features to your project.
 Successfully added features to your project.
 </pre>
 
-Given that either a _package.json_, _pom.xml_, or _.cdsrc.json_ file is found, a prompt appears on whether to install the ESLint dependencies. Once confirmed, this will install ESLint, the CDS plugin, as well as add the corresponding configuration for the CDS recommended rules into your project.
+If a _package.json_, _pom.xml_, or _.cdsrc.json_ file is found, you have the choice to install the ESLint dependencies directly. Once confirmed, this will install ESLint and the CDS plugin, as well as add the corresponding configuration for the recommended rules into your project.
 
 
 ### CDS Lint CLI {#usage-lint-cli}

--- a/tools/cds-lint/index.md
+++ b/tools/cds-lint/index.md
@@ -88,14 +88,15 @@ It follows standard ESLint behaviour. If there are no lint errors, there is no o
 
 ### CDS Lint in VS Code {#cds-lint-vscode}
 
+::: tip
+Make sure you have ESLint and our ESLint plugin installed via [`cds add lint`](#cds-add-lint).
+:::
+
 To turn on Lint checking your VS Code Editor simply download the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for _Visual Studio Code_.
 CDS Lint seamlessly integrates with it. For _SAP Business Application Studio_ this comes preinstalled.
 
-> [!IMPORTANT]
-> Make sure you have ESLint and our CDS plugin for ESLint installed via [`cds add` commmand](#cds-add-lint).
-
 Now you can see lint reports also in your Editor. You should be able to see any rules [marked by **Editor default** here](./rules). Any other (project-based) rules are not turned on by
-default but can be turned on via the `show` rule option. For example, if we want to show the [`valid-csv-header`](./meta/valid-csv-header) rule reports in the Editor, we would add the following to our ESLint 
+default but can be turned on via the `show` rule option. For example, if we want to show the [`valid-csv-header`](./meta/valid-csv-header#❌-incorrect-example) rule reports in the Editor, we would add the following to our ESLint 
 `rules` configuration:
 
 ```json

--- a/tools/cds-lint/index.md
+++ b/tools/cds-lint/index.md
@@ -86,6 +86,26 @@ cds lint
 It follows standard ESLint behaviour. If there are no lint errors, there is no output. If there are, a standard ESLint error report will be printed.
 
 
+### CDS Lint in VS Code {#cds-lint-vscode}
+
+To turn on Lint checking your VS Code Editor simply download the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for _Visual Studio Code_.
+CDS Lint seamlessly integrates with it. For _SAP Business Application Studio_ this comes preinstalled.
+
+> [!IMPORTANT]
+> Make sure you have ESLint and our CDS plugin for ESLint installed via [`cds add` commmand](#cds-add-lint).
+
+Now you can see lint reports also in your Editor. You should be able to see any rules [marked by **Editor default** here](./rules). Any other (project-based) rules are not turned on by
+default but can be turned on via the `show` rule option. For example, if we want to show the [`valid-csv-header`](./meta/valid-csv-header) rule reports in the Editor, we would add the following to our ESLint 
+`rules` configuration:
+
+```json
+{
+  "rules": {
+    "@sap/cds/valid-csv-header": ["warn", "show"]
+  }
+}
+```
+
 
 ### CDS Lint Rules
 
@@ -169,12 +189,3 @@ DEBUG=lint cds lint
 Linting:
 <span>[lint] - eslint --ext ".cds,.csn,.csv" ...</span>
 </pre>
-
-
-### CDS Lint in VS Code (optional)  {#cds-lint-vscode}
-
-To turn on Lint checking your VS Code Editor, follow the steps below:
-
-1. Download the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for _Visual Studio Code_. CDS Lint seamlessly integrates with it. For _SAP Business Application Studio_ this comes preinstalled.
-
-2. Make sure you have ESLint and our CDS pluginf for ESLint installed via [`cds add` commmand](#cds-add-lint).

--- a/tools/cds-lint/index.md
+++ b/tools/cds-lint/index.md
@@ -95,7 +95,7 @@ Make sure you have ESLint and our ESLint plugin installed via [`cds add lint`](#
 To turn on Lint checking in your VS Code Editor simply download the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for _Visual Studio Code_.
 CDS Lint seamlessly integrates with it. For _SAP Business Application Studio_ this comes preinstalled.
 
-Now you can see lint reports also in your editor. You should be able to see any rules [marked by **Editor default** here](./rules). Any other (project-based) rules are not turned on by
+Now you can see lint reports also in your editor. You can see all rules [marked as **Editor default** here](./rules). Any other (project-based) rules are not turned on by
 default but can be turned on via the `show` rule option. For example, if we want to show the [`valid-csv-header`](./meta/valid-csv-header#❌-incorrect-example) rule reports in the Editor, we would add the following to our ESLint 
 `rules` configuration:
 

--- a/tools/cds-lint/index.md
+++ b/tools/cds-lint/index.md
@@ -95,7 +95,7 @@ Make sure you have ESLint and our ESLint plugin installed via [`cds add lint`](#
 To turn on Lint checking in your VS Code Editor simply download the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for _Visual Studio Code_.
 CDS Lint seamlessly integrates with it. For _SAP Business Application Studio_ this comes preinstalled.
 
-Now you can see lint reports also in your Editor. You should be able to see any rules [marked by **Editor default** here](./rules). Any other (project-based) rules are not turned on by
+Now you can see lint reports also in your editor. You should be able to see any rules [marked by **Editor default** here](./rules). Any other (project-based) rules are not turned on by
 default but can be turned on via the `show` rule option. For example, if we want to show the [`valid-csv-header`](./meta/valid-csv-header#❌-incorrect-example) rule reports in the Editor, we would add the following to our ESLint 
 `rules` configuration:
 

--- a/tools/cds-lint/index.md
+++ b/tools/cds-lint/index.md
@@ -92,7 +92,7 @@ It follows standard ESLint behaviour. If there are no lint errors, there is no o
 Make sure you have ESLint and our ESLint plugin installed via [`cds add lint`](#cds-add-lint).
 :::
 
-To turn on Lint checking your VS Code Editor simply download the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for _Visual Studio Code_.
+To turn on Lint checking in your VS Code Editor simply download the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for _Visual Studio Code_.
 CDS Lint seamlessly integrates with it. For _SAP Business Application Studio_ this comes preinstalled.
 
 Now you can see lint reports also in your Editor. You should be able to see any rules [marked by **Editor default** here](./rules). Any other (project-based) rules are not turned on by


### PR DESCRIPTION
- Make `cds add lint` a *mandatory* setup step for any CDS project to be able to use `cds lint`
- Hide header in *Rules reference* table for better legibility of rule descriptions
- Rename **In Editor** to **Editor default** rules  in *Rules reference* table legend