### PR TITLE
audit logging: enforce data integrity for data subject id fields

### DIFF
--- a/guides/data-privacy/annotations.md
+++ b/guides/data-privacy/annotations.md
@@ -144,7 +144,7 @@ Use this annotation to identify data subject's unique key, or a reference to it.
 - Each `@PersonalData` entity needs to identify a `DataSubjectID` element.
 - For entities with `DataSubject` semantics, this is typically the primary key.
 - For entities with `DataSubjectDetails` or `Other`  semantics, this is usually an association to the data subject.
-- Fields marked as `DataSubjectID` should use [`not null`](../databases#not-null) to guarantee a value is present at all times
+- Fields marked as `DataSubjectID` should use [`not null`](../databases#not-null) to guarantee a value is present at all times.
 
 Hence, we annotate our model as follows:
 


### PR DESCRIPTION
A [recently opened issue in the audit log plugin repo](https://github.com/cap-js/audit-logging/issues/180) showcased an error scenario, where the stakeholder tried to model an entity  (`@PersonalData.EntitySemantics: 'Other'`) that references a data subject by way of `association to one DataSubject @PersonalData.FieldSemantics: 'DataSubjectID'`. In this scenario it is possible to produce an error response from the audit logging service, if no value for `data_subject.id` is present. However, in the context of audit logging, IMO this should never be possible. To unilaterally 'solve' the problem we might want to update our docs to specify that fields that are supposed to hold the data subject id must not be null. 