### PR TITLE
Point out additional restriction for feature toggles

### DIFF
--- a/guides/extensibility/feature-toggles.md
+++ b/guides/extensibility/feature-toggles.md
@@ -127,8 +127,7 @@ This feature extends corresponding SAP Fiori annotations to display already exis
 Note the following limitations for `.cds` files in features:
 
 - no `.cds` files in subfolders, for example, `fts/isbn/sub/file.cds`
-- no `using` dependencies between features
-- anything you depend on in your feature must be part of your base model
+- no `using` dependencies between features, any entity, service or type that you refer to or extend needs to be part of the base model
 - further limitations re `extend aspect` → to be documented
 :::
 


### PR DESCRIPTION
Fixes cap-issues/18713

Feature toggles may only refer to parts of the model that are included in the base model. Using anything that has not been used from within the base model will not be available during build.

To be reviewed by code owner (MTXs team)