### PR TITLE
Minor fix for CSN representation of annotate

### DIFF
--- a/cds/csn.md
+++ b/cds/csn.md
@@ -585,7 +585,7 @@ csn = { extensions:[
 
 ### annotate with \<anonymous aspect\>
 
-The form `{ annotate:<target>, with:{...} }` allows to add or override annotations of the target definition as well as those of nested elements:
+The form `{ annotate:<target>, <property>: <value>, … }` allows to add or override annotations of the target definition as well as those of nested elements:
 
 ```js
 csn = {extensions:[


### PR DESCRIPTION
CSN representation for "annotate" doesn't contain a "with". Align to section above for "extend".