### PR TITLE
Suggest `url` instead of `database` for `cds.requires.db.credentials`

### DIFF
--- a/node.js/cds-connect.md
+++ b/node.js/cds-connect.md
@@ -637,7 +637,7 @@ One prominent exception of that, which you would frequently add to your _package
       "[development]": {
         "kind": "sqlite",
         "credentials": {
-          "database": "db/bookshop.db"
+          "url": "db/bookshop.db"
         }
       }
     }
@@ -694,7 +694,7 @@ The latter is appropriate in test suites. In productive code, you never provide 
     },
     "db": {
       "credentials": {
-        "database": "sqlite.db"
+        "url": "sqlite.db"
       }
     }
   }

--- a/node.js/cds-connect.md
+++ b/node.js/cds-connect.md
@@ -637,7 +637,7 @@ One prominent exception of that, which you would frequently add to your _package
       "[development]": {
         "kind": "sqlite",
         "credentials": {
-          "url": "db/bookshop.db"
+          "url": "db/bookshop.sqlite"
         }
       }
     }
@@ -694,7 +694,7 @@ The latter is appropriate in test suites. In productive code, you never provide 
     },
     "db": {
       "credentials": {
-        "url": "sqlite.db"
+        "url": "db.sqlite"
       }
     }
   }

--- a/node.js/cds-env.md
+++ b/node.js/cds-env.md
@@ -105,7 +105,7 @@ For example, given the following sources:
     "db": {
       "kind": "sql",
       "model": "./db",
-      "credentials": { "database": ":memory:" }
+      "credentials": { "url": ":memory:" }
     }
   }
 }


### PR DESCRIPTION
Having looked at our impl + history I'm fairly sure `cds.requires.db.credentials.database` is outdated and shouldn't be recommended any more.

It's even used with different semantics in Postgres, where this field ist just `"postgres"`, not a DB URL:
https://github.com/cap-js/cds-dbs/blob/d7920ec3ceeb3a40d923bb1d40a93bc38e68bd23/postgres/package.json#L56

Imo we could also close cap/issues#13994 with this one.