### PR TITLE
Use `deploy --out` instead of stdout

### DIFF
--- a/guides/databases-postgres.md
+++ b/guides/databases-postgres.md
@@ -410,7 +410,7 @@ You can use `cds deploy` with option `--dry` to simulate and inspect how things 
 1. Capture your current model in a CSN file:
 
    ```sh
-   cds deploy --dry --model-only > cds-model.csn
+   cds deploy --dry --model-only --out cds-model.csn
    ```
 
 2. Change your models, for example in *[cap/samples/bookshop/db/schema.cds](https://github.com/SAP-samples/cloud-cap-samples/blob/main/bookshop/db/schema.cds)*:
@@ -427,7 +427,7 @@ You can use `cds deploy` with option `--dry` to simulate and inspect how things 
 3. Generate delta DDL statements:
 
    ```sh
-   cds deploy --dry --delta-from cds-model.csn > delta.sql
+   cds deploy --dry --delta-from cds-model.csn --out delta.sql
    ```
 
 4. Inspect the generated SQL statements, which should look like this:
@@ -484,7 +484,7 @@ For generating such a script, perform the same steps as in section [Dry-Run Offl
 above, but replace the command in step 3 by
 
 ```sh
-cds deploy --script --delta-from cds-model.csn > delta_script.sql
+cds deploy --script --delta-from cds-model.csn --out delta_script.sql
 ```
 
 If your model change includes changes that could lead to data loss, there will be a warning
@@ -542,12 +542,12 @@ databaseChangeLog:
 Use `cds deploy` to create the _v1/model.sql_ file:
 
 ```sh
-cds deploy --profile pg --dry > srv/src/main/resources/db/changelog/v1/model.sql
+cds deploy --profile pg --dry --out srv/src/main/resources/db/changelog/v1/model.sql
 ```
 Finally, store the CSN file, which corresponds to this schema version:
 
 ```sh
-cds deploy --model-only --dry > srv/src/main/resources/db/changelog/v1/model.csn
+cds deploy --model-only --dry --out srv/src/main/resources/db/changelog/v1/model.csn
 ```
 
 The CSN file is needed as an input to compute the delta DDL script for the next change set.
@@ -565,7 +565,7 @@ If changes of the CDS model require changes on the database, you can create a ne
 Use `cds deploy` to compute the delta DDL script based on the previous model versions (_v1/model.csn_) and the current model. Write the diff into a _v2/delta.sql_ file:
 
 ```sh
-cds deploy --profile pg --dry --delta-from srv/src/main/resources/db/changelog/v1/model.csn > \
+cds deploy --profile pg --dry --delta-from srv/src/main/resources/db/changelog/v1/model.csn --out \
                                            srv/src/main/resources/db/changelog/v2/model.sql
 ```
 
@@ -592,7 +592,7 @@ databaseChangeLog:
 Finally, store the CSN file, which corresponds to this schema version:
 
 ```sh
-cds deploy --model-only --dry > srv/src/main/resources/db/changelog/v2/model.csn
+cds deploy --model-only --dry --out srv/src/main/resources/db/changelog/v2/model.csn
 ```
 
 If you now start the application, Liquibase executes all change sets, which haven't yet been deployed to the database.

--- a/guides/databases-sqlite.md
+++ b/guides/databases-sqlite.md
@@ -88,7 +88,7 @@ Further configuration depends on whether you run SQLite as an [in-memory databas
 
 ### Initial Database Schema
 
-Configure the build to create an initial _schema.sql_ file for SQLite using `cds deploy --to sqlite --dry > srv/src/main/resources/schema.sql`.
+Configure the build to create an initial _schema.sql_ file for SQLite using `cds deploy --to sqlite --dry --out srv/src/main/resources/schema.sql`.
 
 ::: code-group
 ```xml [srv/pom.xml]
@@ -99,7 +99,7 @@ Configure the build to create an initial _schema.sql_ file for SQLite using `cds
 	</goals>
 	<configuration>
 		<commands>
-			<command>deploy --to sqlite --dry > srv/src/main/resources/schema.sql</command>
+			<command>deploy --to sqlite --dry --out srv/src/main/resources/schema.sql</command>
 		</commands>
 	</configuration>
 </execution>

--- a/java/cqn-services/persistence-services.md
+++ b/java/cqn-services/persistence-services.md
@@ -158,7 +158,7 @@ cds.sql.hana.optimizationMode: legacy
 Use the [hints](../working-with-cql/query-execution#hana-hints) `hdb.USE_HEX_PLAN` and `hdb.NO_USE_HEX_PLAN` to overrule the configured optimization mode per statement.
 
 ::: warning Rare error in `HEX` mode
-In some corner cases, particularly when using [native HANA views](../../advanced/hana#create-native-sap-hana-object), queries in `HEX` optimization mode may fail with a "hex enforced but cannot be selected" error. This is the case if the statement execution requires the combination of HEX only features with other features that are not yet supported by the HEX engine. If CAP detects this error it will, as a fallback, execute the query in _legacy_ mode. 
+In some corner cases, particularly when using [native HANA views](../../advanced/hana#create-native-sap-hana-object), queries in `HEX` optimization mode may fail with a "hex enforced but cannot be selected" error. This is the case if the statement execution requires the combination of HEX only features with other features that are not yet supported by the HEX engine. If CAP detects this error it will, as a fallback, execute the query in _legacy_ mode.
 If you know upfront that a query can't be executed by the HEX engine, you can add a `hdb.NO_USE_HEX_PLAN` hint to the query, so the SQL generator won't use features that require the HEX engine.
 :::
 
@@ -179,7 +179,7 @@ To generate a `schema.sql` for PostgreSQL, use the dialect `postgres` with the `
 	</goals>
 	<configuration>
 		<commands>
-			<command>deploy --to postgres --dry > "${project.basedir}/src/main/resources/schema.sql"</command>
+			<command>deploy --to postgres --dry --out "${project.basedir}/src/main/resources/schema.sql"</command>
 		</commands>
 	</configuration>
 </execution>
@@ -229,7 +229,7 @@ To generate a `schema.sql` for H2, use the dialect `h2` with the `cds deploy` co
 	</goals>
 	<configuration>
 		<commands>
-			<command>deploy --to h2 --dry > "${project.basedir}/src/main/resources/schema.sql"</command>
+			<command>deploy --to h2 --dry --out "${project.basedir}/src/main/resources/schema.sql"</command>
 		</commands>
 	</configuration>
 </execution>
@@ -258,7 +258,7 @@ To generate a `schema.sql` for SQLite, use the dialect `sqlite` with the `cds de
 	</goals>
 	<configuration>
 		<commands>
-			<command>deploy --to sqlite --dry > "${project.basedir}/src/main/resources/schema.sql"</command>
+			<command>deploy --to sqlite --dry --out "${project.basedir}/src/main/resources/schema.sql"</command>
 		</commands>
 	</configuration>
 </execution>


### PR DESCRIPTION
The new param `cds deploy --out <file>` allows writing DDL statements to a separate file.

This is needed by CAP Java to replace their stdout redirection (`cds deploy --dry > schema.sql`). That one fails if debug traces are on as these mess up the output.

So,

```sh
cds deploy --to h2 --dry > schema.sql
```

can change to

```sh
cds deploy --to h2 --dry --out schema.sql
```

Also, one can now request the log independently of the `dry` mode to get an additional log:

```sh
cds deploy --to h2 --out schema.sql
```
