### PR TITLE
fix(databases): Fix code comment in SQL snippet

### DIFF
--- a/guides/databases.md
+++ b/guides/databases.md
@@ -756,7 +756,7 @@ CREATE TABLE Books (
   author_ID INTEGER,    -- generated foreign key field
   ...,
   PRIMARY KEY(ID),
-  CONSTRAINT Books_author // [!code focus]
+  CONSTRAINT Books_author -- [!code focus]
     FOREIGN KEY(author_ID)  -- link generated foreign key field author_ID ...
     REFERENCES Authors(ID)  -- ... with primary key field ID of table Authors
     ON UPDATE RESTRICT


### PR DESCRIPTION
SQL uses `--` for comments.
Use it for the code-focus comment as well.
It didn't work on the rendered page anyway.