### PR TITLE
Changed database file name for application.yaml CAP Java

### DIFF
--- a/guides/databases-sqlite.md
+++ b/guides/databases-sqlite.md
@@ -238,7 +238,7 @@ Finally, configure the DB connection - ideally in a dedicated `sqlite` profile:
 spring:
   config.activate.on-profile: sqlite
   datasource:
-    url: "jdbc:sqlite:sqlite.db"
+    url: "jdbc:sqlite:db.sqlite"
     driver-class-name: org.sqlite.JDBC
     hikari:
       maximum-pool-size: 1


### PR DESCRIPTION
PR for issue #1635

Fixes inconsistent database naming schema for persistent .sqlite databases in CAP java projects.