### PR TITLE
Remove limitation of remote services

### DIFF
--- a/java/cqn-services/remote-services.md
+++ b/java/cqn-services/remote-services.md
@@ -486,7 +486,3 @@ OAuth2DestinationBuilder
         .property("name", "my-destination")
         .build();
 ```
-
-### Limitations
-
-Streaming of media content is not supported. This means that elements of an entity annotated with `@Core.MediaType` cannot be accessed via Remote OData Services and will cause an error. It is recommended to exclude these elements in your projections on the imported entity.


### PR DESCRIPTION
As of version 4.1.0 of CAP Java this limitation is no longer valid and can be removed from Capire.
See release notes: https://pages.github.tools.sap/cap/docs/releases/june25#media-properties-in-remote-odata