### PR TITLE
doc(CSN): Formatting; follow conventions for i18n

### DIFF
--- a/cds/csn.md
+++ b/cds/csn.md
@@ -207,10 +207,10 @@ Custom-defined types are entries in [`definitions`](#definitions) with an option
 
 ```js
 ({definitions: {
-  'scalar.type': {type:"cds.String", length:3 },
-  'struct.type': {elements:{ 'foo': {type:"cds.Integer"}}},
+  'scalar.type':  {type:"cds.String", length:3 },
+  'struct.type':  {elements:{'foo': {type:"cds.Integer"}}},
   'arrayed.type': {items:{type:"cds.Integer"}},
-  'enum.type':   {enum:{ 'asc':{}, 'desc':{} }}
+  'enum.type':    {enum:{ 'asc':{}, 'desc':{} }}
 }})
 ```
 
@@ -663,13 +663,14 @@ Example:
 ## Imports
 
 The `requires` property lists other models to import definitions from.
+It is the CSN equivalent of the CDL [`using` directive](./cdl#using).
 
 #### Example
 
 ```js
 ({
-  requires:[ '@sap/cds/common', './db/schema' ],
-  [...]
+  requires: [ '@sap/cds/common', './db/schema' ],
+  // [...]
 })
 ```
 
@@ -681,9 +682,9 @@ A CSN may optionally contain a top-level `i18n` property, which can contain tran
 
 ```js
 ({
-  "i18n": {
-    "language-key": {
-      "text-key": "some string"
+  i18n: {
+    'language-key': {
+      'text-key': "some string"
     }
   }
 })


### PR DESCRIPTION
This commit only includes some formatting changes, and adds a link to the CSN's `requires` equivalent in CDL.