### PR TITLE
Remove `--for production` from facets

### DIFF
--- a/get-started/attic/grow-as-you-go.-md
+++ b/get-started/attic/grow-as-you-go.-md
@@ -15,10 +15,10 @@ As your project evolves, you would gradually add new features, for example as ou
 While we used SQLite in-memory databases and mocked authentication during development, we would use SAP HANA Cloud and a combination of App Router, IAS and/or XSUAA in production. We can quickly do so as follows:
 
 ```sh
-cds add hana,approuter,xsuaa --for production
+cds add hana,approuter,xsuaa
 ```
 
-This adds respective packages and configuration to your project. The content of your project, that is, models or code, doesn't change and doesn't have to be touched. The option  `--for production` controls that these service variants are only used when in production profile, that is, when the app is deployed to the cloud. Locally you continue to develop in airplane mode.
+This adds respective packages and configuration to your project with the `[production]` profile. The content of your project, that is, models or code, doesn't change and doesn't have to be touched. The profile controls that these service variants are only used when in production, that is, when the app is deployed to the cloud. Locally you continue to develop in airplane mode.
 
 
 
@@ -39,7 +39,7 @@ cds add mta
 If you are creating a SaaS application you also need to add support for tenant subscriptions and tenant upgrades. When a tenant subscribes, new database containers have to be bootstrapped along with other resources, like message channels. CAP provides the so-called MTX services which do that automatically in a sidecar micro service. You can add all required packages and configurations by:
 
 ```sh
-cds add multitenancy --for production
+cds add multitenancy
 ```
 
 [Learn more about multitenancy.](../guides/multitenancy/){.learn-more}

--- a/guides/deployment/to-cf.md
+++ b/guides/deployment/to-cf.md
@@ -147,7 +147,7 @@ While we used SQLite or H2 as a low-cost stand-in during development, we're goin
 </div>
 
 ```sh
-cds add hana --for production
+cds add hana
 ```
 
 [Learn more about using SAP HANA for production.](../databases-hana){.learn-more}
@@ -157,7 +157,7 @@ cds add hana --for production
 Configure your app for XSUAA-based authentication:
 
 ```sh
-cds add xsuaa --for production
+cds add xsuaa
 ```
 
 ::: tip This will also generate an `xs-security.json` file
@@ -226,7 +226,7 @@ cds add workzone
 To enable multitenancy for production, run the following command:
 
 ```sh
-cds add multitenancy --for production
+cds add multitenancy
 ```
 
 [Learn more about MTX services.](../multitenancy/#behind-the-scenes){.learn-more}

--- a/guides/deployment/to-kyma.md
+++ b/guides/deployment/to-kyma.md
@@ -137,7 +137,7 @@ Let's  start with a new sample project and prepare it for production using an SA
 
 ```sh
 cds init bookshop --add sample && cd bookshop
-cds add hana,xsuaa --for production
+cds add hana,xsuaa
 ```
 
 #### User Interfaces <Beta />

--- a/guides/multitenancy/index.md
+++ b/guides/multitenancy/index.md
@@ -53,7 +53,7 @@ cd bookshop
 Now, you can run this to enable multitenancy for your CAP application:
 
 ```sh
-cds add multitenancy --for production
+cds add multitenancy
 ```
 
 <div class="impl node">
@@ -715,7 +715,7 @@ In order to get your multitenant application deployed, follow this excerpt from 
 Once: Add SAP HANA Cloud, XSUAA, and [App Router](../deployment/to-cf#add-app-router) configuration. The App Router acts as a single point-of-entry gateway to route requests to. In particular, it ensures user login and authentication in combination with XSUAA.
 
 ```sh
-cds add hana,xsuaa --for production
+cds add hana,xsuaa
 ```
 
 If you intend to serve UIs you can easily set up the SAP Cloud Portal service:
@@ -993,14 +993,14 @@ cds watch --profile dev
 ## SaaS Dependencies {#saas-dependencies}
 Some of the xsuaa-based services your application consumes need to be registered as _reuse services_ to work in multitenant environments. This holds true for the usage of both the SaaS Registry service and the Subscription Manager Service (SMS).
 
-CAP Java as well as `@sap/cds-mtxs`, each offer an easy way to integrate these dependencies. They support some services out of the box and also provide a simple API for applications. Most notably, you need such dependencies for the following SAP BTP services: [Audit Log](https://discovery-center.cloud.sap/serviceCatalog/audit-log-service), [Event Mesh](https://discovery-center.cloud.sap/serviceCatalog/event-mesh), [Destination](https://discovery-center.cloud.sap/serviceCatalog/destination), [HTML5 Application Repository](https://discovery-center.cloud.sap/serviceCatalog/html5-application-repository-service), and [Cloud Portal](https://discovery-center.cloud.sap/serviceCatalog/cloud-portal-service). 
+CAP Java as well as `@sap/cds-mtxs`, each offer an easy way to integrate these dependencies. They support some services out of the box and also provide a simple API for applications. Most notably, you need such dependencies for the following SAP BTP services: [Audit Log](https://discovery-center.cloud.sap/serviceCatalog/audit-log-service), [Event Mesh](https://discovery-center.cloud.sap/serviceCatalog/event-mesh), [Destination](https://discovery-center.cloud.sap/serviceCatalog/destination), [HTML5 Application Repository](https://discovery-center.cloud.sap/serviceCatalog/html5-application-repository-service), and [Cloud Portal](https://discovery-center.cloud.sap/serviceCatalog/cloud-portal-service).
 
 For CAP Java, all these services are supported natively and SaaS dependencies are automatically created if such a service instance is bound to the CAP Java application, that is, the `srv` module.
 
 :::tip Explicitly activate the Destination service
 SaaS dependency for Destination service needs to be activated explicitly in the `application.yaml` due to security reasons. SaaS dependencies for some of the other services can be **de**activated by setting the corresponding property to `false` in the `application.yaml`.
 
-Refer to the `cds.multiTenancy.dependencies` section in the [CDS properties](/java/developing-applications/properties#cds-properties). 
+Refer to the `cds.multiTenancy.dependencies` section in the [CDS properties](/java/developing-applications/properties#cds-properties).
 :::
 
 For CAP Node.js, all these services are supported natively and can be activated individually by providing configuration in `cds.requires`. In the most common case, you simply activate service dependencies like so:
@@ -1049,7 +1049,7 @@ The Boolean values in the _mtx/sidecar/package.json_ activate the default config
 
 ### Additional Services
 
-If your CAP Java application uses a service that isn't supported out of the box, you can add a custom dependency by providing a custom handler. Refer to [Define Dependent Services](../../java/multitenancy#define-dependent-services) for details. 
+If your CAP Java application uses a service that isn't supported out of the box, you can add a custom dependency by providing a custom handler. Refer to [Define Dependent Services](../../java/multitenancy#define-dependent-services) for details.
 
 
 In Node.js, you can use the `subscriptionDependency` setting to provide a dependency configuration similar to the standard configuration shown before. Use your application's or CAP plugin's _package.json_:

--- a/guides/security/authorization.md
+++ b/guides/security/authorization.md
@@ -492,7 +492,7 @@ The condition defined in the `where`-clause typically associates domain data wit
 - `UPDATE` (as reject condition<sup>2</sup>)
 - `DELETE` (as reject condition<sup>2</sup>)
 
- > <sup>1</sup> Node.js supports _static expressions_ that *don't have any reference to the model* such as `where: $user.level = 2` for all events.  
+ > <sup>1</sup> Node.js supports _static expressions_ that *don't have any reference to the model* such as `where: $user.level = 2` for all events.
  > <sup>2</sup> CAP Java uses a filter condition by default.
 
 For instance, a user is allowed to read or edit `Orders` (defined with the `managed` aspect) that they have created:
@@ -899,7 +899,7 @@ Information about roles and attributes has to be made available to the UAA platf
 Derive scopes, attributes, and role templates from the CDS model:
 
 ```sh
-cds add xsuaa --for production
+cds add xsuaa
 ```
 
 This generates an _xs-security.json_ file:

--- a/guides/using-services.md
+++ b/guides/using-services.md
@@ -1394,7 +1394,7 @@ The MTA-based deployment is described in [the deployment guide](deployment/). Yo
 
 
 ```sh
-cds add xsuaa,destination,connectivity --for production
+cds add xsuaa,destination,connectivity
 ```
 
 ::: details Learn what this does in the background...


### PR DESCRIPTION
We'll use the `production` profile as a default when applicable (`cds add hana,xsuaa`) in cds-dk 9 → not required here any more.