### PR TITLE
add hints for hybrid testing

### DIFF
--- a/advanced/hybrid-testing.md
+++ b/advanced/hybrid-testing.md
@@ -142,6 +142,10 @@ Only services that have the `shareable` flag in the metadata set to `true` can b
 See the [CloudFoundry docs](https://docs.cloudfoundry.org/devguide/services/sharing-instances.html) for further details.
 :::
 
+::: tip Allow dynamic deploy targets
+Service bindings created by `cds bind` contain the Cloud Foundry API endpoint, org, and space. You can allow your services to connect to the currently targeted Cloud Foundry org and space by removing these properties from the binding structure.
+:::
+
 ### Services on Kubernetes
 
 
@@ -522,36 +526,25 @@ No credentials are saved!
 In your CI/CD pipeline you can resolve the bindings and inject them into the test commands:
 
 ```sh
-# Install DK for "cds env"
-npm i @sap/cds-dk --no-save
-
 # Login
 cf auth $USER $PASSWORD
-
-## Uncomment if your service bindings have
-## no "org" and "space" set (see note below)
-# cf target -o $ORG -s $SPACE
+# Optional if your bindings have org and space removed to be agnostic
+cf target -o $ORG -s $SPACE
 
 # Set profile
-export CDS_ENV=integration-test
-# Set resolved bindings
-export cds_requires="$(cds env get requires --resolve-bindings)"
+export CDS_ENV=integration-test  # [!code highlight]
 
-# Execute test
-npm run integration-test
+# Set resolved bindings
+export cds_requires="$(cds env get requires --resolve-bindings)"  # [!code highlight]
+
+# Run tests
+npm run integration-test  # [!code highlight]
 ```
 
-:::tip Use `cds.test`
-Besides using integration tests, the same applies to hybrid testing using [`cds.test`](../node.js/cds-test).
+Some comments to the previous snippet:
+- With `CDS_ENV` you specify the [configuration profile](../node.js/cds-env#profiles) for the test, where you previously put the service binding configuration.
+- [`cds env get requires`](../node.js/cds-env#services) prints the `requires` section of the configuration as a JSON string. Through `--resolve-bindings`, it includes the credentials of the service bindings from the cloud. To make the credentials available for all subsequent `cds` commands and the tests, the `requires` JSON string is put into the `cds_requires` script variable.
+- In `npm run integration-test` any test code can run, for example, [`cds.test`](../node.js/cds-test).
 
-:::
 
 <!-- TODO: "cds deploy" should take the existing bindings for hana -->
-
-With `CDS_ENV`, you specify the configuration profile for the test, where you previously put the service binding configuration.
-
-`cds env get requires` prints the `requires` section of the configuration as a JSON string. By adding the `--resolve-bindings` option, it includes the credentials of the service bindings from the cloud. To make the credentials available for all subsequent `cds` commands and the tests, the `requires` JSON string is put into the `cds_requires` variable.
-
-::: tip Allow dynamic deploy targets
-Service bindings created by `cds bind` contain the Cloud Foundry API endpoint, org, and space. You can allow your services to connect to the currently targeted Cloud Foundry org and space by removing these properties from the binding structure.
-:::

--- a/advanced/hybrid-testing.md
+++ b/advanced/hybrid-testing.md
@@ -541,6 +541,11 @@ export cds_requires="$(cds env get requires --resolve-bindings)"
 npm run integration-test
 ```
 
+:::tip Use `cds.test`
+Besides using integration tests, the same applies to hybrid testing using [`cds.test`](../node.js/cds-test).
+
+:::
+
 <!-- TODO: "cds deploy" should take the existing bindings for hana -->
 
 With `CDS_ENV`, you specify the configuration profile for the test, where you previously put the service binding configuration.

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -524,6 +524,12 @@ We recommended to switch on `CDS_TEST_ENV_CHECK` in all your tests to detect suc
 
 ## Best Practices
 
+### Integration Tests - Hybrid Testing
+
+When writing integration tests, it's important to keep them clean and focused. Remember, your environment setup shouldn't be part of the test code itself. Instead, ensure that your testing framework or CI/CD pipeline handles environment configuration. This way, your tests remain isolated and reproducible across different setups. This approach helps maintain the clarity and reliability of your integration tests.
+
+[Learn how to resolve bindings in the environment.](../advanced/hybrid-testing#integration-tests){.learn-more}
+
 ### Check Status Codes Last
 
 Avoid checking for single status codes. Instead, simply check the response data:

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -574,7 +574,7 @@ describe(() => { cds.test(...) })
 ```
 :::
 
-[Learn how setup integration tests with `cds bind`.](../advanced/hybrid-testing#integration-tests){.learn-more}
+[Learn how to setup integration tests with `cds bind`.](../advanced/hybrid-testing#integration-tests){.learn-more}
 
 
 ## Using `cds.test` in REPL

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -133,7 +133,7 @@ Run them with `npm run jest` or with `npm run mocha`.
 _jest_ helpers might cause conflicts with the generic implementation of `@sap/cds`.
 
 To avoid such conflicts, do not use the following helpers:
-- _jest.resetModules_ as it leaves the server in an inconsistent state. 
+- _jest.resetModules_ as it leaves the server in an inconsistent state.
 - _jest.useFakeTimers_ as it intercepts the server shutdown causing test timeouts.
 :::
 
@@ -524,12 +524,6 @@ We recommended to switch on `CDS_TEST_ENV_CHECK` in all your tests to detect suc
 
 ## Best Practices
 
-### Integration Tests - Hybrid Testing
-
-When writing integration tests, it's important to keep them clean and focused. Remember, your environment setup shouldn't be part of the test code itself. Instead, ensure that your testing framework or CI/CD pipeline handles environment configuration. This way, your tests remain isolated and reproducible across different setups. This approach helps maintain the clarity and reliability of your integration tests.
-
-[Learn how to resolve bindings in the environment.](../advanced/hybrid-testing#integration-tests){.learn-more}
-
 ### Check Status Codes Last
 
 Avoid checking for single status codes. Instead, simply check the response data:
@@ -567,6 +561,20 @@ await expect(POST(`/catalog/Books`,...)).to.be.rejectedWith(
 )
 ```
 
+### Keep Test Code Environment Agnostic
+
+Environment setup shouldn't be part of the test code itself. That should be handled by setup scripts like CI/CD pipelines.
+This way, your tests remain isolated and reproducible across different setups.
+
+::: code-group
+```js [my.test.js]
+// NO service bindings, env. variables, profiles, etc. here
+// Do this outside in setup scripts etc.
+describe(() => { cds.test(...) })
+```
+:::
+
+[Learn how setup integration tests with `cds bind`.](../advanced/hybrid-testing#integration-tests){.learn-more}
 
 
 ## Using `cds.test` in REPL


### PR DESCRIPTION
Triggered by user feedback:

> [node/test](https://pages.github.tools.sap/cap/docs/node.js/cds-test): There's no info on how to run this with hybrid testing. this doesnt work in a test cds.test("serve", '--profile', 'hybrid', '--resolve-bindi