### PR TITLE
fix profile

### DIFF
--- a/guides/multitenancy/index.md
+++ b/guides/multitenancy/index.md
@@ -175,12 +175,18 @@ cds add multitenancy
      "devDependencies": {
        "@cap-js/sqlite": "^2"
      },
+     "engines": {
+       "node": ">=20"
+     },
      "scripts": {
        "start": "cds-serve",
        "build": "cds build ../.. --for mtx-sidecar --production && npm ci --prefix gen"
      },
      "cds": {
-       "profile": "mtx-sidecar"
+       "profiles": [
+         "mtx-sidecar",
+         "java"
+       ]
      }
    }
    ```


### PR DESCRIPTION
~~This somehow found it's way in... the build does not work with `with-mtx-sidecar`, the correct profile here is `mtx-sidecar` as also described in the node section.~~

Updating the sidecar package.json to what is currently generated (incl java profile).