### PR TITLE
Avoid `cap>=ire` in the window title

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -84,6 +84,7 @@ const loadSyntax = async (file:string, name:string, alias:string=name):Promise<L
 
 const config:UserConfig<CapireThemeConfig> = {
   title: 'cap≽ire',
+  titleTemplate: ':title | capire', // for the window title
   description: 'Documentation for SAP Cloud Application Programming Model',
   base,
   srcExclude: ['**/.github/**', '**/README.md', '**/LICENSE.md', '**/CONTRIBUTING.md', '**/CODE_OF_CONDUCT.md', '**/menu.md', '**/-*.md'],

--- a/index.md
+++ b/index.md
@@ -1,6 +1,8 @@
 ---
 layout: home
 status: released
+title: Home
+titleTemplate: ':title | capire'
 
 hero:
   name: SAP Cloud Application Programming Model


### PR DESCRIPTION
`cap>=ire` is hard as a search term in browser history, so use a simpler text in the window title.