### PR TITLE
add impl() noop wrapper to simple sample

### DIFF
--- a/get-started/in-a-nutshell.md
+++ b/get-started/in-a-nutshell.md
@@ -614,14 +614,14 @@ Copy this into _srv/cat-service.js_ to add custom event handlers:
 ::: code-group
 ```js [srv/cat-service.js]
 const cds = require('@sap/cds')
-module.exports = function (){
+module.exports = cds.service.impl (function (){
   // Register your event handlers in here, for example, ...
   this.after ('each','Books', book => {
     if (book.stock > 111) {
       book.title += ` -- 11% discount!`
     }
   })
-}
+})
 ```
 :::
 

--- a/get-started/in-a-nutshell.md
+++ b/get-started/in-a-nutshell.md
@@ -613,15 +613,14 @@ Copy this into _srv/cat-service.js_ to add custom event handlers:
 
 ::: code-group
 ```js [srv/cat-service.js]
-const cds = require('@sap/cds')
-module.exports = cds.service.impl (function (){
+module.exports = function (){
   // Register your event handlers in here, for example, ...
   this.after ('each','Books', book => {
     if (book.stock > 111) {
       book.title += ` -- 11% discount!`
     }
   })
-})
+}
 ```
 :::
 

--- a/guides/providing-services.md
+++ b/guides/providing-services.md
@@ -924,12 +924,12 @@ Within your custom implementations, you can register event handlers like that:
 
 ```js [Node.js]
 const cds = require('@sap/cds')
-module.exports = function (){
+module.exports = cds.service.impl (function (){
   this.on ('submitOrder', (req)=>{...}) //> custom actions
   this.on ('CREATE',`Books`, (req)=>{...})
   this.before ('UPDATE',`*`, (req)=>{...})
   this.after ('READ',`Books`, (books)=>{...})
-}
+})
 ```
 ```Java
 @Component

--- a/guides/providing-services.md
+++ b/guides/providing-services.md
@@ -923,13 +923,12 @@ Within your custom implementations, you can register event handlers like that:
 ::: code-group
 
 ```js [Node.js]
-const cds = require('@sap/cds')
-module.exports = cds.service.impl (function (){
+module.exports = function (){
   this.on ('submitOrder', (req)=>{...}) //> custom actions
   this.on ('CREATE',`Books`, (req)=>{...})
   this.before ('UPDATE',`*`, (req)=>{...})
   this.after ('READ',`Books`, (books)=>{...})
-})
+}
 ```
 ```Java
 @Component


### PR DESCRIPTION
The sample given had a `const cds = require('@sap/cds')` but didn't use the `cds` after that. Moreover, the constant was then highlighted in VS Code as unused, with a rather urgent red squiggly line, which no-one wants :-)

I suggest that rather than omit this line, perhaps it's better to leave it in and use it to provide the noop wrapper that enables Intellisense.