### PR TITLE
Added bound actions to collection docs

### DIFF
--- a/guides/providing-services.md
+++ b/guides/providing-services.md
@@ -1033,6 +1033,8 @@ service Sue {
   entity Foo { key ID:Integer } actions {
     function getStock() returns Integer;
     action order (x:Integer) returns Integer;
+    //bound to the collection and not a specific instance of Foo
+    action customCreate (in: many $self; x: String) returns Foo;
   }
 }
 ```
@@ -1046,12 +1048,7 @@ The differentiation between *Actions* and *Functions* as well as *bound* and *un
 - **Actions** modify data in the server
 - **Functions** retrieve data
 - **Unbound** actions/functions are like plain unbound functions in JavaScript.
-- **Bound** actions/functions always receive the bound entity's primary key as implicit first argument, similar to `this` pointers in Java or JavaScript.
-
-::: tip Prefer *Unbound* Actions/Functions
-From CDS perspective we recommend **preferring unbound** actions/functions, as these are much more straightforward to implement and invoke.
-:::
-
+- **Bound** actions/functions always receive the bound entity's primary key as implicit first argument, similar to `this` pointers in Java or JavaScript. The exception are bound actions to collections, which are bound against the collection and not a specific instance of the entity. An example use case are custom create actions for the SAP Fiori elements UI.
 
 
 ### Implementing Actions / Functions

--- a/guides/providing-services.md
+++ b/guides/providing-services.md
@@ -1034,7 +1034,7 @@ service Sue {
     function getStock() returns Integer;
     action order (x:Integer) returns Integer;
     //bound to the collection and not a specific instance of Foo
-    action customCreate (in: many $self; x: String) returns Foo;
+    action customCreate (in: many $self, x: String) returns Foo;
   }
 }
 ```


### PR DESCRIPTION
Hi,

the providing services guide lacked information about bound actions to collection. Moreover the preference for unbound actions is counter productive as those are a lot harder to use with Fiori elements but also related to the implementation did not make much sense.

BR,
Marten