### PR TITLE
Add migration plugin-name to hdiconfig

### DIFF
--- a/guides/databases-hana.md
+++ b/guides/databases-hana.md
@@ -449,6 +449,8 @@ Direct migration from _.hdbcds_ to _.hdbmigrationtable_ isn't supported by HDI. 
 [Learn more in the **Enhance Project Configuration for SAP HANA Cloud** section.](#configure-hana){.learn-more}
 
 During the transition from _.hdbtable_ to _.hdbmigrationtable_ you have to deploy version=1 of the _.hdbmigrationtable_ artifact, which must not include any migration steps.
+
+Ensure to add `"hdbmigrationtable": { "plugin_name": "com.sap.hana.di.table.migration" }` to your `.hdiconfig` file.
 :::
 
 HDI supports the _hdbcds → hdbtable → hdbmigrationtable_ migration flow without data loss. Even going back from _.hdbmigrationtable_ to _.hdbtable_ is possible. Keep in mind that you lose the migration history in this case.


### PR DESCRIPTION
add plugin-name to `.hdiconfig` for migration

Without this, the migration will not work and deployment will show the following error:
`Error: "src/.hdiconfig": Configuration does not define a build plugin for file suffix "hdbmigrationtable"`

For me it was hard to find this information and I think it is missing in the documentation.