### PR TITLE
use -f to cf install-plugin

### DIFF
--- a/guides/deployment/to-cf.md
+++ b/guides/deployment/to-cf.md
@@ -120,8 +120,8 @@ npm i @sap/cds        #> if necessary
 
    ```sh
    cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-   cf install-plugin multiapps
-   cf install-plugin html5-plugin
+   cf install-plugin -f multiapps
+   cf install-plugin -f html5-plugin
    ```
 
 ## Prepare for Production {#prepare-for-production}


### PR DESCRIPTION
If you copy/paste these three shell commands the effect won't be what the user expects, as without the `-f` option the `install-plugin` command will stop and prompt the user like this:

```shell
; cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
https://plugins.cloudfoundry.org already registered as CF-Community
# /work/scratch/debugtest
; cf install-plugin multiapps
Searching CF-Community for plugin multiapps...
Plugin multiapps 3.5.0 found in: CF-Community
Attention: Plugins are binaries written by potentially untrusted authors.
Install and use plugins at your own risk.
Do you want to install the plugin multiapps? [yN]: cf install-plugin html5-plugin
```

i.e. the 3rd line `cf install-plugin html5-plugin` will be presented as the value at the "yN" prompt instead of being a separate command.

Using `-f` will bypass the prompt. I would say this is fine, it's what the user wants anyway.