### PR TITLE
Link to CI/CD documentation after doing ad-hoc deployment

### DIFF
--- a/guides/deployment/cicd.md
+++ b/guides/deployment/cicd.md
@@ -80,7 +80,7 @@ contexts:
       user: ci-user
 current-context: ci-context
 ```
-[Learn more about configuring Kubernetes](./to-kyma#configure-kubernetes){.learn-more style="margin-top:20px"}
+[Learn more about configuring Kubernetes](./to-kyma#configure-kubernetes){.learn-more}
 
 :::
 

--- a/guides/deployment/to-cf.md
+++ b/guides/deployment/to-cf.md
@@ -384,7 +384,7 @@ sed -i 's/org.springframework.boot.loader.JarLauncher/-Dloader.main=com.sap.cds.
 
 ## Next Up...
 
-You would then [set up your CI/CD for deployment](../deployment/cicd).
+You would then [set up your CI/CD](../deployment/cicd) for automating deployments, for example after merging pull requests.
 
 
 <!--

--- a/guides/deployment/to-kyma.md
+++ b/guides/deployment/to-kyma.md
@@ -238,7 +238,7 @@ and [CAP for Java](https://github.com/SAP-samples/cloud-cap-samples-java) exampl
 
 ## Next Up...
 
-You would then [set up your CI/CD for deployment](../deployment/cicd).
+You would then [set up your CI/CD](../deployment/cicd) for automating deployments, for example after merging pull requests.
 
 {style="margin-top:11em"}
 


### PR DESCRIPTION
I think we should feature the CI/CD guide more prominently and point to it after doing the ad-hoc deployment.