### PR TITLE
docs(java): Mention that only _installed_ protocol adapters are enabled

### DIFF
--- a/java/cqn-services/application-services.md
+++ b/java/cqn-services/application-services.md
@@ -381,7 +381,7 @@ cds:
 
 With the annotation `@path`, you can configure the relative path of a service under which it's served by protocol adapters. The path is appended to the protocol adapter's base path.
 
-With the annotations `@protocol` or `@protocols`, you can configure a list of protocol adapters a service should be served by. By default, a service is served by all protocol adapters. If you explicitly define a protocol, the service is only served by that protocol adapter.
+With the annotations `@protocol` or `@protocols`, you can configure a list of protocol adapters a service should be served by. By default, a service is served by all installed protocol adapters. If you explicitly define a protocol, the service is only served by that protocol adapter.
 
 In the following example, the service `CatalogService` is available on the combined paths `/odata/v4/browse` with OData V4 and `/odata/v2/browse` with OData V2:
 


### PR DESCRIPTION
Be more specific: Not all protocol adapters that are part of CAP Java are enabled by default, but only those that are actually installed.