### PR TITLE
Fix (?) to shared-db testing in microservices.md

### DIFF
--- a/guides/deployment/microservices.md
+++ b/guides/deployment/microservices.md
@@ -162,7 +162,7 @@ cd shared-db
 cds compile db -2 sql
 ```
 ```sh
-cds compile -2 hana --all
+cds compile db -2 hana
 ```
 
 ```sh

--- a/guides/deployment/microservices.md
+++ b/guides/deployment/microservices.md
@@ -159,7 +159,7 @@ cd shared-db
 ```
 
 ```sh
-cds compile -2 sql --all
+cds compile db -2 sql
 ```
 ```sh
 cds compile -2 hana --all

--- a/guides/deployment/microservices.md
+++ b/guides/deployment/microservices.md
@@ -159,10 +159,10 @@ cd shared-db
 ```
 
 ```sh
-cds db -2 sql
+cds compile -2 sql --all
 ```
 ```sh
-cds db -2 hana
+cds compile -2 hana --all
 ```
 
 ```sh


### PR DESCRIPTION
The `cds db -2 sql` and `cds db -2 hana` commands are a bit suspect, as the `db` command doesn't exist. From the paragraph just before these commands, I suspect this should be `compile`, but even then, we need also to specify the `--all` option, otherwise we get the message "You must specify a model to compile.".