### PR TITLE
Update cds-server.md with working examples

### DIFF
--- a/node.js/cds-server.md
+++ b/node.js/cds-server.md
@@ -237,7 +237,7 @@ The behavior of the built-in `server.js` can be customized through the options d
 
 ### CORS Middleware
 
-The built-in CORS middleware can be enabled explicitly with `cds.server.cors = true`.  By default, this is `false` if in production.
+The built-in CORS middleware can be enabled explicitly with `cds.env.server.cors = true`.  By default, this is `false` if in production.
 
 [Learn more about best practices regarding **Cross-Origin Resource Sharing (CORS)**.](../node.js/best-practices.md#cross-origin-resource-sharing-cors) {.learn-more}
 
@@ -245,7 +245,7 @@ The built-in CORS middleware can be enabled explicitly with `cds.server.cors = t
 
 ### Toggle Generic Index Page
 
-The default generic _index.html_ page is not served if `NODE_ENV` is set to `production`. Set `cds.server.index = true` to restore the generic index page in production.
+The default generic _index.html_ page is not served if `NODE_ENV` is set to `production`. Set `cds.env.server.index = true` to restore the generic index page in production.
 
 [See the **Generic *index.html*** page in action.](../get-started/in-a-nutshell.md#generic-index-html) {.learn-more}
 


### PR DESCRIPTION
Instructions are missing `env` property from the chain and thus have no effect. This patch fixes the documentation from this part.