### PR TITLE
Add details to cds ql and improve db migration guide

### DIFF
--- a/guides/databases-sqlite.md
+++ b/guides/databases-sqlite.md
@@ -631,6 +631,8 @@ This is a breaking change in regard to the previous implementation.
 ### Miscellaneous {.node}
 
 - Only `$now` and `$user` are supported as values for `@cds.on.insert/update`.
+- Managed fields are automatically filled with `INSERT.entries()`, but not when using `INSERT.columns().values()` or `INSERT.columns().rows()`.
+- If the column of a `SELECT` is a path expression without alias, the field name in the result is prefixed according to the path expression. For example, `SELECT.from(Books).columns('author.name')` results in `author_name`.
 - CQNs with subqueries require table aliases to refer to elements of outer queries.
 - Table aliases must not contain dots.
 - CQNs with an empty columns array now throw an error.

--- a/guides/databases.md
+++ b/guides/databases.md
@@ -22,6 +22,10 @@ impl-variants: true
 
 <div markdown="1" class="impl node">
 
+### Migrating to New Database Services?  {.node}
+
+With cds 8, the new database services for SQLite, PostgresSQL and SAP HANA became generally available, and it is highly recommended to migrate. You can find instructions in the [migration guide](../databases-sqlite#migration). While it is written in the context of the new SQLite Service, the same hints apply to PostgresSQL and SAP HANA.
+
 ### Adding Database Packages  {.node}
 
 Following are cds-plugin packages for CAP Node.js runtime that support respective databases:

--- a/node.js/cds-ql.md
+++ b/node.js/cds-ql.md
@@ -499,7 +499,7 @@ Projection functions use these mechanisms:
 
 **Note:** Not every CQL or SQL construct can be expressed with projection functions. This is where tagged template strings kick in
 
-
+The result set returned by `SELECT.columns` is an array of objects reflecting the requested columns. Columns specified with a path expression (and without an alias) result in a field which is prefixed according to the path. For example, `author.name` results in a field named `author_name`.
 
 ### from() {.method #select-from}
 
@@ -785,7 +785,7 @@ INSERT.into(Books).entries(await SELECT.from(Products))
 
 :::
 
-
+>  With `.entries`, [managed](../cds/common#aspect-managed) fields are automatically filled if these fields are not provided.
 
 ### values() {.method alt="The following documentation on rows also applies to values. "}
 
@@ -815,6 +815,9 @@ INSERT.into (Books) .columns (
    [ 252, 'Eleonora', 150, 234 ]
 )
 ```
+
+>  When using `.columns` with `.values` or `.rows`, [managed](../cds/common#aspect-managed) fields are **not** automatically filled if these fields are not provided. This is different from using `.entries`.
+
 ### from() {.method #from}
 
 
@@ -822,6 +825,9 @@ Constructs a _INSERT into SELECT_ statement.
 ```js
 INSERT.into('Bar') .from (SELECT.from('Foo'))
 ```
+
+>  [Managed](../cds/common#aspect-managed) fields are **not** automatically updated or filled if these fields are not provided.
+
 ### as() {.method}
 
 The use of _.as()_ method is deprecated. Please use [_.from()_](#from) method instead.


### PR DESCRIPTION
Based on customer's feedback I propose to clarify the following points:
- different behaviour of `INSERT.entries` / `INSERT.columns` / `INSERT.from` with regard to managed fields
- field names returned for SELECT columns with path expression
- SQLite migration guide also relevant for HANA