### PR TITLE
Go back to former notebook hint text

### DIFF
--- a/.vitepress/theme/components/NotebookHint.vue
+++ b/.vitepress/theme/components/NotebookHint.vue
@@ -2,15 +2,13 @@
     <span class="notebook" v-if="supportsNotebook">
       <div class="tip-notebook custom-block">
         <p class="custom-block-title">
-          This guide is automatically tested and verified.
+          This guide is available as CAP Notebook.
           <text class="notebook-test-msg">
-            <a class="link-notebook-runner" href="https://github.com/marketplace/actions/notebook-runner">
-              <text class="sap-icons">&#xe304;</text>
-            </a>
+            <text class="sap-icons" title="This guide is automatically tested and verified">&#xe304;</text>
           </text>
         </p>
         <p>
-          <a class="link nb-download" @click="linkNotebook($event)">Download the CAP Notebook</a> and run it in your local VS Code editor.
+          <a class="link nb-download" @click="linkNotebook($event)">Download the notebook</a> to run it locally in your VS Code editor.
         </p>
       </div>
     </span>

--- a/.vitepress/theme/components/NotebookHint.vue
+++ b/.vitepress/theme/components/NotebookHint.vue
@@ -2,7 +2,7 @@
     <span class="notebook" v-if="supportsNotebook">
       <div class="tip-notebook custom-block">
         <p class="custom-block-title">
-          This guide is available as CAP Notebook.
+          This guide is available as a CAP Notebook.
           <text class="notebook-test-msg">
             <text class="sap-icons" title="This guide is automatically tested and verified">&#xe304;</text>
           </text>


### PR DESCRIPTION
The former text was intentional:
- We want to stress the fact the the guide is available as notebook, not that is is tested (users should just assume this to be true).
- The link in the Verified icon could be confused with the download link.  Instead, that information is shown in the icon tooltip.

This reverts commit b358841f37e35cf4bf644eef6559a5c6ee122cc2.