### PR TITLE
Common badges for alpha, beta, and required versions

### DIFF
--- a/.vitepress/theme/components/Alpha.vue
+++ b/.vitepress/theme/components/Alpha.vue
@@ -2,6 +2,6 @@
   <Badge
     type="warning"
     text="alpha"
-    title="This is an alpha feature. Alpha features are experimental. They may never be generally available. If released subsequently, the APIs and behavior might change."
+    title="Alpha features are experimental. They may never be generally available. If released subsequently, the APIs and behavior might change."
   />
 </template>

--- a/.vitepress/theme/components/Alpha.vue
+++ b/.vitepress/theme/components/Alpha.vue
@@ -1,0 +1,7 @@
+<template>
+  <Badge
+    type="warning"
+    text="alpha"
+    title="This is an alpha feature. Alpha features are experimental. They may never be generally available. If released subsequently, the APIs and behavior might change."
+  />
+</template>

--- a/.vitepress/theme/components/Beta.vue
+++ b/.vitepress/theme/components/Beta.vue
@@ -1,0 +1,7 @@
+<template>
+  <Badge
+    type="warning"
+    text="beta"
+    title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases."
+  />
+</template>

--- a/.vitepress/theme/components/Beta.vue
+++ b/.vitepress/theme/components/Beta.vue
@@ -2,6 +2,6 @@
   <Badge
     type="warning"
     text="beta"
-    title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases."
+    title="Beta features are planned to be generally available in subsequent releases, however, APIs and their behavior are not final and may change in the general release."
   />
 </template>

--- a/.vitepress/theme/components/Since.vue
+++ b/.vitepress/theme/components/Since.vue
@@ -1,5 +1,5 @@
 <template>
-  <Badge type="info" :text="`since ${of} ${version}`" :title="`This feature is only available with ${of} version ${version} or higher`" />
+  <Badge type="info" :text="`requires ${of} ${version}`" :title="`This feature is only available as of ${of} version ${version} or higher`" />
 </template>
 
 <script setup lang="ts">

--- a/.vitepress/theme/components/Since.vue
+++ b/.vitepress/theme/components/Since.vue
@@ -1,5 +1,5 @@
 <template>
-  <Badge type="info" :text="`since ${of} ${version}`" />
+  <Badge type="info" :text="`since ${of} ${version}`" :title="`This feature is only available with ${of} version ${version} or higher`" />
 </template>
 
 <script setup lang="ts">

--- a/.vitepress/theme/components/Since.vue
+++ b/.vitepress/theme/components/Since.vue
@@ -1,0 +1,7 @@
+<template>
+  <Badge type="info" :text="`since ${of} ${version}`" />
+</template>
+
+<script setup lang="ts">
+  defineProps(['version', 'of'])
+</script>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import { EnhanceAppContext } from 'vitepress';
 import Layout from './Layout.vue';
 import IndexList from './components/IndexList.vue';
 import ImplVariantsHint from './components/implvariants/ImpVariantsHint.vue';
+import Since from './components/Since.vue';
 
 import './custom.scss'
 
@@ -15,5 +16,6 @@ export default {
   enhanceApp(ctx: EnhanceAppContext) {
     ctx.app.component('IndexList', IndexList)
     ctx.app.component('ImplVariantsHint', ImplVariantsHint)
+    ctx.app.component('Since', Since)
   }
 }

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -3,6 +3,8 @@ import { EnhanceAppContext } from 'vitepress';
 import Layout from './Layout.vue';
 import IndexList from './components/IndexList.vue';
 import ImplVariantsHint from './components/implvariants/ImpVariantsHint.vue';
+import Alpha from './components/Alpha.vue';
+import Beta from './components/Beta.vue';
 import Since from './components/Since.vue';
 
 import './custom.scss'
@@ -16,6 +18,8 @@ export default {
   enhanceApp(ctx: EnhanceAppContext) {
     ctx.app.component('IndexList', IndexList)
     ctx.app.component('ImplVariantsHint', ImplVariantsHint)
+    ctx.app.component('Alpha', Alpha)
+    ctx.app.component('Beta', Beta)
     ctx.app.component('Since', Since)
   }
 }

--- a/about/index.md
+++ b/about/index.md
@@ -579,6 +579,11 @@ Not an official product name, though.
   : a plain (JavaScript) object-based representation to capture expressions.
   (also contained in [CQN](../cds/cqn))
 
-- <Beta /> - Beta features are planned to be generally available in subsequent releases, however, APIs and their behavior are not final and may change in the general release.
 
-- <Alpha /> - Alpha features are experimental. They may never be generally available. If released subsequently, the APIs and behavior might change.
+#### Badges
+
+- <Alpha /> — Alpha features are experimental. They may never be generally available. If released subsequently, the APIs and behavior might change.
+
+- <Beta /> — Beta features are planned to be generally available in subsequent releases, however, APIs and their behavior are not final and may change in the general release.
+
+- <Since version="1.2.3" of="@sap/..." /> — The marked feature is only available with the given version or higher.

--- a/about/index.md
+++ b/about/index.md
@@ -579,6 +579,6 @@ Not an official product name, though.
   : a plain (JavaScript) object-based representation to capture expressions.
   (also contained in [CQN](../cds/cqn))
 
-- <Badge type="warning" text="beta" /> - Beta features are planned to be generally available in subsequent releases, however, APIs and their behavior are not final and may change in the general release.
+- <Beta /> - Beta features are planned to be generally available in subsequent releases, however, APIs and their behavior are not final and may change in the general release.
 
-- <Badge type="warning" text="alpha" /> - Alpha features are experimental. They may never be generally available. If released subsequently, the APIs and behavior might change.
+- <Alpha /> - Alpha features are experimental. They may never be generally available. If released subsequently, the APIs and behavior might change.

--- a/advanced/hybrid-testing.md
+++ b/advanced/hybrid-testing.md
@@ -21,7 +21,7 @@ CAP enables you to run and test your CAP application using a local SQLite databa
 cds bind db --to bookshop-db
 ```
 
-Binds the service `db` of your local CAP application to the service instance `bookshop-db`, using your currently targeted Cloud Foundry space. Here, `bookshop-db` is a _managed_ service of type `hana` with plan `hdi-shared`. 
+Binds the service `db` of your local CAP application to the service instance `bookshop-db`, using your currently targeted Cloud Foundry space. Here, `bookshop-db` is a _managed_ service of type `hana` with plan `hdi-shared`.
 
 ::: tip `cds bind` automatically creates a service key for you
 If no service key for your service `<srv>` is specified, a `<srv>-key` is automatically created.
@@ -93,7 +93,7 @@ Output:
 [bind] - TIP: Run with cloud bindings: cds watch --profile hybrid
 ```
 
-#### Shared Service Instances on Cloud Foundry <Badge type="note" text="for @sap/cds-dk^7.9" /> { #binding-shared-service-instances} 
+#### Shared Service Instances on Cloud Foundry <Since version="7.9.0" of="@sap/cds-dk" /> { #binding-shared-service-instances}
 
 On SAP BTP Cloud Foundry, service instances can be shared across orgs and spaces. If you have access to a shared service instance, you can also bind to a shared service instance just like any other service instance.
 

--- a/advanced/odata.md
+++ b/advanced/odata.md
@@ -67,7 +67,7 @@ System query options can also be applied to an [expanded navigation property](ht
 [ETags](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UseofETagsforAvoidingUpdateConflicts) | For avoiding update conflicts | <X/> | <X/> |
 | [Delete an Entity](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_DeleteanEntity) | `DELETE` request on Entity |  <X/> | <X/> |
 | [Delta Payloads](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_DeltaPayloads) | For nested entity collections in [deep updates](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UpdateRelatedEntitiesWhenUpdatinganE) | <D/> | <X/> |
-| [Patch Collection](#odata-patch-collection) | Update Entity collection with [delta](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_DeltaPayloads) | <Na/> | <X/><sup><Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " /></sup> |
+| [Patch Collection](#odata-patch-collection) | Update Entity collection with [delta](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_DeltaPayloads) | <Na/> | <X/><sup><Beta /></sup> |
 
 
 ## PATCH Entity Collection with Mass Data (Java) { #odata-patch-collection }
@@ -185,7 +185,7 @@ entity Books {
 ```
 
 ::: warning
-This annotation affects the client side facing API only. There's no automatic data modification of any kind behind the scenes, like rounding, truncation, conversion, and so on. It's your responsibility to perform all required modifications on the data stream such that the values match their type in the API. 
+This annotation affects the client side facing API only. There's no automatic data modification of any kind behind the scenes, like rounding, truncation, conversion, and so on. It's your responsibility to perform all required modifications on the data stream such that the values match their type in the API.
 If you are not doing the required conversions, you can "cast" any scalar CDS type into any incompatible EDM type:
 
 ```cds
@@ -621,7 +621,7 @@ is translated to:
 ```
 
 One of the main use cases for such dynamic expressions is SAP Fiori,
-but note that Fiori supports dynamic expressions only for 
+but note that Fiori supports dynamic expressions only for
 [specific annotations](https://ui5.sap.com/#/topic/0e7b890677c240b8ba65f8e8d417c048).
 
 

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -352,7 +352,7 @@ table row. Therefore, such an expression must not contain subqueries, aggregate 
 
 No restrictons apply for reading a calculated element on-write.
 
-#### Association-like calculated elements <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " /> {#association-like-calculated-elements}
+#### Association-like calculated elements <Beta /> {#association-like-calculated-elements}
 
 A calculated element can also define a refined association, like in this example:
 
@@ -688,7 +688,7 @@ Essentially, Compositions are the same as _[associations](#associations)_, just 
 
 ::: warning Limitations of Compositions of one
 Using of compositions of one for entities is discouraged. There is often no added value of using them as the information can be placed in the root entity. Compositions of one have limitations as follow:
-- Very limited Draft support. Fiori elements does not support compositions of one unless you take care of their creation in a custom handler. 
+- Very limited Draft support. Fiori elements does not support compositions of one unless you take care of their creation in a custom handler.
 - No extensive support for modifications over paths if compostions of one are involved. You must fill in foreign keys manually in a custom handler.
 :::
 
@@ -796,7 +796,7 @@ entity P_Employees as projection on Employees {
 The effective signature of the projection contains an association `addresses` with the same
 properties as association `addresses` of entity `Employees`.
 
-#### Publish Associations with Filter <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " /> {#publish-associations-with-filter}
+#### Publish Associations with Filter <Beta /> {#publish-associations-with-filter}
 
 ::: warning
 This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases.
@@ -1003,7 +1003,7 @@ For example, for SAP Fiori models, it's the _4odata_ and _2edm(x)_ processors.
 :::
 
 
-### Expressions as Annotation Values <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " /> {#expressions-as-annotation-values}
+### Expressions as Annotation Values <Beta /> {#expressions-as-annotation-values}
 
 ::: warning
 Expressions in annotation values are released as beta feature.

--- a/java/cds-data.md
+++ b/java/cds-data.md
@@ -278,7 +278,7 @@ Avoid cyclic relationships between CdsData objects when using toJson.
 :::
 
 
-## Vector Embeddings <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " /> { #vector-embeddings }
+## Vector Embeddings <Beta /> { #vector-embeddings }
 
 In CDS [vector embeddings](../guides/databases-hana#vector-embeddings) are stored in elements of type `cds.Vector`:
 

--- a/java/change-tracking.md
+++ b/java/change-tracking.md
@@ -4,16 +4,16 @@ synopsis: >
 status: released
 ---
 
-# Change Tracking <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " />
+# Change Tracking <Beta />
 <style scoped>
   h1:before {
     content: "Java"; display: block; font-size: 60%; margin: 0 0 .2em;
   }
 </style>
 
-The feature tracks the changes of all modifying operations executed via CQN statements, which are indirectly triggered 
-by the protocol adapters or directly by a custom code. 
-Changes made through the native SQL, JDBC, or other means that bypass the CAP Java runtime or that are forwarded 
+The feature tracks the changes of all modifying operations executed via CQN statements, which are indirectly triggered
+by the protocol adapters or directly by a custom code.
+Changes made through the native SQL, JDBC, or other means that bypass the CAP Java runtime or that are forwarded
 to the remote services aren't tracked.
 
 ## Enabling Change Tracking
@@ -28,14 +28,14 @@ To use the change tracking feature, you need to add a dependency to [cds-feature
 </dependency>
 ```
 
-Your POM must also include the goal to resolve the CDS model delivered from the feature. 
+Your POM must also include the goal to resolve the CDS model delivered from the feature.
 See [Reference the New CDS Model in an Existing CAP Java Project](/java/building-plugins#reference-the-new-cds-model-in-an-existing-cap-java-project).
 
 For the UI part, you also need to enable the [On-the-fly Localization of EDMX](/releases/archive/2023/dec23#on-the-fly-localization-of-edmx).
 
 ### Annotating Entities
 
-To capture changes for an entity, you need to extend it with a technical aspect and annotate it 
+To capture changes for an entity, you need to extend it with a technical aspect and annotate it
 with the annotation `@changelog` that declares the elements whose changes are to be logged.
 
 Given the following entity that represents a book on the domain level:
@@ -68,15 +68,15 @@ Include the change log model that is provided by this feature:
 using {sap.changelog as changelog} from 'com.sap.cds/change-tracking';
 ```
 
-Extend **the domain entity** with the aspect `changelog.changeTracked` like this: 
+Extend **the domain entity** with the aspect `changelog.changeTracked` like this:
 
 ```cds
 extend model.Books with changelog.changeTracked;
 ```
 
-This aspect adds the association `changes` that lets you consume the change log both programmatically 
-via CQN statements and in the UI. This implies that every projection 
-of the entity `Books` has this association and the changes will be visible in all of them. 
+This aspect adds the association `changes` that lets you consume the change log both programmatically
+via CQN statements and in the UI. This implies that every projection
+of the entity `Books` has this association and the changes will be visible in all of them.
 
 Your extended service definition should look like this:
 
@@ -103,7 +103,7 @@ annotate Bookshop.Books {
 ```
 
 :::warning Personal data is ignored
-Elements with [personal data](../guides/data-privacy/annotations#personaldata), that is, elements that are annotated 
+Elements with [personal data](../guides/data-privacy/annotations#personaldata), that is, elements that are annotated
 with @PersonalData and hence subject to audit logging, are ignored by the change tracking.
 :::
 
@@ -117,7 +117,7 @@ or mass changes where change tracking can be a very expensive operation, and you
 
 Change tracking also works with the entities that have compositions and tracks the changes made to the items of the compositions.
 
-For example, if you have an entity that represents the order with a composition that represents the items of the order, 
+For example, if you have an entity that represents the order with a composition that represents the items of the order,
 you can annotate the elements of both and track the changes made through the order and the items in a deep update.
 
 ```cds
@@ -130,14 +130,14 @@ entity OrderItems {
 entity Orders {
   key ID: UUID;
   customerName: String @changelog;
-  [...] 
+  [...]
   items: Composition of many OrderItems;
 }
 ```
 
 ### Identifiers for Changes
 
-You can store some elements of the entity together with the changes in the change log to produce a user-friendly identifier. 
+You can store some elements of the entity together with the changes in the change log to produce a user-friendly identifier.
 You define this identifier by annotating the entity with the `@changelog` annotation and including the elements that you want
 to store together with the changed value:
 
@@ -147,21 +147,21 @@ annotate Bookshop.Book with @changelog: [
 ];
 ```
 
-This identifier can contain the elements of the entity or values of to-one associations that are reachable via path. 
-For example, for a book you can store an author name if you have an association from the book to the author. 
+This identifier can contain the elements of the entity or values of to-one associations that are reachable via path.
+For example, for a book you can store an author name if you have an association from the book to the author.
 
-The best candidates for identifier elements are the elements that are insert-only or that don't change often. 
+The best candidates for identifier elements are the elements that are insert-only or that don't change often.
 
 :::warning Stored as-is
-The values of the identifier are stored together with the change log as-is. They are not translated and some data types might 
-not be formatted per user locale or some requirements, for example, different units of measurement or currencies. 
+The values of the identifier are stored together with the change log as-is. They are not translated and some data types might
+not be formatted per user locale or some requirements, for example, different units of measurement or currencies.
 You should consider this when you decide what to include in the identifier.
 :::
 
 ### Displaying Changes
 
-The changes of the entity are exposed as an association `changes` that you can use to display the change log in the UI. 
-By default, the entity `Changes` is auto-exposed, but it won't be writable via OData requests.   
+The changes of the entity are exposed as an association `changes` that you can use to display the change log in the UI.
+By default, the entity `Changes` is auto-exposed, but it won't be writable via OData requests.
 
 If you want to display the change log together with the overview of your entity, you need to add the facet
 to the object page that displays the changes:
@@ -182,10 +182,10 @@ annotate Bookshop.Books with @(
 ```
 
 If you want to have a common UI for all changes, you need to expose the change log as a projection and define
-your own presentation for it as the changes are exposed only as part of the change-tracked entity. This projection 
+your own presentation for it as the changes are exposed only as part of the change-tracked entity. This projection
 must be read-only and shouldn't be writable via OData requests.
 
-The change log is extended with the texts for your entities from the `@title` annotation and the element. Otherwise, the change log contains only the technical names of the entities and the elements. 
+The change log is extended with the texts for your entities from the `@title` annotation and the element. Otherwise, the change log contains only the technical names of the entities and the elements.
 Titles are translated, if they're annotated as translatable. See [Externalizing Texts Bundles](../guides/i18n#localization-i18n) for more information.
 
 ## How Changes are Stored
@@ -205,20 +205,20 @@ Each entry in the `Changes` entity contains the following information:
 
 ## Detection of Changes
 
-The change tracking intercepts the modifying CQL statements (`Insert`, `Upsert`, `Update`, and `Delete`) and 
+The change tracking intercepts the modifying CQL statements (`Insert`, `Upsert`, `Update`, and `Delete`) and
 requires additional READ events to retrieve the old and the new image of the entity.
 
-These two images are compared and differences are stored in the change log. The nature of the change is determined by comparing the old and new 
-values of the entity: data that weren't present in the old values are considered as added whereas data that aren't present in 
-the new values are considered as deleted. Elements that are present in both old and new values but have different values 
+These two images are compared and differences are stored in the change log. The nature of the change is determined by comparing the old and new
+values of the entity: data that weren't present in the old values are considered as added whereas data that aren't present in
+the new values are considered as deleted. Elements that are present in both old and new values but have different values
 are considered as modified. Each change detected by the change tracking feature is stored in the change log as a separate entry.
 
-In the case of the deeply structured documents, for example, entities with the compositions, the change tracking feature detects 
+In the case of the deeply structured documents, for example, entities with the compositions, the change tracking feature detects
 the changes across the complete document and stores them in the change log with the metadata reflecting the structure of the change.
 
-For example, given the order and item model from above, if you change values for the tracked elements with 
-the deep update, for example,  the customer name in the order and the quantity of the item, the change log contains 
-two entries: one for the order and one for the item. The change log entry for the item will also reflect that 
+For example, given the order and item model from above, if you change values for the tracked elements with
+the deep update, for example,  the customer name in the order and the quantity of the item, the change log contains
+two entries: one for the order and one for the item. The change log entry for the item will also reflect that
 the root of the change is an order.
 
 :::warning Prefer deep updates for change tracked entities
@@ -227,11 +227,11 @@ If you change the values of the `OrderItems` entity directly via an OData reques
 
 ## Things to Consider when Using Change Tracking
 
-- Consider the storage costs of the change log. The change log can grow very fast and can consume a lot of space 
-  in case of frequent changes. You should consider the retention policy of the change log as it won't be deleted when you delete the entities. 
-- Consider the performance impact. Change tracking needs to execute additional reads during updates to retrieve and compare updated values. 
+- Consider the storage costs of the change log. The change log can grow very fast and can consume a lot of space
+  in case of frequent changes. You should consider the retention policy of the change log as it won't be deleted when you delete the entities.
+- Consider the performance impact. Change tracking needs to execute additional reads during updates to retrieve and compare updated values.
   This can slow down the update operations and can be very expensive in the case of updates that affect a lot of entities.
-- Consider the ways your entities are changed. You might want to track the changes only on the service projection level that are used for 
+- Consider the ways your entities are changed. You might want to track the changes only on the service projection level that are used for
   the user interaction and not on the domain level (for instance during data replication).
-- If you want to expose the complete change log to the user, you need to consider the security implications of this. If your entities have complex access rules, 
-  you need to consider how to extend these rules to the change log. 
+- If you want to expose the complete change log to the user, you need to consider the security implications of this. If your entities have complex access rules,
+  you need to consider how to extend these rules to the change log.

--- a/java/messaging.md
+++ b/java/messaging.md
@@ -279,7 +279,7 @@ cds:
 
 <span id="beforeredispubsub" />
 
-#### Configuring Redis PubSub Support <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " />: { #configuring-redis-pubsub-support-beta}
+#### Configuring Redis PubSub Support <Beta />: { #configuring-redis-pubsub-support-beta}
 
 ::: warning
 This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases.

--- a/java/operating-applications/optimizing.md
+++ b/java/operating-applications/optimizing.md
@@ -16,8 +16,8 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
 
 ## Profiling { #profiling}
 
-To minimize overhead at runtime, [monitoring](observability#monitoring) information is gathered rather on a global application level and hence might not be sufficient to troubleshoot specific issues. 
-In such a situation, the use of more focused profiling tools can be an option. 
+To minimize overhead at runtime, [monitoring](observability#monitoring) information is gathered rather on a global application level and hence might not be sufficient to troubleshoot specific issues.
+In such a situation, the use of more focused profiling tools can be an option.
 Typically, such tools are capable of focusing on a specific aspect of an application (for instance CPU or Memory management), but they come with an additional overhead and should only be enabled when needed. Hence, they need to meet the following requirements:
 
 * Switchable at runtime
@@ -80,7 +80,7 @@ Afterwards, connect to `localhost:<local-port>` in the JMX client. Common JMX cl
 
 
 
-## GraalVM Native Image Support <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " /> { #graalvm-native-image-support-beta }
+## GraalVM Native Image Support <Beta /> { #graalvm-native-image-support-beta }
 
 Since Spring Boot 3 it's possible to compile Spring Boot applications to stand-alone native executables leveraging GraalVM Native Images.
 Native Image applications have faster startup times and require less memory. CAP Java provides compatibility with the Native Image technology.

--- a/java/working-with-cql/query-execution.md
+++ b/java/working-with-cql/query-execution.md
@@ -313,7 +313,7 @@ A convenient option to determine a new ETag value upon update is the [@cds.on.up
 
 We do not recommend providing a new ETag value by custom code in a `@Before`-update handler. If you do set a value explicitly in custom code and an ETag element is annotated with `@cds.on.update`, the runtime does not generate a new value upon update for this element. Instead, the value that comes from your custom code is used.
 
-#### Runtime-Managed Versions <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " />
+#### Runtime-Managed Versions <Beta />
 
 Alternatively, you can store ETag values in _version elements_. For version elements, the values are exclusively managed by the runtime without the option to set them in custom code. Annotate an element with `@cds.java.version` to advise the runtime to manage its value.
 

--- a/node.js/best-practices.md
+++ b/node.js/best-practices.md
@@ -250,9 +250,9 @@ Handling CSRF at the _App Router_ level ensures consistency across instances. Th
 
 ### Cross-Origin Resource Sharing (CORS)
 
-With _Cross-Origin Resource Sharing_ (CORS) the server that hosts the UI can tell the browser about servers it trusts to provide resources. In addition, so-called "preflight" requests tell the browser if the cross-origin server will process a request with a specific method and a specific origin. 
+With _Cross-Origin Resource Sharing_ (CORS) the server that hosts the UI can tell the browser about servers it trusts to provide resources. In addition, so-called "preflight" requests tell the browser if the cross-origin server will process a request with a specific method and a specific origin.
 
-If not running in production, CAP's [built-in server.js](cds-server) allows all origins. 
+If not running in production, CAP's [built-in server.js](cds-server) allows all origins.
 
 #### Custom CORS Implementation
 
@@ -383,7 +383,7 @@ srv.before("UPDATE", "EntityName", (req) => {
 Internally the [timestamp](events#timestamp) is a Javascript `Date` object, that is converted to the right format, when sent to the database. So if in any case a date string is needed, the best solution would be to initialize a Date object, that is then translated to the correct UTC String for the database.
 
 
-## Custom Streaming <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " /> { #custom-streaming-beta }
+## Custom Streaming <Beta /> { #custom-streaming-beta }
 
 When using [Media Data](../guides/providing-services#serving-media-data) the Node.js runtime offers a possibility to
 return a custom stream object as response to `READ` requests like `GET /Books/coverImage`.

--- a/node.js/cds-plugins.md
+++ b/node.js/cds-plugins.md
@@ -82,7 +82,7 @@ await cds.plugins
 
 Currently, the following commands support plugins: `cds-serve`, `cds watch`, `cds run`, `cds env`, `cds deploy`, `cds build`, `cds.test()`.
 
-## Configuration Schema <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " /> { #configuration-schema }
+## Configuration Schema <Beta /> { #configuration-schema }
 
 To help developers conveniently add configuration for a plugin with code completion, plugin developers can declare additions to the `cds` schema in their plugin.
 

--- a/node.js/events.md
+++ b/node.js/events.md
@@ -445,7 +445,7 @@ In production, errors should never disclose any internal information that could 
 Additionally, the OData protocol specifies which properties an error object may have. If a custom property shall reach the client, it must be prefixed with `@` to not be purged.
 
 
-### req. diff() <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " /> {.method}
+### req. diff() <Beta /> {.method}
 [`req.diff`]: #req-diff
 
 Use this asynchronous method to calculate the difference between the data on the database and the passed data (defaults to `req.data`, if not passed). Note that the usage of `req.diff` only makes sense in *before* handlers as they are run before the actual change was persisted on the database.

--- a/node.js/messaging.md
+++ b/node.js/messaging.md
@@ -403,7 +403,7 @@ If you enable the [cors middleware](https://www.npmjs.com/package/cors), [handsh
 
 <div id="kafka-sap" />
 
-### Redis PubSub <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " />
+### Redis PubSub <Beta />
 ::: warning
 This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases.
 :::

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -150,7 +150,7 @@ Available for:
 
 
 
-## Attachments <Badge type="warning" text="beta" title="" />
+## Attachments <Beta />
 
 
 The Attachments plugin provides out-of-the-box asset storage and handling. To use it, extend a domain model by using the predefined `aspect` called Attachments:
@@ -266,7 +266,7 @@ Available for:
 [<img src="../assets/logos/nodejs.svg" title="Link to the plugins repository." style="height:2.5em; display:inline; margin:0 0.2em;" alt="Node.js"/>](https://github.com/cap-js/notifications#readme)
 
 
-## Telemetry <Badge type="warning" text="beta" />
+## Telemetry <Beta />
 
 
 The Telemetry plugin provides observability features such as tracing and metrics, including [automatic OpenTelemetry instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/automatic).

--- a/tools/index.md
+++ b/tools/index.md
@@ -532,7 +532,7 @@ Until a further change, reference calculation is reasonably fast.
 - Changing settings in _CDS_ section will currently perform a complete workspace invalidation i.e. required indexes will lead to recompilations on demand as described above.
 - Changing certain `cds.env` settings, for example folder configurations, will invalidate the workspace as well.
 
-### CDS Source Formatter <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " /> { #cds-formatter}
+### CDS Source Formatter <Beta /> { #cds-formatter}
 
 The CDS code formatter provides a command line interface. Use it as a pre-commit hook or within your CI/CD pipeline, to guarantee a consistent
 formatting.


### PR DESCRIPTION
Replace generic `<Badge .../>` with `<Alpha/>` and `<Beta/>`: 

![image](https://github.com/cap-js/docs/assets/7470719/26ba6603-f648-4246-8725-81740d2df3b1)

![image](https://github.com/cap-js/docs/assets/7470719/2239ef9d-a43f-4f3e-ad3e-e539c8d767c8)

Also have a new `<Since />` badge to specify min. version requirements:

![image](https://github.com/cap-js/docs/assets/7470719/56b905e3-0864-41c7-8224-62f53ac7c62e)
