### PR TITLE
fix(in-a-nutshell): Fix start of paragraph for Java example

### DIFF
--- a/get-started/in-a-nutshell.md
+++ b/get-started/in-a-nutshell.md
@@ -823,7 +823,7 @@ public class SubmitOrderHandler implements EventHandler {
 
 ### Sample HTTP Request
 
-Or submit orders until you see the error messages. Create a file called _test.http_ and copy the request into it.
+Test the implementation by submitting orders until you see the error messages. Create a file called _test.http_ and copy the request into it.
 
 <div class="impl node">
 


### PR DESCRIPTION
For Java, the previous section does not end in a sentence that can be continued by a `Or submit…` section.  Instead, let's just rewrite the section to make it runtime-agnostic.