### PR TITLE
Prefer `-a` instead of `--to-app-services` in `cds bind`

### DIFF
--- a/advanced/hybrid-testing.md
+++ b/advanced/hybrid-testing.md
@@ -458,10 +458,10 @@ cds bind --to my-service,redis-cache:my-key,bookshop-xsuaa --credentials \
   '{ "my-service": { "onpremise_proxy_host": "localhost" }, "redis-cache:my-key":{ "hostname": "localhost", "port": 1234 }}'
 ```
 
-Use the service instance name in combination with the option `--to-app-services` if you want to create bindings for all service instances of your application:
+Use the service instance name in combination with the option `-a` if you want to create bindings for all service instances of your application:
 
 ```sh
-cds bind --to-app-services bookshop-srv --credentials \
+cds bind -a bookshop-srv --credentials \
   '{ "my-service": { "onpremise_proxy_host": "localhost" }, "redis-cache":{ "hostname": "localhost", "port": 1234 }}'
 ```
 

--- a/guides/multitenancy/index.md
+++ b/guides/multitenancy/index.md
@@ -897,14 +897,14 @@ For faster turnaround cycles in development and testing, you can run the app loc
 To achieve this, bind your SaaS app and the MTX sidecar to its required cloud services, for example:
 
 ```sh
-cds bind --to-app-services bookshop-srv
+cds bind -a bookshop-srv
 ```
 
 For testing the sidecar, make sure to run the command there as well:
 
 ```sh
 cd mtx/sidecar
-cds bind --to-app-services bookshop-srv
+cds bind -a bookshop-mtx
 ```
 
 To generate the SAP HANA HDI files for deployment, go to your project root and run the build:

--- a/guides/multitenancy/old-mtx-migration.md
+++ b/guides/multitenancy/old-mtx-migration.md
@@ -420,7 +420,7 @@ See also [Extensibility configuration](./mtxs.md#extensibility-config)
 ### Verify Application Locally
 
 As first verification of your configuration changes, you can try to run your application locally in [hybrid mode](../../advanced/hybrid-testing#run-with-service-bindings). To bind all the service
-that are bound to your existing application, you can call `cds bind --to-app-services <your application>`. Afterwards, you can run `cds run --profile hybrid --resolve-bindings`.
+that are bound to your existing application, you can call `cds bind -a <your application>`. Afterwards, you can run `cds run --profile hybrid --resolve-bindings`.
 
 ### Migrate Tenant Content of Existing Applications
 


### PR DESCRIPTION
Much simpler and more intuitive. I just leave the one usage of `--to-app-services` here:
https://cap.cloud.sap/docs/advanced/hybrid-testing#bindings-from-a-cloud-application
