### PR TITLE
Update lint example for 'valid-csv-header'

### DIFF
--- a/tools/cds-lint/examples/valid-csv-header/incorrect/db/data/sap.capire.bookshop-Books.csv
+++ b/tools/cds-lint/examples/valid-csv-header/incorrect/db/data/sap.capire.bookshop-Books.csv
@@ -1,3 +1,3 @@
-ID;tile;author_ID // [!code warning]
+ID;tile;author_ID
 201;Wuthering Heights;101
 207;Jane Eyre;107


### PR DESCRIPTION
- No comments in `*.csv` allowed