### PR TITLE
Update $expand support for node

### DIFF
--- a/advanced/odata.md
+++ b/advanced/odata.md
@@ -54,7 +54,7 @@ System query options can also be applied to an [expanded navigation property](ht
 | `$filter`      | Filter associated entities                | <X/>     | <X/>   |
 | `$expand`      | Nested expand                             | <X/>     | <X/>   |
 | `$orderby`     | Sort associated entities                  | <X/>     | <X/>   |
-| `$top`,`$skip` | Paginate associated entities              | <Na/>    | <X/>   |
+| `$top`,`$skip` | Paginate associated entities              | <X/>     | <X/>   |
 | `$count`       | Count associated entities                 | <Na/>    | <X/>   |
 | `$search`      | Search associated entities                | <Na/>    | <Na/>  |
 


### PR DESCRIPTION
Hi colleagues,

$top and $skip are supported since cds 8 with node, so docs should reflect it.

Thanks & BR,
Marten