### PR TITLE
feat: add disclaimer to change tracking plugin

### DIFF
--- a/plugins/index.md
+++ b/plugins/index.md
@@ -217,6 +217,10 @@ Learn more about audit logging in [Node.js](../guides/data-privacy/audit-logging
 
 ## Change Tracking
 
+:::warning Personal data is ignored
+Elements with [personal data](../guides/data-privacy/annotations#personaldata), that is, elements that are annotated
+with @PersonalData and hence subject to audit logging, are ignored by the change tracking.
+:::
 
 The Change Tracking plugin provides out-of-the box support for automated capturing, storing, and viewing of the change records of modeled entities. All we need is to add @changelog annotations to your models to indicate which entities and elements should be change-tracked.
 


### PR DESCRIPTION
this was already done in https://cap.cloud.sap/docs/java/change-tracking

but there is no disclaimer for this in the node world (besides a warning in the readme of the plugin) 

I think it makes sense to address this concern prominently.