### PR TITLE
fix(odata): Fix `<Record>` example for `null` value

### DIFF
--- a/advanced/odata.md
+++ b/advanced/odata.md
@@ -336,18 +336,14 @@ Primitive annotation values, meaning Strings, Numbers, `true`, and `false` are m
 <Annotation Term="Some.String" String="foo"/>
 ```
 
-Rendering a `null` value must be done as dynamic expression:
+Rendering a `null` value must be done as dynamic expression or as an [annotation expression](#expression-annotations):
 
 ```cds
 @Some.Null: { $edmJson: { $Null } }
-```
-
-or as an [annotation expression](#expression-annotations):
-
-```cds
+// or
 @Some.Null: (null)
 ```
-
+Both result in the following:
 ```xml
 <Annotation Term="Some.Null">
   <Null/>

--- a/advanced/odata.md
+++ b/advanced/odata.md
@@ -360,7 +360,7 @@ Record-like source structures are mapped to `<Record>` nodes in EDMX, with primi
 
 ```cds
 @Some.Record: {
-  Null: null,
+  Null: { $edmJson: { $Null } },
   Boolean: true,
   Integer: 1,
   Number: 3.14,

--- a/advanced/odata.md
+++ b/advanced/odata.md
@@ -344,6 +344,12 @@ Rendering a `null` value must be done as dynamic expression:
 @Some.Null: { $edmJson: { $Null } }
 ```
 
+or as an [annotation expression](#expression-annotations):
+
+```cds
+@Some.Null: (null)
+```
+
 ```xml
 <Annotation Term="Some.Null">
   <Null/>
@@ -360,7 +366,7 @@ Record-like source structures are mapped to `<Record>` nodes in EDMX, with primi
 
 ```cds
 @Some.Record: {
-  Null: { $edmJson: { $Null } },
+  Null: (null),
   Boolean: true,
   Integer: 1,
   Number: 3.14,
@@ -1017,7 +1023,7 @@ The annotation is added to the OData API, as well as the mandatory reference to 
 </Annotations>
 ```
 
-The compiler neither evaluates the annotation values nor the URI.
+The compiler evaluates neither annotation values nor the URI.
 It is your responsibility to make the URI accessible if required.
 Unlike for the standard vocabularies listed above, the compiler has no access to the content of
 the vocabulary, so the values are translated completely generically.
@@ -1203,7 +1209,7 @@ The CAP Java SDK exposes all properties annotated with `@Semantics.currencyCode`
 * The property's value if it's unique within a group of dimensions
 * `null` otherwise
 
-A custom aggregate for a currency code or unit of measure should be also exposed by the `@Aggregation.CustomAggregate` annotation. Moreover, a property for a monetary amount or a measured quantity should be annotated with `@Semantics.amount.currencyCode` or `@Semantics.quantity.unitOfMeasure` to reference the corresponding property that holds the amount's currency code or the quantity's unit of measure, respectively.
+A custom aggregate for a currency code or unit of measure should also be exposed by the `@Aggregation.CustomAggregate` annotation. Moreover, a property for a monetary amount or a measured quantity should be annotated with `@Semantics.amount.currencyCode` or `@Semantics.quantity.unitOfMeasure` to reference the corresponding property that holds the amount's currency code or the quantity's unit of measure, respectively.
 
 ### Other Features
 


### PR DESCRIPTION
Due to annotation flattening, the value `null` would _not_ be rendered as `<Null/>` in OData EDMX.  Instead, as the section before that mentions, we need to use special `$edmJson` syntax or the new expression syntax `(null)`.

Tested with cds-compiler v5.3.2