### PR TITLE
Improve Error Handling target API

### DIFF
--- a/java/event-handlers/indicating-errors.md
+++ b/java/event-handlers/indicating-errors.md
@@ -207,7 +207,7 @@ Here, we have a `CatalogService` that exposes et al. the `Books` entity and a `B
 
 ### CRUD Events
 
-Within a `Before` handler that triggers on inserts of new books, a message target can only refer to the `cqn` parameter. You can use generic String-based APIs or a typed API backed by the interfaces generated from the CDS model:
+Within a `Before` handler that triggers on inserts of new books, a message target can only refer to the `cqn` parameter. You can use generic `String`-based APIs or a typed API backed by the interfaces generated from the CDS model:
 
 ```java
 @Before


### PR DESCRIPTION
Prefer showing targets via Messages API, as this allows collecting multiple error messages and should be preferred in applications.

Also reduced usage of the String-based API, as this has limitations in draft messages scenarios.