### PR TITLE
fix missing bracket in anon ping server.js sample

### DIFF
--- a/node.js/best-practices.md
+++ b/node.js/best-practices.md
@@ -304,7 +304,7 @@ You can override the default implementation and register a custom express middle
 ```js
 cds.on('bootstrap', app => app.get('/health', (_, res) => {
   res.status(200).send(`I'm fine, thanks.`)
-})
+}))
 ```
 
 More sophisticated health checks, like database availability for example, should use authentication to prevent Denial of Service attacks!


### PR DESCRIPTION
The sample code was just missing a final closing bracket. I only noticed because I used the code to try out the custom express middleware sample :-) 