### PR TITLE
fix (?) the after phase handler sample in messaging topic

### DIFF
--- a/guides/messaging/index.md
+++ b/guides/messaging/index.md
@@ -157,7 +157,7 @@ Find the code to emit events in *[@capire/reviews/srv/reviews-service.js](https:
 class ReviewsService extends cds.ApplicationService { async init() {
 
   // Emit a `reviewed` event whenever a subject's avg rating changes
-  this.after (['CREATE','UPDATE','DELETE'], 'Reviews', (req) => {
+  this.after (['CREATE','UPDATE','DELETE'], 'Reviews', (_, req) => {
     let { subject } = req.data, count, rating //= ...
     return this.emit ('reviewed', { subject, count, rating })
   })


### PR DESCRIPTION
I may have misunderstood something, but ...

The `req` parameter is second, not first, in `after` phase handlers (see https://cap.cloud.sap/docs/node.js/core-services#srv-after-request). Different values, depending on the actual event (create, update, delete) will be provided for the first argument, none of which is the request.