### PR TITLE
Align `pre.log` styling

### DIFF
--- a/.vitepress/theme/custom.scss
+++ b/.vitepress/theme/custom.scss
@@ -112,20 +112,26 @@ main {
 
     pre.log {
       font-size: var(--vp-code-font-size);
-      line-height: 1.4em;
-      font-style: italic;
-      padding: 20px !important;
+      line-height: var(--vp-code-line-height);
+      padding: 12px 22px !important;
       border-radius: 8px;
       overflow: hidden;
       span {
         &.cmd {
-          color: #FFCB6B;
+          color: #6F42C1;
+          .dark & { color: #B392F0; }
+        }
+        &.args {
+          color: #032F62;
+          .dark & { color: #9ECBFF; }
         }
         &.flags {
-          color: #C3E88D;
+          color: #005CC5;
+          .dark & { color: #79B8FF; }
         }
         &.cwd {
           color: #777;
+          .dark & { color: #999; }
         }
         &.livereload {
           color: #FDEC87
@@ -133,6 +139,7 @@ main {
       }
       em {
         color: #00ab00e0;
+        font-style: normal;
       }
       b {
         color: #ee0000e0;

--- a/tools/index.md
+++ b/tools/index.md
@@ -30,6 +30,7 @@ Use `cds version` to get information about your installed package version:
 
 <pre class="log">
 <span class="cwd">$</span> <span class="cmd">cds</span> <span class="args">version</span>
+
 <em>@capire/samples:</em> 2.0.0
 <em>@sap/cds:</em> 6.7.0
 <em>@sap/cds-compiler:</em> 3.8.2
@@ -41,6 +42,7 @@ Use `cds version` to get information about your installed package version:
 <em>home:</em> .../node_modules/@sap/cds
 
 <span class="cwd">$</span> <span class="cmd">cds</span> <span class="args">version</span> <span class="flags">--markdown</span>
+
 | @capire/samples    | https://github.com/sap-samples/cloud-cap-samples.git |
 | ------------------ | ----------- |
 | Node.js            | v18.13.0    |

--- a/tools/index.md
+++ b/tools/index.md
@@ -29,7 +29,7 @@ npm i -g @sap/cds-dk
 Use `cds version` to get information about your installed package version:
 
 <pre class="log">
-<i>$</i> cds version
+<span class="cwd">$</span> <span class="cmd">cds</span> <span class="args">version</span>
 <em>@capire/samples:</em> 2.0.0
 <em>@sap/cds:</em> 6.7.0
 <em>@sap/cds-compiler:</em> 3.8.2
@@ -40,10 +40,9 @@ Use `cds version` to get information about your installed package version:
 <em>Node.js:</em> v18.13.0
 <em>home:</em> .../node_modules/@sap/cds
 
-<i>$</i> cds version --markdown
-
-| @capire/samples | https://github.com/sap-samples/cloud-cap-samples.git |
-|:------------------ | ----------- |
+<span class="cwd">$</span> <span class="cmd">cds</span> <span class="args">version</span> <span class="flags">--markdown</span>
+| @capire/samples    | https://github.com/sap-samples/cloud-cap-samples.git |
+| ------------------ | ----------- |
 | Node.js            | v18.13.0    |
 | @sap/cds           | 6.7.0       |
 | @sap/cds-compiler  | 3.8.2       |


### PR DESCRIPTION
Our `pre.log` styling currently isn't nicely aligned with built-in code fences, which becomes apparent in the "Tools" page for instance, where they are both used. This PR aligns the styling of `pre.log` fences with Vitepress ones.

Before:
![Screenshot 2024-04-24 at 13 58 56](https://github.com/cap-js/docs/assets/24377039/c919038f-3962-4022-9c45-6a9fbddc8be0)

After:
![Screenshot 2024-04-24 at 13 58 47](https://github.com/cap-js/docs/assets/24377039/85eb317a-fa07-46fa-afb7-44776d0b7e9f)
