### PR TITLE
Fix "incorrect" parm name in after() examples in core-services.md

### DIFF
--- a/node.js/core-services.md
+++ b/node.js/core-services.md
@@ -183,7 +183,7 @@ class BooksService extends cds.ApplicationService {
   init() {
     const { Books, Authors } = this.entities
     this.before ('READ', Authors, req => {...})
-    this.after ('READ', Books, req => {...})
+    this.after ('READ', Books, books => {...})
     this.on ('submitOrder', req => {...})
     return super.init()
   }
@@ -438,7 +438,7 @@ class BooksService extends cds.ApplicationService {
   init(){
     const { Books, Authors } = this.entities
     this.before ('READ', Authors, req => {...})
-    this.after ('READ', Books, req => {...})
+    this.after ('READ', Books, books => {...})
     this.on ('submitOrder', req => {...})
     return super.init()
   }


### PR DESCRIPTION
Two of the instances of `this.after(...)` examples in this section have "incorrect" or at least very misleading parameter names. I guess they were created by copy/pasting the lines to create the `before`, `on` and `after` callback registration lines. However the first parameter passed to the `after` callback is not the request, [it is the data](https://cap.cloud.sap/docs/node.js/core-services#srv-after-request). I have replaced `req` with `books` in these two instances to be consistent with how it's show elsewhere in this section.