### PR TITLE
@Semantics.amount.currencyCode and @Semantics.currencyCode  supported by both runtimes

### DIFF
--- a/advanced/odata.md
+++ b/advanced/odata.md
@@ -1203,7 +1203,7 @@ entity Sales {
 }
 ```
 
-All properties annotated with `@Semantics.currencyCode` or `@Semantics.unitOfMeasure` as a [custom aggregate](../advanced/odata#custom-aggregates) are exposed with the property's name that returns:
+All properties annotated with `@Semantics.currencyCode` or `@Semantics.unitOfMeasure` are exposed as a [custom aggregate](../advanced/odata#custom-aggregates) with the property's name that returns:
 
 * The property's value if it's unique within a group of dimensions
 * `null` otherwise


### PR DESCRIPTION
Related to https://github.com/capire/docs/issues/1844