### PR TITLE
CDS glossary - remove 'and'

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -570,7 +570,7 @@ Business Object Patterns promote the notion of active objects, which provide ins
 - [**CAP**]() — Colloquial shorthand for "SAP Cloud Application Programming Model".
 Not an official product name, though.
 
-- [**CDS**](../cds/) — Core Data and Services
+- [**CDS**](../cds/) — Core Data Services
   : a family of languages, tools and libraries to declare, process and consume conceptual, semantically enriched data models.
 
 - [**CDL**](../cds/cdl) — CDS Definition Language


### PR DESCRIPTION
Hi @danjoa ,

this is the last/only occurrence of Core Data **and** Service in capire. As soon as we merge this, I'll also align our pages on the [Help Portal](https://help.sap.com/docs/btp/sap-business-technology-platform/developing-with-sap-cloud-application-programming-model?version=Cloud)