### PR TITLE
OpenAPI: adding the updated descriptions for openAPI fields

### DIFF
--- a/advanced/publishing-apis/openapi.md
+++ b/advanced/publishing-apis/openapi.md
@@ -72,9 +72,9 @@ See [Frequently Asked Questions](#faq) for examples on how to use these annotati
 | `Computed`         | Property                                                                      | omit from Create and Update structures                            |
 | `DefaultNamespace` | Schema                                                                        | path templates for actions and functions without namespace prefix |
 | `Description`      | Action, ActionImport, Function, FunctionImport                                | `summary` of Operation Object                                     |
-| `Description`      | EntitySet, Singleton                                                          | `description` of Tag Object                                       |
-| `Description`      | EntityType                                                                    | `description` of Request Body Object                              |
-| `Description`      | ComplexType, EntityType, EnumerationType, Parameter, Property, TypeDefinition | `description` of Schema Object                                    |
+| `Description`      | EntitySet, Singleton                                                          | `title` of Tag Object                                       |
+| `Description`      | EntityType                                                                    | `title` of Request Body Object                              |
+| `Description`      | ComplexType, EntityType, EnumerationType, Parameter, Property, TypeDefinition | `title` of Schema Object                                    |
 | `Description`      | Schema, EntityContainer                                                       | `info.title`                                                      |
 | `Example`          | Property                                                                      | `example` of Schema Object                                        |
 | `Immutable`        | Property                                                                      | omit from Update structure                                        |


### PR DESCRIPTION
In this PR, we have updated the descriptions for the recent change made for `title` and `description` fields  (https://github.tools.sap/cap/issues/issues/15507#issuecomment-5950272)