### PR TITLE
docs(localized): Improve documentation on helper views: mention casts

### DIFF
--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -350,7 +350,7 @@ In addition, there are restrictions that depend on the particular database. Curr
 supported by CAP have a common restriction: The calculation expression may only refer to fields of the same
 table row. Therefore, such an expression must not contain subqueries, aggregate functions, or paths with associations.
 
-No restrictons apply for reading a calculated element on-write.
+No restrictions apply for reading a calculated element on-write.
 
 #### Association-like calculated elements <Badge type="warning" text="beta" title="This is a beta feature. Beta features aren't part of the officially delivered scope that SAP guarantees for future releases. " /> {#association-like-calculated-elements}
 

--- a/guides/localized-data.md
+++ b/guides/localized-data.md
@@ -59,10 +59,6 @@ entity Books.texts {
 ```
 
 [See the definition of `sap.common.Locale`.](../cds/common#locale-type){ .learn-more}
-::: warning Note:
-The above shows the situation with CDS compiler v2 and later. Former versions of the
-compiler generated an entity `Books_texts`.
-:::
 
 Second, the source entity is extended with associations to _Books.texts_:
 

--- a/guides/localized-data.md
+++ b/guides/localized-data.md
@@ -60,7 +60,7 @@ entity Books.texts {
 
 [See the definition of `sap.common.Locale`.](../cds/common#locale-type){ .learn-more}
 ::: warning Note:
-The above shows the situation with CDS compiler v2. Former versions of the
+The above shows the situation with CDS compiler v2 and later. Former versions of the
 compiler generated an entity `Books_texts`.
 :::
 
@@ -122,13 +122,13 @@ The following view definitions preserve the `localized` association in the view,
 
 ```cds
 entity OpenBookView as select from Books {*}
-  excluding {price, currency};
+  excluding { price, currency };
 ```
 
 Include the `localized` association:
 
 ```cds
-entity ClosedBookView as select from Books {ID, title, descr, localized};
+entity ClosedBookView as select from Books { ID, title, descr, localized };
 ```
 
 
@@ -270,24 +270,34 @@ using { Books } from './books';
 service CatalogService {
   entity BooksList as projection on Books { ID, title, price };
   entity BooksDetails as projection on Books;
+  entity BooksShort as projection on Books { 
+    ID, price,
+    substr(title, 0, 10) as title : localized String(10), 
+  };
 }
 ```
 
 ### `localized.` Helper Views
 
-For each exposed entity in a service definition, and all intermediate views, a corresponding `localized.` entity is created. It has the same query clauses and all annotations, except for the `from` clause being redirected to the underlying entity's `localized.` counterpart.
+For each exposed entity in a service definition, and all intermediate views, a corresponding `localized.` entity is created. It has the same query clauses and all annotations, except for the `from` clause being redirected to the underlying entity's `localized.` counterpart.  A helper view is only created if the corresponding entity contains at least one element with a `localized` property, or it exposes an association to an entity that is localized.  You may need to cast an element if that property is not propagated, e.g. for expressions such as in `CatalogService.BooksShort`.
 
 ```cds
 using { localized.Books } from './books_localized';
 
 entity localized.CatalogService.BooksList as
-SELECT from localized.Books { ID, title, price };
+  SELECT from localized.Books { ID, title, price };
 
 entity localized.CatalogService.BooksDetails as
-SELECT from localized.Books;
+  SELECT from localized.Books;
+  
+entity localized.CatalogService.BooksShort as
+    SELECT from localized.Books { ID, price,
+        substr(title, 0, 10) as title : localized String(10),
+    };
 ```
 ::: warning Note:
-In contrast to former versions, with CDS compiler v2 we don't add such entities to CSN anymore but only on generated SQL DDL output. Note that these `localized.` entities also aren't exposed through OData.
+Note that these `localized.` entities are not part of CSN and aren't exposed through OData.
+They are only generated for SQL.
 :::
 
 ### Read Operations


### PR DESCRIPTION
It may be necessary to cast an element to `localized`, e.g. if no other element is localized.  Because properties are not propagated from elements to expressions, casts may be necessary. I've added an example where this is the case.