### PR TITLE
perf: Adjust good order by example for correct SQL generation

### DIFF
--- a/advanced/performance-modeling.md
+++ b/advanced/performance-modeling.md
@@ -207,9 +207,10 @@ GET http://localhost/odata/OrderItemsViewAssoc?$expand=Items&$select=OrderNo,Ite
 First sort on the `OrdersItems` and then join back to the `OrdersHeaders` with the help of an association:
 
 ```cds
-view SortedOrdersAssoc as select
-from OrdersItems {*, Header.OrderNo, Header.buyer, Header.currency }
-order by OrdersItems.title;
+view SortedOrdersAssoc as select {*, Header.OrderNo, Header.buyer, Header.currency } as Flatten 
+from (
+  from OrdersItems {*} order by OrdersItems.title
+);
 ```
 
 #### **Bad**{.bad}

--- a/advanced/performance-modeling.md
+++ b/advanced/performance-modeling.md
@@ -209,7 +209,7 @@ First sort on the `OrdersItems` and then join back to the `OrdersHeaders` with t
 ```cds
 view SortedOrdersAssoc as select {*, Header.OrderNo, Header.buyer, Header.currency } as Flatten 
 from (
-  from OrdersItems {*} order by OrdersItems.title
+  select from OrdersItems {*} order by OrdersItems.title
 );
 ```
 
@@ -240,9 +240,11 @@ Basically, what is true for [Sorting](#sorting) is also valid for filtering.
 #### **Good**{.good}
 
 ```cds
-view FilteredOrdersAssoc as select
-from OrdersItems {*, Header.OrderNo, Header.buyer, Header.currency }
-where OrdersItems.price > 100;
+view FilteredOrdersAssoc as select {*, Header.OrderNo, Header.buyer, Header.currency } as Flatten
+from (
+  select from OrdersItems {*}
+  where OrdersItems.price > 100
+);
 ```
 
 #### **Bad**{.bad}
@@ -261,7 +263,7 @@ view FilteredOrdersJoin as select
 from OrdersHeaders JOIN OrdersItems on OrdersHeaders.ID = OrdersItems.Header.ID
 where price > 100;
 ```
-This query cannot utilize database indexes properly.
+This query has to identify that price can be filtered before the join. Which can cause the full join to be materialized before filtered back down to a smaller subset again.
 
 ## Calculated Fields
 Database operations on calculated fields cannot leverage any DB indexes.  This impacts performance significantly, as calculated fields cause full table scans.


### PR DESCRIPTION
When reviewing the performance modeling guide found the following identically problematic modeling.

## Sorting

To show the difference I reproduced it inside `sflight` to have the ability to generate the actual SQL.

```cds
entity CapireExample as select 
from my.Booking {BookingUUID, to_Travel.TravelID}
order by BookingUUID ASC;

entity FixedExample as 
select {*, to_Travel.TravelID} as Outer from (
  select from my.Booking {BookingUUID,to_Travel } order by BookingUUID ASC
);
```

Which each generate the following SQL view definitions:

```sql
CREATE VIEW CapireExample AS
SELECT
  Booking_0.BookingUUID,
  to_Travel_1.TravelID
FROM
  (
    sap_fe_cap_travel_Booking AS Booking_0
    LEFT JOIN sap_fe_cap_travel_Travel AS to_Travel_1 ON Booking_0.to_Travel_TravelUUID = to_Travel_1.TravelUUID
  )
ORDER BY
  BookingUUID ASC;

CREATE VIEW FixedExample AS
SELECT
  __select_2___0.BookingUUID AS Outer_BookingUUID,
  __select_2___0.to_Travel_TravelUUID AS Outer_to_Travel_TravelUUID,
  to_Travel_2.TravelID AS Outer_TravelID
FROM
  (
    (
      SELECT
        Booking_1.BookingUUID,
        Booking_1.to_Travel_TravelUUID
      FROM
        sap_fe_cap_travel_Booking AS Booking_1
      ORDER BY
        BookingUUID ASC
    ) AS __select_2___0
    LEFT JOIN sap_fe_cap_travel_Travel AS to_Travel_2 ON __select_2___0.to_Travel_TravelUUID = to_Travel_2.TravelUUID
  );
```

By having the `ORDER BY` inside the sub select of the underlying entity there is no requirement for the execution plan to identify `SORT_THRU_JOIN` optimization when the entity is being queried with a `LIMIT` clause.

## Filter

As the documentation points out the same basically applies to `WHERE` clauses as well, but here it becomes more important as it has a direct impact on the result set size. By removing the ambiguity of the `WHERE` clause being able to be pushed down it removes the **potential** that the `FILTER_TRU_JOIN` optimization is not correctly identified by the optimizer. This becomes especially important when multiple `associations` are being flattened and translated into multiple `JOIN` clauses. As it becomes more difficult for the optimizer to identify when to apply which subset of the `WHERE` clause onto which level of the `JOIN` sources. 

Additionally it is not clear which `association` is flattened at what point by the compiler. Which can make it nearly impossible for the more complex `JOIN` optimization rules to be applied to the query. As the cardinality of the joins becomes important to determine whether it is possible to re order the joins. Which can mean that while the `WHERE` clauses references a source column and a flattened column. Just because the flattened column is flattened by the last `JOIN` clause all intermediate joins might be applied before the `WHERE` clause.

Most of these issue don't show when using `HANA`, but when using `Postgres` these optimization rules stop much earlier to ensure functional correctness. Additionally it is important that `HANA` only has `1000` optimization tries that involve re writing `JOIN` clauses. So when the total `view` + `query` complexity has multiple `JOIN`, `WHERE` and `LIMIT` clauses the number of potential solutions grows exponentially and will quickly go over the `1000` prediction attempts.

```cds
entity FilterCapireExample as select 
from my.Booking {BookingUUID, to_Travel.TravelID}
where FlightPrice > 10;

entity FilterFixedExample as 
select {*, to_Travel.TravelID} as Outer from (
  select from my.Booking {BookingUUID,to_Travel } where FlightPrice > 10
);
```
