### PR TITLE
Avoid wording about 'lock-in to BTP'

### DIFF
--- a/node.js/authentication.md
+++ b/node.js/authentication.md
@@ -344,7 +344,7 @@ npm add @sap/xssec
 [See **XSUAA in Hybrid Setup** below for additional information of how to test this](#xsuaa-setup){.learn-more}
 
 ::: warning
-Only use this authentication kind if it's required for your use case, as it binds you to a specific authentication service on SAP BTP.  Adjustments might be necessary if you want to change to a different authentication service in the future.
+Only use this authentication kind if it's required for your use case, as it binds you to a specific authentication service on SAP BTP.  Adjustments might be necessary if you want to change to a different BTP authentication service in the future.
 :::
 
 

--- a/node.js/authentication.md
+++ b/node.js/authentication.md
@@ -344,7 +344,7 @@ npm add @sap/xssec
 [See **XSUAA in Hybrid Setup** below for additional information of how to test this](#xsuaa-setup){.learn-more}
 
 ::: warning
-It's recommended to only use this authentication kind if it's necessary for your use case, as it denotes a lock-in to SAP BTP.
+Only use this authentication kind if it's required for your use case, as it binds you to a specific authentication service on SAP BTP.  Adjustments might be necessary if you want to change to a different authentication service in the future.
 :::
 
 

--- a/node.js/authentication.md
+++ b/node.js/authentication.md
@@ -343,10 +343,6 @@ npm add @sap/xssec
 
 [See **XSUAA in Hybrid Setup** below for additional information of how to test this](#xsuaa-setup){.learn-more}
 
-::: warning
-Only use this authentication kind if it's required for your use case, as it binds you to a specific authentication service on SAP BTP.  Adjustments might be necessary if you want to change to a different BTP authentication service in the future.
-:::
-
 
 ### IAS-based Authentication { #ias }
 


### PR DESCRIPTION
The current language of a 'lock-in to SAP BTP' is unfortunate and could be misunderstood.  Make it a bit more neutral.