### PR TITLE
chore: remove node.js only marker for most standard functions

### DIFF
--- a/guides/databases.md
+++ b/guides/databases.md
@@ -926,7 +926,7 @@ A specified set of standard functions - inspired by [OData](https://docs.oasis-o
 
 ### OData standard functions
 
-The `@sap/cds-compiler` and all CAP database services (Node.js & Java) come with out of the box support for common OData functions.
+The `@sap/cds-compiler` and the database services come with out of the box support for common OData functions.
 
 ::: warning Case Sensitivity
 The OData function mappings are case-sensitive and must be written as in the list below.


### PR DESCRIPTION
most of the standard database functions are also supported by the java runtime. Hence this section needed to be updated.

Date / Aggregation / SAP HANA functions are still a todo for Java. Once the BLIs are implemented, we can also unlock those sections for Java.