### PR TITLE
docs(In a Nutshell): Mention path `/browse` in text also

### DIFF
--- a/get-started/in-a-nutshell.md
+++ b/get-started/in-a-nutshell.md
@@ -274,7 +274,7 @@ So, let's go on feeding it with two service definitions for different use cases:
 
 An `AdminService` for administrators to maintain `Books` and `Authors`.
 
-A `CatalogService` for end users to browse and order `Books`.
+A `CatalogService` for end users to browse and order `Books` under path `/browse`.
 
 To do so, create the following two files in folder _./srv_ and fill them with this content:
 


### PR DESCRIPTION
While reading the section for the first time, I wondered why the next sections talk about `/browse`. Where did it come from? Turns out, I was lazy and didn't read the second CDS file.

With this commit, let's make it a little bit more clear that the catalog service has a different URL.