### PR TITLE
fix(Java): Remove deprecated `addIntegrationTest` command

### DIFF
--- a/java/getting-started.md
+++ b/java/getting-started.md
@@ -165,7 +165,7 @@ The `artifactId` is set to `<PROJECT-ROOT>` and the `groupId` to `customer`.
 Optionally, you can use the [CDS Maven plugin](./developing-applications/building#cds-maven-plugin) to enhance your CAP Java application with an additional Maven module to perform integration tests. To add such a module, go into the root folder of your CAP Java project and execute the following Maven command:
 
 ```sh
-mvn com.sap.cds:cds-maven-plugin:addIntegrationTest
+mvn com.sap.cds:cds-maven-plugin:add -Dfeature=INTEGRATION_TEST
 ```
 
 This command also creates a new folder *integration-tests/src/test/java*, which contains integration test classes.


### PR DESCRIPTION
Deprecated since CAP Java 3.0