### PR TITLE
ci: Update `actions/setup-node` to v4

### DIFF
--- a/.github/workflows/PR-SAP.yml
+++ b/.github/workflows/PR-SAP.yml
@@ -28,7 +28,7 @@ jobs:
           GH_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN_PARENT: ${{ secrets.GH_TOKEN_PARENT }}
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           cache: 'npm'

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           cache: 'npm'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
         GH_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
         GH_TOKEN_PARENT: ${{ secrets.GH_TOKEN_PARENT }}
     - name: Use Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
         cache: 'npm'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           cache: 'npm'


### PR DESCRIPTION
This gets rid of CI warnings about Node 16, as they upgraded to Node 20.