### PR TITLE
docs: Grammar fix in events.md

### DIFF
--- a/node.js/events.md
+++ b/node.js/events.md
@@ -343,7 +343,7 @@ Captures the incoming request as a [CQN query](cds-ql#class-cds-ql-query). For e
 req.query = {SELECT:{from:{ref:['Books']}}}
 ```
 
-If bound custom operations, then `req.query` contains the query to the entity on which the bound custom operation is called. For unbound custom operations, `req.query` contains an empty object.
+For bound custom operations, `req.query` contains the query to the entity on which the operation is called. For unbound custom operations, `req.query` contains an empty object.
 
 ### . subject {.property}
 

--- a/node.js/events.md
+++ b/node.js/events.md
@@ -343,7 +343,7 @@ Captures the incoming request as a [CQN query](cds-ql#class-cds-ql-query). For e
 req.query = {SELECT:{from:{ref:['Books']}}}
 ```
 
-If bound custom operations `req.query` contains the query to the entity, on which the bound custom operation is called. For unbound custom operations, `req.query` contains an empty object.
+If bound custom operations, then `req.query` contains the query to the entity on which the bound custom operation is called. For unbound custom operations, `req.query` contains an empty object.
 
 ### . subject {.property}
 


### PR DESCRIPTION
Grammar fix for cds.Request . query to clarify the sentence on bound custom operations. Had the comma in the wrong location which made the sentence confusing.