### PR TITLE
CAP Java: Support for hierachies on SQLite

### DIFF
--- a/advanced/fiori.md
+++ b/advanced/fiori.md
@@ -750,7 +750,7 @@ Recursive hierarchies are parent-child hierarchies, where each entity references
 A generic hierarchy implementation for hierarchies is available on all relational datases supported by the CAP runtimes.
 
 ::: warning
-On H2 the size of hierarchies should be kept small for performance reasons.
+On H2, only small hierarchies should be used for performance reasons.
 :::
 
 ### Example


### PR DESCRIPTION
Both runtimes now support hierarchies on all supported relational databases.