### PR TITLE
Auth explanation request

### DIFF
--- a/node.js/authentication.md
+++ b/node.js/authentication.md
@@ -18,6 +18,9 @@ uacp: This page is linked from the Help Portal at https://help.sap.com/products/
 [user]: #cds-user
 [`req.user`]: #cds-user
 
+afaik we cannot (or should not) use req.user any more. Instead we use cds.context.user in the middleware now. 
+We need some explanation on the different users here. Today I had to debug and identify an anonymous user. This is not documented yet, so please elaborte here or somewhere else.
+
 Represents the currently logged-in user as filled into [`req.user`](events#user) by authentication middlewares.
 Simply create instances of `cds.User` or of subclasses thereof in custom middlewares.
 For example:


### PR DESCRIPTION
This is unfinished text, so please do not merge.

When migrating to CDSv8 (from 7) we did have a few issues, especially on middleware related to the user.

Please update your documentation, it is missing these points currently afaik.

> We cannot (or should not) use `req.user` any more. Instead we use `cds.context.user` in the middleware now. 
> We need some explanation on the different users here. Today I had to debug and identify an anonymous user. This is not documented yet, so please elaborate here or somewhere else.