### PR TITLE
Use `schema.cds` naming throughout

### DIFF
--- a/guides/i18n.md
+++ b/guides/i18n.md
@@ -127,7 +127,7 @@ So, the complete stack of overlaid models for the given example would look like 
 | *_i18n/i18n_en.properties* | default language bundle |
 | *_i18n/i18n.properties* | default fallback bundle |
 | *srv/my-service.cds* | service definition |
-| *db/data-model.cds* | underlying data model |
+| *db/schema.cds* | underlying data model |
 
 ::: tip _Note_ <!--  -->
 The _default language_ is usually `en` but can be overridden by configuring `cds.i18n.default_language` in your project's _package.json_.
@@ -145,7 +145,7 @@ For example, assuming that your data model imports from a _foundation_ package, 
 | *./_i18n/i18n_en.properties* |
 | *./_i18n/i18n.properties* |
 | *./srv/my-service.cds* |
-| *./db/data-model.cds* |
+| *./db/schema.cds* |
 | *foundation/_i18n/i18n_de.properties* |
 | *foundation/_i18n/i18n_en.properties* |
 | *foundation/_i18n/i18n.properties* |

--- a/java/getting-started.md
+++ b/java/getting-started.md
@@ -124,7 +124,7 @@ The generated project has the following folder structure:
 ```txt
 <PROJECT-ROOT>/
 |-- db/
-    `-- data-model.cds
+    `-- schema.cds
 `-- srv/
     |-- cat-service.cds
     |-- src/main/java/
@@ -136,7 +136,7 @@ The generated folders have the following content:
 
 | Folder | Description |
 | --- | --- |
-| *db* | Contains content related to your database. A simple CDS domain model is located in the file _data-model.cds_. |
+| *db* | Contains content related to your database. A simple CDS domain model is located in the file _schema.cds_. |
  | *srv* | Contains the CDS service definitions and Java back-end code and the sample service model  _cat-service.cds_. |
 | *srv/src/main/java* | Contains Java application logic. |
 | *srv/src/gen/java* | Contains the compiled CDS model and generated [accessor interfaces for typed access](./cds-data#typed-access). |


### PR DESCRIPTION
As reported by DJ, we were inconsistent in the way we name our schema file
- `cds add tiny-sample` created a `db/data-model.cds`
- `cds add sample` created a `db/schema.cds`

We settled for `schema.cds` for both in cds8. This should also be reflected in capire.