### PR TITLE
docs: Streamline directory listing style

### DIFF
--- a/java/getting-started.md
+++ b/java/getting-started.md
@@ -123,13 +123,13 @@ The generated project has the following folder structure:
 
 ```txt
 <PROJECT-ROOT>/
-|-- db/
-    `-- data-model.cds
-`-- srv/
-    |-- cat-service.cds
-    |-- src/main/java/
-    |-- src/gen/java/
-    `-- node_modules/
+├─ db/
+│  └─ data-model.cds
+└─ srv/
+   ├─ cat-service.cds
+   ├─ src/main/java/
+   ├─ src/gen/java/
+   └─ node_modules/
 ```
 
 The generated folders have the following content:
@@ -173,8 +173,8 @@ mvn com.sap.cds:cds-maven-plugin:addIntegrationTest
 This command also creates a new folder *integration-tests/src/test/java*, which contains integration test classes:
 ```txt
 <PROJECT-ROOT>/
-`-- integration-tests/
-    `-- src/test/java/
+└─ integration-tests/
+   └─ src/test/java/
 ```
 
 | Folder | Description  |

--- a/java/migration.md
+++ b/java/migration.md
@@ -686,21 +686,21 @@ Don't copy any of the following files to the new project:
 
 ```txt
 <PROJECT-ROOT>/
-|-- db/
-|   |-- .build.js
-|   `-- package.json
-`-- srv/src/main/
-            |-- resources/
-            |    |-- application.properties
-            |    `-- connection.properties
-            `-- webapp/
-                 |-- META-INF/
-                 |   |-- sap_java_buildpack/config/resources_configuration.xml
-                 |   `-- context.xml
-                 `-- WEB-INF/
-                     |-- resources.xml
-                     |-- spring-security.xml
-                     `-- web.xml
+├─ db/
+│  ├─ .build.js
+│  └─ package.json
+└─ srv/src/main/
+           ├─ resources/
+           │  ├─ application.properties
+           │  └─ connection.properties
+           └─ webapp/
+              ├─ META-INF/
+              │  ├─ sap_java_buildpack/config/resources_configuration.xml
+              │  └─ context.xml
+              └─ WEB-INF/
+                 ├─ resources.xml
+                 ├─ spring-security.xml
+                 └─ web.xml
 ```
 
 

--- a/java/reflection-api.md
+++ b/java/reflection-api.md
@@ -193,22 +193,22 @@ CAP Java does not make any assumption _how_ the set of enabled features (_active
 Features are modeled in CDS by dividing up CDS code concerning separate features into separate subfolders of a common `fts` folder of your project, as shown by the following example:
 
 ```txt
-|-- [db]
-|   |-- my-model.cds
-|   `-- ...
-|-- [srv]
-|   |-- my-service.cds
-|   `-- ...
-`-- [fts]
-    |-- [X]
-    |   |-- model.cds
-    |   `-- ...
-    |-- [Y]
-    |   |-- feature-model.cds
-    |   `-- ...
-    `-- [Z]
-        |-- wrdlbrmpft.cds
-        `-- ...
+├─ [db]
+│  ├─ my-model.cds
+│  └─ ...
+├─ [srv]
+│  ├─ my-service.cds
+│  └─ ...
+└─ [fts]
+   ├─ [X]
+   │  ├─ model.cds
+   │  └─ ...
+   ├─ [Y]
+   │  ├─ feature-model.cds
+   │  └─ ...
+   └─ [Z]
+      ├─ wrdlbrmpft.cds
+      └─ ...
 ```
 
 In this example, three _CDS features_ `X`, `Y` and `Z` are defined. Note that the name of a feature (by which it is referenced in a _feature toggle_) corresponds to the name of the feature's subfolder. A CDS feature can contain arbitrary CDS code. It can either define new entities or extensions of existing entities.


### PR DESCRIPTION
The main getting started guide[^1] uses box drawing characters[^2], and I think we should streamline that syntax.

[^1]: https://pages.github.tools.sap/cap/docs/get-started/jumpstart#project-structure
[^2]: https://en.wikipedia.org/wiki/Box-drawing_characters