### PR TITLE
Improve change tracking docu

### DIFF
--- a/java/change-tracking.md
+++ b/java/change-tracking.md
@@ -19,7 +19,7 @@ to the remote services aren't tracked.
 
 ## Enabling Change Tracking
 
-To use the change tracking feature, you need to add a dependency to [cds-feature-change-tracking](https://central.sonatype.com/artifact/com.sap.cds/cds-feature-change-tracking) in the `pom.xml` file of your service:
+To use the change tracking feature, you need to add a dependency to [cds-feature-change-tracking](https://central.sonatype.com/artifact/com.sap.cds/cds-feature-change-tracking) in the `srv/pom.xml` file of your service:
 
 ```xml
 <dependency>


### PR DESCRIPTION
Stakeholder created an internal issue because change tracking feature was not working. He added the maven dependency in the root `pom.xml` instead of the `pom.xml` of the srv module. This PR is making the docs more concrete.