### PR TITLE
Add `cds add handler` docs

### DIFF
--- a/tools/cds-cli.md
+++ b/tools/cds-cli.md
@@ -127,6 +127,7 @@ COMMANDS
     <em>  | subscribe</em>  subscribe a tenant to a multitenant SaaS app
     <em>  | completion</em> add/remove shell completion for cds commands
     <em>  | mock</em>       call cds serve with mocked service
+    <em>  | handler</em>    add handler stubs for actions and functions
 
   Learn more about each command using:
   <em>cds help</em> &lt;command&gt; or
@@ -246,6 +247,7 @@ The facets built into `@sap/cds-dk` provide you with a large set of standard fea
 | `typer`                       |       <X/>       |      <Na/>       |
 | `typescript`                  |       <X/>       |      <Na/>       |
 | `completion`                  |       <X/>       |       <X/>       |
+| `handler`(#handler)           |       <Na/>      |       <X/>       |
 
 > <sup>1</sup> Only for Cloud Foundry <br>
 
@@ -412,6 +414,10 @@ assumes a remote app named `bookshop` on CloudFoundry and a JWT token for this a
 ::: details Cloud login required
 For CloudFoundry, use `cf login ...` and select org and space.
 :::
+
+#### handler <Since version="8.3.0" of="@sap/cds-dk" /> {.add}
+
+
 
 
 ## cds env

--- a/tools/cds-cli.md
+++ b/tools/cds-cli.md
@@ -417,7 +417,32 @@ For CloudFoundry, use `cf login ...` and select org and space.
 
 #### handler <Since version="8.3.0" of="@sap/cds-dk" /> {.add}
 
+Generates handler stubs for actions and functions in Java projects. 
 
+The simplest form of:
+
+```sh
+cds add handler
+```
+
+called from the `srv` directory of the project generates handler files for all actions and functions.
+
+
+#### Filtering {#handler-filtering}
+
+You can filter by the names of actions and functions. 
+
+```sh
+cds add handler --filter submitOrder
+```
+
+#### Other options
+
+The `--out` option for specifying custom output directories and the `--force` option for overwriting existing files are available as well.
+
+```sh
+cds add handler --out customFolder --force
+```
 
 
 ## cds env

--- a/tools/cds-cli.md
+++ b/tools/cds-cli.md
@@ -427,7 +427,6 @@ cds add handler
 
 called from the `srv` directory of the project generates handler files for all actions and functions.
 
-
 #### Filtering {#handler-filtering}
 
 You can filter by the names of actions and functions. 


### PR DESCRIPTION
For https://github.tools.sap/cap/cds-dk/pull/2944 and https://github.tools.sap/cap/cds-tools/issues/1333.
Currently, generating handlers for actions/functions only, for Java only.

[Release notes](https://github.tools.sap/cap/docs/pull/1060) 