### PR TITLE
Align usage of different subqueries in title and sentences

### DIFF
--- a/java/working-with-cql/query-api.md
+++ b/java/working-with-cql/query-api.md
@@ -290,7 +290,7 @@ import static bookshop.Bookshop_.ORDERS;
 Select.from(ORDERS, o -> o.filter(o.ID().eq(23)).items());
 ```
 
-#### From `subquery` {#from-select}
+#### `FROM` Subquery {#from-select}
 
 It's also possible to execute a nested select where an _outer_ query operates on the result of a _subquery_.
 
@@ -1888,8 +1888,8 @@ Select.from(AUTHORS).where(a -> a.books().anyMatch(
 
 #### `EXISTS` Subquery {#exists-subquery}
 
-An `EXISTS` subquery is used to test if a subquery returns any records. Typically a subquery is correlated with the enclosing _outer_ query.
-You construct an `EXISTS` subquery with the [`exists`](https://javadoc.io/doc/com.sap.cds/cds4j-api/latest/com/sap/cds/ql/StructuredType.html#exists-java.util.function.Function-) method, which takes a [function](#lambda-expressions) that creates the subquery from a reference to the _outer_ query. To access elements of the outer query from within the subquery, this _outer_ reference must be used:
+An `exists` subquery is used to test if a subquery returns any records. Typically a subquery is correlated with the enclosing _outer_ query.
+You construct an `exists` subquery with the [`exists`](https://javadoc.io/doc/com.sap.cds/cds4j-api/latest/com/sap/cds/ql/StructuredType.html#exists-java.util.function.Function-) method, which takes a [function](#lambda-expressions) that creates the subquery from a reference to the _outer_ query. To access elements of the outer query from within the subquery, this _outer_ reference must be used:
 
 ```java
 import static bookshop.Bookshop_.AUTHORS;
@@ -1922,7 +1922,7 @@ Select.from("Authors").where(CQL.exists(subquery));
 
 ### `IN` Subquery
 
-An `IN` subquery is used to test if an element (or tuple of elements) of an outer query is contained in the result of a subquery. You can use an `IN` subquery in fluent style or in tree style:
+An `in` subquery is used to test if an element (or tuple of elements) of an outer query is contained in the result of a subquery. You can use an `in` subquery in fluent style or in tree style:
 
 ```java
 // fluent style


### PR DESCRIPTION
We are/were inconsistent in our usage. 
![image](https://github.com/user-attachments/assets/7d7a522e-dbc4-4747-aa98-b68a42ef9366)
vs.
![image](https://github.com/user-attachments/assets/18f95397-877f-4900-a328-482b5e27dba5)

Also in sentences we used a mix:
![image](https://github.com/user-attachments/assets/9441ce54-4728-41f7-a500-cf7078e8328d)

This PR tries to align those things as follows:
- Uppercase in titles
- Monospace on FROM etc and not on subquery
- Lowercase in sentences

