### PR TITLE
Fix logo grid in "About"

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -48,12 +48,12 @@ The CAP framework features a mix of proven and broadly adopted open-source and S
 <style scoped>
   #logos {
     margin: 24px auto;
-    max-width: 280px; /* Maximum width of the logos container */
+    max-width: 280px;
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    justify-content: center; /* Center grid items along the row */
-    align-items: center; /* Center grid items vertically */
-    gap: 12px; /* Space between grid items */
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
   }
 
   #logos img {

--- a/about/index.md
+++ b/about/index.md
@@ -36,17 +36,36 @@ CAP-based projects benefit from a **[primary focus on domain](#domain-modeling)*
 
 The CAP framework features a mix of proven and broadly adopted open-source and SAP technologies, as highlighted in the figure below.
 
-<img src="../assets/overview.drawio.svg" style="width:450px; margin: auto" alt="The graphic is explained in the accompanying text.">
+<img src="../assets/overview.drawio.svg" style="width:480px; margin: auto" alt="The graphic is explained in the accompanying text.">
 
 <div id="logos" style="text-align:center;">
   <img src="../assets/logos/nodejs.svg" style="height:40px" alt="Node.js logo" />
-  <img src="../assets/logos/express.png" style="height:30px" alt="Express logo"/>
-  <img src="../assets/logos/java.svg" style="height:44px" alt="Java logo"/>
+  <img src="../assets/logos/express.png" style="height:34px" alt="Express logo"/>
+  <img src="../assets/logos/java.svg" style="height:44px;margin-top:-10px;" alt="Java logo"/>
   <img src="../assets/logos/spring.svg" style="height:25px" alt="spring logo" />
 </div>
 
 <style scoped>
-  #logos img { display:inline-block; margin: 12px;align-items:center;vertical-align:middle }
+  #logos {
+    margin: 24px auto;
+    max-width: 280px; /* Maximum width of the logos container */
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    justify-content: center; /* Center grid items along the row */
+    align-items: center; /* Center grid items vertically */
+    gap: 12px; /* Space between grid items */
+  }
+
+  #logos img {
+    margin: 4px auto;
+  }
+
+  @media (min-width: 500px) {
+    #logos {
+      max-width: 500px;
+      grid-template-columns: repeat(4, 1fr); /* Four columns in one row for wider screens */
+    }
+  }
 </style>
 
 On top of open source technologies, CAP mainly adds:

--- a/about/index.md
+++ b/about/index.md
@@ -63,7 +63,7 @@ The CAP framework features a mix of proven and broadly adopted open-source and S
   @media (min-width: 500px) {
     #logos {
       max-width: 500px;
-      grid-template-columns: repeat(4, 1fr); /* Four columns in one row for wider screens */
+      grid-template-columns: repeat(4, 1fr);
     }
   }
 </style>


### PR DESCRIPTION
Currently the logo grid in "About" adds a line break after the third logo if there's not enough space left.

This PR changes it so we have either a 4x1 row or 2x2 matrix, so the Node.js + Express and Java + Spring logo pairs are always in the same row.

Before:
![Screenshot 2024-05-13 at 09 08 41](https://github.com/cap-js/docs/assets/24377039/b08f3e05-cacc-4d07-881f-1f8e80ff97f6)

After:
![Screenshot 2024-05-13 at 09 07 51](https://github.com/cap-js/docs/assets/24377039/325234ea-2184-4d24-9820-8de4d2f3eb46)
