### PR TITLE
fix(java): Fix variable mismatch: `ctx` vs `context`

### DIFF
--- a/java/messaging.md
+++ b/java/messaging.md
@@ -635,7 +635,7 @@ The following example demonstrates how the error handler can be used to catch me
 
 ```java
 @On(service = "messaging")
-private void handleError(MessagingErrorEventContext context) {
+private void handleError(MessagingErrorEventContext ctx) {
 
   String errorCode = ctx.getException().getErrorStatus().getCodeString();
   if (errorCode.equals(CdsErrorStatuses.NO_ON_HANDLER.getCodeString()) ||
@@ -646,9 +646,9 @@ private void handleError(MessagingErrorEventContext context) {
       // error handling for application errors
 
       // how to access the event context of the raised exception:
-      // context.getException().getEventContexts().stream().findFirst().ifPresent(e -> {
-      //	  String event = e.getEvent());
-      //	  String payload = e.get("data"));
+      // ctx.getException().getEventContexts().stream().findFirst().ifPresent(e -> {
+      //    String event = e.getEvent());
+      //    String payload = e.get("data"));
       // });
 
       ctx.setResult(true); // acknowledge

--- a/java/outbox.md
+++ b/java/outbox.md
@@ -208,7 +208,7 @@ void processMyEvent(OutboxMessageEventContext context) {
 
   // Perform processing logic for myEvent
 
-  ctx.setCompleted();
+  context.setCompleted();
 }
 ```
 


### PR DESCRIPTION
There were two snippets that were not consistent in the naming of their context variable.  In one case, `ctx` did not exist, in the other, `context` did not exist.