### PR TITLE
Update typescript.md: add global installation of tsx earlier

### DIFF
--- a/node.js/typescript.md
+++ b/node.js/typescript.md
@@ -17,7 +17,7 @@ Follow these steps to add TypeScript support:
 1. Install typescript packages globally:
 
     ```sh
-    npm i -g typescript ts-node
+    npm i -g typescript ts-node tsx
     ```
 
 2. Add a basic _tsconfig.json_ file to your project:


### PR DESCRIPTION
Following the documentation of setting up TypeScript, I ran into the following issue:

```
$ cds watch

cds serve all --with-mocks --in-memory?
live reload enabled for browsers

        ___________________________

Error: detected C:\Users\...\cap-ts\tsconfig.json, but could not run with 'tsx'. Enable Typescript with
  npm install -D tsx typescript
```

Global installation is mentioned later within cds-tsx but if its also required for `cds watch` it should be mentioned before already.

Therefore, my suggestion to add `tsx` to the other packages that should be installed globally.


(Also it seems that the auto-generated tsconfig.json - when running `cds add typescript` - is missing `compilerOptions.outDir`; otherwise VSCode complains about `Cannot write file '.../cap-ts/eslint.config.mjs' because it would overwrite input file.` but I guess that's a setup/code issue and not a docs issue)