### PR TITLE
Remove `cds.watch` documentation

### DIFF
--- a/tools/cds-cli.md
+++ b/tools/cds-cli.md
@@ -486,9 +486,6 @@ Additional watched or ignored paths can be specified via CLI options:
 cds watch --include ../other-app --exclude .idea/
 ```
 
-Alternatively, you can add these paths through settings <Config keyOnly>cds.watch.include: ["../other-app"]</Config> and <Config keyOnly>cds.watch.exclude: [".idea"]</Config> to your project configuration.
-
-
 ## cds repl
 
 Use `cds repl` to live-interact with cds' JavaScript APIs in an interactive read-eval-print-loop.


### PR DESCRIPTION
A requested by Daniel we'll only allow the CLI options, but not the CDS config.