### PR TITLE
Removed outdated precondition from change-tracking.md

### DIFF
--- a/java/change-tracking.md
+++ b/java/change-tracking.md
@@ -29,10 +29,8 @@ To use the change tracking feature, you need to add a dependency to [cds-feature
 </dependency>
 ```
 
-Your POM must also include the goal to resolve the CDS model delivered from the feature.
+- Your POM must also include the goal to resolve the CDS model delivered from the feature.
 See [Reference the New CDS Model in an Existing CAP Java Project](/java/building-plugins#reference-the-new-cds-model-in-an-existing-cap-java-project).
-
-- For the UI part, you also need to enable the [On-the-fly Localization of EDMX](/releases/archive/2023/dec23#on-the-fly-localization-of-edmx).
 
 - If you use SAP Fiori elements as your UI framework and intend to use the built-in UI, update your SAP UI5 version to 1.121.2 or higher.
 


### PR DESCRIPTION
For CAP Java 3.0, the lazy EDMX localisation is a default.

Fixes this https://github.com/cap-js/docs/pull/983#pullrequestreview-2104174161