### PR TITLE
Auto-dark support for videos

### DIFF
--- a/.vitepress/theme/styles.scss
+++ b/.vitepress/theme/styles.scss
@@ -57,7 +57,8 @@
     --vp-c-text-1: rgba(255, 255, 245, 0.86);
 
     /* brightness fine-tuned to turn #fff into --vp-c-bg */
-    img, svg.adapt-dark {
+    img, svg.adapt-dark,
+    video.bright { // assuming videos are usually dark, only darken them if marked as bright
       filter: brightness(.884) invert(1) hue-rotate(177deg)
     }
     img.mute-dark {


### PR DESCRIPTION
Allow videos to go dark if annotated with `bright`.

This assumes the current situation that nearly all videos are dark. So instead of annotating all of them with `ignore-dark`, use a `bright` class.

See the March release notes for an example.