### PR TITLE
fix typo and rearrange to avoid multiple plural-possessive-quotes in …

### DIFF
--- a/node.js/core-services.md
+++ b/node.js/core-services.md
@@ -237,7 +237,7 @@ exports['foo.bar.Foo'] = class Foo {...}
 exports['foo.bar.Boo'] = class Bar {...}
 ```
 
-The exports' names must **match the servce definitions' fully-qualified names**.
+The exports' names must **match the fully-qualified names of the service definitions**.
 
 :::
 


### PR DESCRIPTION
…core-services.md

Spotted "servce" [sic] then thought I'd rearrange the phrase anyway to help avoid two plural-possessive-quotes in one phrase :-)