### PR TITLE
Fix code highlights

### DIFF
--- a/tools/cds-lint/components/PlaygroundBadge.vue
+++ b/tools/cds-lint/components/PlaygroundBadge.vue
@@ -74,7 +74,7 @@ function link(name: Props['name'] = "", kind: Props['kind'], rules?: Props['rule
   if (files) {
     for (const file of files) {
       sources[file] = data[`${name}/${kind}/${file}`]
-        ?.replace(/\/\/\s*\[!code.*?\]/g, ''); // remove Vitepress code comments
+        ?.replace(/\/?\/?\s*\[!code.*?\]/g, ''); // remove Vitepress code comments
     }
   }
   return `https://eslint-online-playground.netlify.app/#${compress(sources)}`

--- a/tools/cds-lint/examples/no-dollar-prefixed-names/incorrect/db/schema.cds
+++ b/tools/cds-lint/examples/no-dollar-prefixed-names/incorrect/db/schema.cds
@@ -4,7 +4,7 @@ entity Books {
   key ID : Integer;
   @mandatory title  : localized String(111);
   @mandatory author : Association to Authors;
-  $pages: Integer; // [!code error] // elements should not start with a dollar sign ($)
+  $pages: Integer; // elements should not start with a dollar sign ($) [!code error]
 }
 
 entity Authors {

--- a/tools/cds-lint/examples/valid-csv-header/incorrect/db/data/sap.capire.bookshop-Books.csv
+++ b/tools/cds-lint/examples/valid-csv-header/incorrect/db/data/sap.capire.bookshop-Books.csv
@@ -1,3 +1,3 @@
-ID;tile;author_ID // [!code warning]
+ID;tile;author_ID
 201;Wuthering Heights;101
 207;Jane Eyre;107

--- a/tools/cds-lint/rules/valid-csv-header.md
+++ b/tools/cds-lint/rules/valid-csv-header.md
@@ -43,7 +43,7 @@ The following example shows a correct CSV file header that matches the column na
 In the next example, there's a typo in the header of the CSV file. The column name `title` is misspelled as `tile`, so the rule reports a warning:
 
 ::: code-group
-<<< ../examples/valid-csv-header/incorrect/db/data/sap.capire.bookshop-Books.csv#snippet{csv:line-numbers} [db/data/sap.capire.bookshop-Books.csv]
+<<< ../examples/valid-csv-header/incorrect/db/data/sap.capire.bookshop-Books.csv#snippet{csv:line-numbers{1}} [db/data/sap.capire.bookshop-Books.csv]
 :::
 <PlaygroundBadge
   name="valid-csv-header"


### PR DESCRIPTION
As an aftermath of the changes in #1661, fix code highlights that contain an additional comment on the same line.

Also put the `[!code...]` block at end of the line, so that the actual comment gets displayed more naturally.

For the included `csv` file, use a `{line}` highlight as there is no way anymore for an inline `[!code]` comment (as csv files don't have naturall comment characters).