### PR TITLE
docs: Add missing ,

### DIFF
--- a/node.js/cds-log.md
+++ b/node.js/cds-log.md
@@ -245,7 +245,7 @@ You can specify winston custom options to that method [as documented for `winsto
 
 ```js
 cds.log.Logger = cds.log.winstonLogger({
-  format: winston.format.simple()
+  format: winston.format.simple(),
   transports: [
     new winston.transports.Console(),
     new winston.transports.File({
@@ -253,7 +253,7 @@ cds.log.Logger = cds.log.winstonLogger({
       level: 'error'
     })
   ],
-})
+});
 ```
 
 ### _Custom Loggers_

--- a/node.js/cds-log.md
+++ b/node.js/cds-log.md
@@ -253,7 +253,7 @@ cds.log.Logger = cds.log.winstonLogger({
       level: 'error'
     })
   ],
-});
+})
 ```
 
 ### _Custom Loggers_


### PR DESCRIPTION
Will remove the syntax error when copying the code