### PR TITLE
Add start and end of string anchors to identifier regex in cdl.md

### DIFF
--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -62,7 +62,7 @@ Keywords are *case-insensitive*, but are most commonly used in lowercase notatio
 
 Identifiers are *case-significant*, that is, `Foo` and `foo` would identify different things.
 
-Identifiers have to comply to `/[$A-Za-z_]\w*/` or be enclosed in `![`...`]` like that:
+Identifiers have to comply to `/^[$A-Za-z_]\w*$/` or be enclosed in `![`...`]` like that:
 
 ```cds
 type ![Delimited Identifier] : String;


### PR DESCRIPTION
This is super minor, of course, but I think the caret helps folks understand the significance of `[$A-Za-z_]` specifically representing the starting character of the identifier name. And when one anchors the start of a string, one should also anchor the end :-)

Feel free to reject and call me out as a fool :-)