### PR TITLE
docs(java): Fix link to "SAP Cloud ALM for Operations"

### DIFF
--- a/java/operating-applications/observability.md
+++ b/java/operating-applications/observability.md
@@ -235,7 +235,7 @@ SAP Cloud Logging is supported with [minimal configuration](#open-telemetry-conf
 
 - [Spring Boot Actuators](#spring-boot-actuators) can help operators to quickly get an overview about the general status of the application on a technical level.
 
-- [Availability](#availability) checks are offered by [SAP Cloud ALM for Operations](https://help.sap.com/docs/cloud-alml).
+- [Availability](#availability) checks are offered by [SAP Cloud ALM for Operations](https://help.sap.com/docs/cloud-alm).
 
 ### Open Telemetry { #open-telemetry }
 


### PR DESCRIPTION
The link had a trailing `l`.