### PR TITLE
[cds^8] telemetry plugin: remove beta flag

### DIFF
--- a/plugins/index.md
+++ b/plugins/index.md
@@ -264,7 +264,7 @@ Available for:
 [![Node.js](../assets/logos/nodejs.svg 'Link to the plugins repository.'){style="height:2.5em; display:inline; margin:0 0.2em;"}](https://github.com/cap-js/notifications#readme)
 
 
-## Telemetry <Beta />
+## Telemetry
 
 
 The Telemetry plugin provides observability features such as tracing and metrics, including [automatic OpenTelemetry instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/automatic).


### PR DESCRIPTION
merge once cds^8 was released and consumed by @cap-js/telemetry