### PR TITLE
docs(java): Re-phrase warning about privacy/compliance for audit log

### DIFF
--- a/java/auditlog.md
+++ b/java/auditlog.md
@@ -115,11 +115,11 @@ By default, not all events are send asynchronously via (persistent) outbox.
 * All other events are stored to persistent outbox, if available. The in-memory outbox acts as a fallback otherwise.
 
 
-::: warning _❗ Warning_
-* It is up to the application developer to make sure that audit log events stored in the persistent outbox don't violate given **compliances rules**.
-For instance, it might be appropriate not to persist audit log events triggered by users who have operator privileges. Such logs could be modified on DB level by the same user afterwards.
+::: warning _❗ Compliance & Data Privacy_
+* It is up to the application developer to make sure that audit log events stored in the persistent outbox don't violate given **compliance rules**.
+  For instance, it might be appropriate not to persist audit log events triggered by users who have operator privileges. Such logs could be modified on DB level by the same user afterward.
 * For technical reasons, the AuditLog service temporarily stores audit log events enhanced with personal data such as the request's _user_ and _tenant_.
-In case of persistent outbox, the application needs to do the necessary to comply with **data privacy rules**.
+  In case of persistent outbox, this needs to be handled individually by the application to comply with **data privacy rules**.
 :::
 
 ## AuditLog Handlers { #auditlog-handlers}


### PR DESCRIPTION
The warning box stated "do the necessary", which (to me) sounds as if there is an obvious and single way to adapt the application. However, it needs to be individually adapted for each application, so let's rephrase it.