### PR TITLE
Minor fix in common.md

### DIFF
--- a/cds/common.md
+++ b/cds/common.md
@@ -205,7 +205,7 @@ The following definitions are within namespace `sap.common`...
 
 ### Aspect `CodeList`
 
-This is the base definition for the three code list entities in _@sap/cds/common_. It can also be used for your own code lists.
+This is the base definition for the code list entities in _@sap/cds/common_. It can also be used for your own code lists.
 
 ```cds
 aspect sap.common.CodeList {


### PR DESCRIPTION
There were likely only three `CodeList` based entities but there are now four. So I've removed the (now inaccurate) number leaving it flexible and (now) correct :-)