### PR TITLE
Changing `where`, `order by` and infix filter features support for Node.js 

### DIFF
--- a/guides/using-services.md
+++ b/guides/using-services.md
@@ -1635,9 +1635,9 @@ The Node.js runtime supports `odata` as an alias for `odata-v4` as well.
 | Resolve associations (within the same remote service)     | <Y/> |  <Y/>   |
 | Redirected associations                                   | <Y/> |  <Y/>   |
 | Flatten associations                                      | <X/> |  <X/>   |
-| `where` conditions                                        | <X/> |  <X/>   |
-| `order by`                                                | <X/> |  <X/>   |
-| Infix filter for associations                             | <X/> |  <X/>   |
+| `where` conditions                                        | <X/> |  <Y/>   |
+| `order by`                                                | <X/> |  <Y/>   |
+| Infix filter for associations                             | <X/> |  <Y/>   |
 | Model Associations with mixins                            | <Y/> |  <Y/>   |
 
 ### Supported Features for Application Defined Destinations


### PR DESCRIPTION
Looks like `where`, `order by` and infix filters are actually supported for projections (tested on `nodejs` and for non-external services only). I have a working example that correcly filters records and orders them.

Currently using:
```
@sap/cds: 8.9.4
@sap/cds-compiler: 5.9.4
```