### PR TITLE
Add TypeScript section to troubleshooting guide

### DIFF
--- a/cds/aspects.md
+++ b/cds/aspects.md
@@ -169,7 +169,7 @@ abstract entity BusinessObject {
 
 ```cds
 aspect Changes {
-  operation : String enum { CREATED, MODIFIED, DELETED };
+  operation : String enum { CREATED; MODIFIED; DELETED };
   changedAt : DateTime;
   changedBy : User;
   diff : array of {
@@ -414,7 +414,7 @@ entity UsersAndGroups as (
   SELECT from Users
 ) UNION ALL (
   SELECT from Groups
-)
+);
 ```
 
 

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1138,14 +1138,8 @@ For an `@inner` annotation, only the syntax `@(...)` is available.
 Instead of interspersing annotations with definitions, you can also use the `annotate` directive to add annotations to existing definitions.
 
 ```cds
-annotate entity Foo with
-  @my.annotation:foo,
-  @another.one: 4711
-;
-```
-```cds
-annotate entity Foo with @(
-  my.annotation:foo,
+annotate Foo with @(
+  my.annotation: foo,
   another.one: 4711
 );
 ```

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1139,7 +1139,7 @@ Instead of interspersing annotations with definitions, you can also use the `ann
 
 ```cds
 annotate entity Foo with
-  @my.annotation:foo
+  @my.annotation:foo,
   @another.one: 4711
 ;
 ```

--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -206,7 +206,7 @@ npm i -D @cap-js/cds-types
 ```
 :::
 
-Installing `@cap-js/cds-types` leverages vscode's automatic type resolution mechanism by symlinking the package in `node_modules/@types/sap__cds` in a postinstall script. If you find that this symlink is missing, try `npm rebuild` to trigger the postinstall script again.
+Installing `@cap-js/cds-types` leverages VS Code's automatic type resolution mechanism by symlinking the package in `node_modules/@types/sap__cds` in a postinstall script. If you find that this symlink is missing, try `npm rebuild` to trigger the postinstall script again.
 
 If the symlink still does not persist, you can explicitly point the type resolution mechanism to `@cap-js/cds-types` in your _tsconfig.json_: 
 

--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -191,6 +191,36 @@ module.exports = cds.server
 | _Root Cause_ | The destination, the remote system or the request details are not configured correctly.
 | _Solution_ | To further troubleshoot the root cause, you can enable logging with environment variables `SAP_CLOUD_SDK_LOG_LEVEL=silly` and `DEBUG=remote`.
 
+## TypeScript
+
+### Type definitions for `@sap/cds` not found or incomplete
+
+The type definitions for `@sap/cds` are maintained in a separate package `@cap-js/cds-types` and have to be explicitly installed as a dev dependency. This can be done by adding the `typescript` facet:
+
+::: code-group
+```sh [facet]
+cds add typescript
+```
+```sh [manually]
+npm i -D @cap-js/cds-types
+```
+:::
+
+Installing `@cap-js/cds-types` leverages vscode's automatic type resolution mechanism by symlinking the package in `node_modules/@types/sap__cds` in a postinstall script. If you find that this symlink is missing, try `npm rebuild` to trigger the postinstall script again.
+
+If the symlink still does not persist, you can explicitly point the type resolution mechanism to `@cap-js/cds-types` in your _tsconfig.json_: 
+
+::: code-group
+```json [tsconfig.json]
+{
+  "compilerOptions": {
+    "types": ["@cap-js/cds-types"],
+  }
+}
+```
+:::
+
+If you find that the types are still incomplete, open a bug report in [the `@cap-js/cds-types` repository](https://github.com/cap-js/cds-types/issues/new/choose).
 
 ## Java
 

--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -215,6 +215,8 @@ npm i -D @cap-js/cds-types
 ```
 :::
 
+#### Fix missing symlink
+
 Installing `@cap-js/cds-types` leverages VS Code's automatic type resolution mechanism by symlinking the package in `node_modules/@types/sap__cds` in a postinstall script. If you find that this symlink is missing, try `npm rebuild` to trigger the postinstall script again.
 
 If the symlink still does not persist, you can explicitly point the type resolution mechanism to `@cap-js/cds-types` in your _tsconfig.json_: 

--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -195,6 +195,15 @@ module.exports = cds.server
 
 ### Type definitions for `@sap/cds` not found or incomplete
 
+|                | Explanation                                                           |
+|----------------|-----------------------------------------------------------------------|
+| _Root Cause 1_ | The package `@cap-js/cds-typer` is not installed.                     |
+| _Solution 1_   | Install the package as a dev dependency.                              |
+| _Root Cause 2_ | Symlink is missing.                                                   |
+| _Solution 2_   | Try `npm rebuild` or add `@cap-js/cds-types` in your _tsconfig.json_. |
+
+
+#### Install package as dev dependency
 The type definitions for `@sap/cds` are maintained in a separate package `@cap-js/cds-types` and have to be explicitly installed as a dev dependency. This can be done by adding the `typescript` facet:
 
 ::: code-group


### PR DESCRIPTION
This PR adds a section in the troubleshooting guide for TypeScript, starting with one frequent complaint that arose since the release of CDS8.