### PR TITLE
Include `cds add approuter` in MT guide again

### DIFF
--- a/guides/multitenancy/index.md
+++ b/guides/multitenancy/index.md
@@ -720,7 +720,7 @@ In order to get your multitenant application deployed, follow this excerpt from 
 Once: Add SAP HANA Cloud, XSUAA, and [App Router](../deployment/to-cf#add-app-router) configuration. The App Router acts as a single point-of-entry gateway to route requests to. In particular, it ensures user login and authentication in combination with XSUAA.
 
 ```sh
-cds add hana,xsuaa
+cds add hana,xsuaa,approuter
 ```
 
 If you intend to serve UIs you can easily set up the SAP Cloud Portal service:


### PR DESCRIPTION
Adding App Router is mentioned explicitly, whereas the Cloud Portal facet that would include it is considered optional.

cf. [this comment](https://github.com/cap-js/docs/commit/eab3b5d50c26882c615ea07fe4ac9401164c4dc3#commitcomment-157837891) on the original commit.

These changes concern the Multitenancy Guide, featuring an excerpt from the Deployment Guide.

The [Deployment Guide](https://cap.cloud.sap/docs/guides/deployment/to-cf#add-app-router), in turn, also mentions adding App Router as a separate item, followed by Cloud Portal as only one of two options.