### PR TITLE
style(odata): Use blockquote-style note for `@Some`, like other sections

### DIFF
--- a/advanced/odata.md
+++ b/advanced/odata.md
@@ -318,9 +318,7 @@ Note that there's no interpretation and no special handling for these qualifiers
 
 ### Primitives
 
-::: tip
-The `@Some` annotation isn't a valid term definition. The following example illustrates the rendering of primitive values.
-:::
+> Note: The `@Some` annotation isn't a valid term definition. The following example illustrates the rendering of primitive values.
 
 Primitive annotation values, meaning Strings, Numbers, `true`, and `false` are mapped to corresponding OData annotations as follows:
 


### PR DESCRIPTION
There are four notes about `@Some`, but only one uses the "tip" box style.  The others use the blockquote-style.