### PR TITLE
Hide scroll-to-top on iOS

### DIFF
--- a/.vitepress/theme/components/ScrollToTop.vue
+++ b/.vitepress/theme/components/ScrollToTop.vue
@@ -28,7 +28,7 @@ export default {
     },
   },
   mounted() {
-    const isIOS = /iPad|iPhone|iPod/.test(window.navigator.userAgent);
+    const isIOS = /iPad|iPhone|iPod/i.test(window.navigator.userAgent);
     if (isIOS) { // iOS already has a system-wide scroll-to-top button at the top
       this.visible = false;
     } else {

--- a/.vitepress/theme/components/ScrollToTop.vue
+++ b/.vitepress/theme/components/ScrollToTop.vue
@@ -28,8 +28,8 @@ export default {
     },
   },
   mounted() {
-    const isIOS = /iPad|iPhone|iPod/.test(window.navigator.userAgent) && !window.MSStream
-    if (isIOS) {
+    const isIOS = /iPad|iPhone|iPod/.test(window.navigator.userAgent) && !window.MSStream;
+    if (isIOS) { // iOS already has a system-wide scroll-to-top button at the top
       this.visible = false;
     } else {
       window.addEventListener('scroll', () => {

--- a/.vitepress/theme/components/ScrollToTop.vue
+++ b/.vitepress/theme/components/ScrollToTop.vue
@@ -28,11 +28,16 @@ export default {
     },
   },
   mounted() {
-    window.addEventListener('scroll', () => {
-      const isVisible = window.scrollY > 240;
-      this.enableFadeInClass = isVisible;
-      this.enableFadeOutClass = !isVisible;
-    });
+    const isIOS = /iPad|iPhone|iPod/.test(window.navigator.userAgent) && !window.MSStream
+    if (isIOS) {
+      this.visible = false;
+    } else {
+      window.addEventListener('scroll', () => {
+        const isVisible = window.scrollY > 240;
+        this.enableFadeInClass = isVisible;
+        this.enableFadeOutClass = !isVisible;
+      });
+    }
   },
 };
 </script>

--- a/.vitepress/theme/components/ScrollToTop.vue
+++ b/.vitepress/theme/components/ScrollToTop.vue
@@ -28,7 +28,7 @@ export default {
     },
   },
   mounted() {
-    const isIOS = /iPad|iPhone|iPod/.test(window.navigator.userAgent) && !window.MSStream;
+    const isIOS = /iPad|iPhone|iPod/.test(window.navigator.userAgent);
     if (isIOS) { // iOS already has a system-wide scroll-to-top button at the top
       this.visible = false;
     } else {


### PR DESCRIPTION
iOS already has a huge system-wide scroll-to-top button (the orange area here), so the button is a bit redundant. On small screens it also overlays the content quite a bit →  I'd disable it for iOS.

<img width="447" alt="Screenshot 2024-09-03 at 13 10 29" src="https://github.com/user-attachments/assets/02cf6167-3c67-4ad2-8ad3-3f29712d0fd3">
