### PR TITLE
install cds-dk instead of add

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -37,7 +37,7 @@ Follow the steps after this for a minimalistic local setup. Alternatively, you c
 - With the prerequisites met, install the [`cds` toolkit](../tools/cds-cli) *globally*:
 
     ```sh
-    npm add -g @sap/cds-dk
+    npm i -g @sap/cds-dk
     ```
 
     [Visit the _Troubleshooting_ guide](troubleshooting.md) if you encounter any errors. {.learn-more}


### PR DESCRIPTION
While setting up my new notebook, I've noticed that we shall `npm install` the cds-dk (not `npm add`) in getting started.
