### PR TITLE
Increase specificity for start page heading

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -311,7 +311,7 @@ Services in CAP are **stateless** and with a **minimal footprint**, which allows
 
 <figure>
    <img src="../assets/agnostic-services.drawio.svg" width="333px">
-  <figcaption><a href="#hexagonal-architecture">Hexagonal Architecture à la CAP</a></figcaption>
+  <figcaption style="text-align: center"><a href="#hexagonal-architecture">Hexagonal Architecture à la CAP</a></figcaption>
 </figure>
 
 <br><br>

--- a/index.md
+++ b/index.md
@@ -50,7 +50,7 @@ features:
 
 /* make hero text smaller in narrow sizes */
 @media (max-width: 640px) {
-  .VPHome .VPHero .name {
+  .VPHome .VPHero h1.name {
     font-size: 33px;
   }
 }


### PR DESCRIPTION
We have this problem again on our start page for small screens:

<img width="554" alt="Screenshot 2024-07-18 at 10 13 23" src="https://github.com/user-attachments/assets/392397f2-f37c-4754-bf07-2179d7d7f871">


Increasing the specificity of the `.VPHome .VPHero h1.name` styling helped reset it to the smaller font on mobile.