### PR TITLE
Hint about limitations of cds.model

### DIFF
--- a/node.js/cds-facade.md
+++ b/node.js/cds-facade.md
@@ -185,7 +185,7 @@ Known values for `cds.cli.command` are `add`, `build`, `compile`, `deploy`, `imp
 
 Is a shortcut to `cds.model.entities`. Used as a function, you can [specify a namespace](/node.js/cds-reflect#entities).
 
-Be aware of the limitations of [`cds.model`](cds-facade#cds-model)
+Be aware of the limitations of [`cds.model`](cds-facade#cds-model).
 
 ### cds. env {.property}
 
@@ -300,7 +300,7 @@ cds.model = await cds.load('*')
 
 
 ::: danger Limitations of `cds.model`
-`cds.model` is just the base model of the application. In multi-tenant scenarios tenants might [extend](../@external/guides/extensibility/index.md#extensibility) the model or parts of the model are put behind [feature flags](../@external/guides/extensibility/feature-toggles.md) and thus `cds.context.model` must be used at runtime to lookup the actual model used by the tenant.
+`cds.model` is just the base model of the application. In multitenant scenarios tenants might [extend](../guides/extensibility/) the model or parts of the model are put behind [feature flags](../guides/extensibility/feature-toggles) and thus `cds.context.model` must be used at runtime to lookup the actual model used by the tenant.
 :::
 
 


### PR DESCRIPTION
Hi colleagues,

in multi-tenant scenarios cds.context.model must be used at runtime instead of cds.model to ensure the model includes the tenant specific feature flags and extensions.

The PR adds a hint for this. to `cds.entities` and `cds.model` BR,
Marten