### PR TITLE
Remove second embedding of `assert.constraints` fragment

### DIFF
--- a/guides/providing-services.md
+++ b/guides/providing-services.md
@@ -928,8 +928,6 @@ The `@assert.target` check constraint relies on database locks to ensure accurat
 
 Next to input validation, you can add [database constraints](databases#database-constraints) to prevent invalid data from being persisted.
 
-<div id="assertconstraints" />
-
 ## Custom Logic
 
 


### PR DESCRIPTION
The fragment for embedding assert.constraint section has been accidently added twice. This PR is cleaning up this inconsistency