### PR TITLE
Update the FAQ for concurrency problems

### DIFF
--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -266,14 +266,16 @@ If you don't want to exclude dependencies completely, but make sure that an in-m
 
 In recent versions of the JVM (starting with Java 11), the container resource usage has been optimized. These optimizations cause CAP Java code that is executed asynchronously (for example, using [`CompletableFuture`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/CompletableFuture.html)) within the [common thread pool](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/ForkJoinPool.html#commonPool()) that has more than one worker thread to throw a `ContextualizedServiceException` with the message "Cannot find implementation for `com.sap.cds.CdsDataProcessor`". Classes `Cds4jServiceLoader`, `CqnAnalyzer` or `CdsDataStoreConnector` also can be mentioned.
 
+On Cloud Foundry, the issue might appear only if you increase the __Instance Memory__ available for your application.
+
 The proper solution for this issue is to always execute your asynchronous tasks within [an executor or an executor service](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/Executor.html). This includes the thread factory that sets the classloader provided by your application server, for example Spring Boot or Tomcat, for the worker threads.
 
 The following workarounds are known:
- * On *Cloud Foundry* you can provide this Java option [`-XX:+UseContainerCpuShares`](https://bugs.openjdk.org/browse/JDK-8281571) or use the Java Build pack >= 1.64.1 and Java 17. 
- * For *Docker* containers you can provide this Java option [-XX:ActiveProcessorCount=\<n\>](https://docs.oracle.com/en/java/javase/11/tools/java.html)
+ * For Cloud Foundry and Docker containers you can provide this Java option [-XX:ActiveProcessorCount=1>](https://docs.oracle.com/en/java/javase/11/tools/java.html).
+ * In Cloud Foundry, you can reduce the size of available memory for your application instance.
  * For *Kubernetes* or *Kyma* you can follow the instructions [here](https://bugs.openjdk.org/browse/JDK-8281571).
 
-We recommend to implement a proper thread pool and not to rely on these workarounds.
+We recommend to implement a proper thread pool and not to rely on these workarounds as they impair performance of your application.
 
 ## OData
 


### PR DESCRIPTION
- Update the FAQ to remove mention of the option that is obsolete. 
- Include additional symptom: the issue could occur if the application uses more than specific amount of memory. This depends on the buildpack, though. 