### PR TITLE
Use smooth scrolling for scroll-to-top

### DIFF
--- a/.vitepress/theme/components/ScrollToTop.vue
+++ b/.vitepress/theme/components/ScrollToTop.vue
@@ -24,7 +24,7 @@ export default {
   },
   methods: {
     scrollToTop() {
-      window.scrollTo({ top: 0, behavior: 'auto' });
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     },
   },
   mounted() {


### PR DESCRIPTION
While on would assume `auto` just takes browser preferences or whatever it will instantly scroll instead of smoothly:
https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior#values

Smooth scrolling is much more common for such buttons and usually the system way (cp. <kbd>⌘↑</kbd> on macOS). Our implementation currently feels a bit juddery because of that.