### PR TITLE
Fix very minor issue in authorization.md

### DIFF
--- a/guides/security/authorization.md
+++ b/guides/security/authorization.md
@@ -190,7 +190,7 @@ service SomeService {
 
 #### Events to Auto-Exposed Entities { #events-and-auto-expose}
 
-In general, entities can be exposed in services in different ways: it can be **explicitly exposed** by the modeler (for example, by a projection), or it can be **auto-exposed** by the CDS compiler due to some reason.
+In general, entities can be exposed in services in different ways: they can be **explicitly exposed** by the modeler (for example, by a projection), or they can be **auto-exposed** by the CDS compiler due to some reason.
 Access to auto-exposed entities needs to be controlled in a specific way. Consider the following example:
 
 ```cds


### PR DESCRIPTION
Singular 'entity' vs plural 'entities'; it seems that the plural is used predominantly here, so fixed in a way that leans in that direction.