### PR TITLE
[cds^8] No strings in INSERT.into and UPSERT.into

### DIFF
--- a/cds/cqn.md
+++ b/cds/cqn.md
@@ -180,7 +180,7 @@ CQN = {SELECT:{
 
 ```js
 UPSERT = {UPSERT:{
-   into: (ref + { as:string }) | string,
+   into: ref + { as:string },
    entries: [ ...{ ...column:any } ],
    as: SELECT
 }}
@@ -190,7 +190,7 @@ UPSERT = {UPSERT:{
 
 ```js
 INSERT = {INSERT:{
-   into: (ref + { as:string }) | string,
+   into: ref + { as:string },
    columns: [ ...string ],
    values: [ ...any ],
    rows: [ ...[ ...any ] ],


### PR DESCRIPTION
With cds 8, we only want to allow refs, no strings in `INSERT.into` and `UPSERT.into` (as it is already the case for UPDATE and DELETE).