### PR TITLE
highlight package freeze before deployment

### DIFF
--- a/guides/deployment/to-cf.md
+++ b/guides/deployment/to-cf.md
@@ -236,11 +236,14 @@ cf target
 ```
 [Learn more about `cf login`](https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/7a37d66c2e7d401db4980db0cd74aa6b.html){.learn-more}
 
-::: tip Prevent outdated lock file issues
-If your project already includes a _package-lock.json_, run `npm update` to make sure it’s in sync with your _package.json_ before proceeding.
-:::
 
-You can now freeze dependencies, build, and deploy the application:
+If your project already includes a _package-lock.json_, freeze your updated dependencies:
+
+```sh
+npm install --package-lock-only
+```
+
+You can now build and deploy the application:
 
 ```sh
 cds up


### PR DESCRIPTION
The tip is quite easy to overlook because it does not look like an actionable item. The `package-lock.json` needs to be updated if there already is one... which is not uncommon, so I think we should include it as a regular step.

After a `cds add mta` we recommend to:
```
run npm update --package-lock-only to freeze dependencies
```

So I'd suggest we also document it here instead of the `npm update`. The `npm update` also changes all other versions which were not changed in the `package.json`.
Of course it is important to regularly run `npm update` to use the latest versions.