### PR TITLE
Remove strange heading

### DIFF
--- a/guides/domain-modeling.md
+++ b/guides/domain-modeling.md
@@ -816,7 +816,6 @@ Managed data fields are filled in automatically and are write-protected for exte
 In case of `UPSERT` operations, the handlers for `@cds.on.update` are executed, but not the ones for `@cds.on.insert`.
 :::
 
-Domain Modeling > Managed Data {style="margin-bottom: 0; font-size:70%; font-style: italic;"}
 ### Aspect _`managed`_ {style="margin-top: 0;"}
 
 You can also use the [pre-defined aspect `managed`](../cds/common#aspect-managed) from [@sap/cds/common](../cds/common) to get the very same as by the definition above:


### PR DESCRIPTION
We have this strange heading in here, maybe in by accident?

<img width="363" height="158" alt="Screenshot 2025-12-08 at 15 39 08" src="https://github.com/user-attachments/assets/f856ed92-59cb-4e9b-b3e6-848d9cbc799e" />
