### PR TITLE
delete cds.env based config for doc comments

### DIFF
--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -2030,13 +2030,6 @@ In CAP Node.js, doc comments need to be switched on when calling the compiler:
 ```sh [CLI]
 cds compile foo.cds --docs
 ```
-```json [package.json]
-{
-  "cds" : {
-    "docs" : true // [!code focus]
-  }
-}
-```
 ```js [JavaScript]
 cds.compile(..., { docs: true })
 ```


### PR DESCRIPTION
- this was anyway wrong (instead "cds": { "cdsc": { "docs": true }})
- use `cds compile --docs` instead of globally enabling doc comments as this could easily blow up the size of all generated CSN and EDMX files