### PR TITLE
fix many-to-many self reference

### DIFF
--- a/guides/domain-modeling.md
+++ b/guides/domain-modeling.md
@@ -523,7 +523,7 @@ entity Projects { ...
   members : Composition of many { key user : Association to Users };
 }
 entity Users { ...
-  projects : Composition of many Projects.members on projects.member = $self;
+  projects : Composition of many Projects.members on projects.user = $self;
 }
 ```
 


### PR DESCRIPTION
`projects.member` does not exist, instead the key `projects.user` needs to be used