### PR TITLE
Troubleshooting: add header with error message to existing entry

### DIFF
--- a/advanced/hybrid-testing.md
+++ b/advanced/hybrid-testing.md
@@ -30,7 +30,7 @@ If no service key for your service `<srv>` is specified, a `<srv>-key` is automa
 The service name `db` can be omitted as it represents the default value for the service kind `hana`.
 :::
 
-[Got errors? See our troubleshooting for connection issues with SAP HANA Cloud.](../get-started/troubleshooting#connection-failed-89008){.learn-more}
+[Got errors? See our troubleshooting for connection issues with SAP HANA Cloud.](../get-started/troubleshooting#deployment-fails--connection-failed-rte89008-socket-closed-by-peer){.learn-more}
 
 Output:
 

--- a/advanced/hybrid-testing.md
+++ b/advanced/hybrid-testing.md
@@ -30,7 +30,7 @@ If no service key for your service `<srv>` is specified, a `<srv>-key` is automa
 The service name `db` can be omitted as it represents the default value for the service kind `hana`.
 :::
 
-[Got errors? See our troubleshooting for connection issues with SAP HANA Cloud.](../get-started/troubleshooting#deployment-fails--connection-failed-rte89008-socket-closed-by-peer){.learn-more}
+[Got errors? See our troubleshooting for connection issues with SAP HANA Cloud.](../get-started/troubleshooting#connection-failed-89008){.learn-more}
 
 Output:
 

--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -492,8 +492,7 @@ Options in [Saas Provisioning Service upgrade API](../guides/multitenancy/mtxs#e
 
 #### Deployment fails — _Connection failed (RTE:[89008] Socket closed by peer_
 
-#### Hybrid testing connectivity issue — _ResourceRequest timed out_
-
+#### Hybrid testing connectivity issue — _ResourceRequest timed out_ {style="margin-top: 0;"}
 
 |  | Explanation |
 | --- | ---- |

--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -489,7 +489,11 @@ Options in [Saas Provisioning Service upgrade API](../guides/multitenancy/mtxs#e
 | _Root Cause_ | Your configuration isn't properly set. |
 | _Solution_ | Configure your project as described in [Using Databases](../guides/databases).
 
-#### Deployment fails — _Connection failed (RTE:[89008] Socket closed by peer_ {#connection-failed-89008}
+
+#### Deployment fails — _Connection failed (RTE:[89008] Socket closed by peer_ {.method}
+
+#### Hybrid testing connectivity issue — _ResourceRequest timed out_ {.method}
+
 
 |  | Explanation |
 | --- | ---- |

--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -490,7 +490,7 @@ Options in [Saas Provisioning Service upgrade API](../guides/multitenancy/mtxs#e
 | _Solution_ | Configure your project as described in [Using Databases](../guides/databases).
 
 
-#### Deployment fails — _Connection failed (RTE:[89008] Socket closed by peer_
+#### Deployment fails — _Connection failed (RTE:[89008] Socket closed by peer_ {#connection-failed-89008}
 
 #### Hybrid testing connectivity issue — _ResourceRequest timed out_ {style="margin-top: 0;"}
 

--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -490,9 +490,9 @@ Options in [Saas Provisioning Service upgrade API](../guides/multitenancy/mtxs#e
 | _Solution_ | Configure your project as described in [Using Databases](../guides/databases).
 
 
-#### Deployment fails — _Connection failed (RTE:[89008] Socket closed by peer_ {.method}
+#### Deployment fails — _Connection failed (RTE:[89008] Socket closed by peer_
 
-#### Hybrid testing connectivity issue — _ResourceRequest timed out_ {.method}
+#### Hybrid testing connectivity issue — _ResourceRequest timed out_
 
 
 |  | Explanation |


### PR DESCRIPTION
Closes: https://github.com/cap-js/docs/issues/1583

As we do have already a solution to this new problem, I wanted to add a header with the error message to the existing content. Similar to:
![image](https://github.com/user-attachments/assets/8fcea15c-3e18-469a-a947-4687400ef7e4)

But when trying that, it didn't work. I added the method class (`{.method}`) just to test, and found that this works. Using any other class, like `{.class}` or `{.annotation}` didn't work.

@swaldmann @chgeo Do you have any idea why?