### PR TITLE
Adding `tar` support in Troubleshooting

### DIFF
--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -789,4 +789,14 @@ For SAP HANA deployment errors see [The HANA section](#how-do-i-resolve-deployme
 Please note that Git Bash on Windows, despite offering a Unix-like environment, may encounter interoperability issues with specific scripts or tools due to its hybrid nature between Windows and Unix systems.
 When using Windows, we recommend testing and verifying all functionalities in the native Windows Command Prompt (cmd.exe) or PowerShell for optimal interoperability. Otherwise, problems can occur when building the mtxs extension on Windows, locally, or in the cloud.
 
+### tar: Error is not recoverable: exiting now
+
+If you get the error `tar: Error is not recoverable: exiting now` (for example, when building MTX resources) you can try installing the `tar` library for better compatibility with Windows systems.
+
+Add it to your `devDependencies` like so:
+
+```sh
+npm add -D tar
+```
+
 <div id="end" />

--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -799,4 +799,6 @@ Add it to your `devDependencies` like so:
 npm add -D tar
 ```
 
+> This will not affect macOS or Linux, which continue using the built-in implementation.
+
 <div id="end" />

--- a/get-started/troubleshooting.md
+++ b/get-started/troubleshooting.md
@@ -799,6 +799,6 @@ Add it to your `devDependencies` like so:
 npm add -D tar
 ```
 
-> This will not affect macOS or Linux, which continue using the built-in implementation.
+> On macOS and Linux, the built-in implementation will continue to be used.
 
 <div id="end" />


### PR DESCRIPTION
Still getting tar on Windows issues quite frequently, it would be helpful to have the `tar` package mentioned in our troubleshooting guide.