### PR TITLE
Add full path to pom.xml in auditlog section.

### DIFF
--- a/java/auditlog.md
+++ b/java/auditlog.md
@@ -135,7 +135,7 @@ logging:
 ```
 ### AuditLog v2 Handler { #handler-v2}
 
-Additionally, the CAP Java SDK provides an _AuditLog v2_ handler that writes the audit messages to the SAP Audit Log service via its API version 2. To enable this handler, an additional feature dependency must be added to the `pom.xml` of the CAP Java project:
+Additionally, the CAP Java SDK provides an _AuditLog v2_ handler that writes the audit messages to the SAP Audit Log service via its API version 2. To enable this handler, an additional feature dependency must be added to the `srv/pom.xml` of the CAP Java project:
 
 ```xml
 <dependency>


### PR DESCRIPTION
Some stakeholders put the dependency into parent pom: https://github.tools.sap/cap/issues/issues/16164#issuecomment-6763421, which is wrong.