### PR TITLE
actual separation of concern

### DIFF
--- a/guides/security/authorization.md
+++ b/guides/security/authorization.md
@@ -830,19 +830,16 @@ service CustomerService {
 <!--- % include _code sample='services-auth.cds' %} -->
 ::: code-group
 ```cds [services-auth.cds]
-service ReviewsService @(requires: 'authenticated-user'){
-  /*...*/
-}
+annotate ReviewsService with @(requires: 'authenticated-user');
 
-service CustomerService @(requires: 'authenticated-user'){
-  entity Orders @(restrict: [
-    { grant: ['READ','WRITE'], to: 'admin' },
-    { grant: 'READ', where: 'buyer = $user' },
-  ]){/*...*/}
-  entity Approval @(restrict: [
-    { grant: 'WRITE', where: '$user.level > 2' }
-  ]){/*...*/}
-}
+annotate CustomerService with @(requires: 'authenticated-user');
+annotate CustomerService.Orders with @(restrict: [
+  { grant: ['READ','WRITE'], to: 'admin' },
+  { grant: 'READ', where: 'buyer = $user' },
+]);
+annotate CustomerService.Approval with @(restrict: [
+  { grant: 'WRITE', where: '$user.level > 2' }
+]);
 ```
 :::
 


### PR DESCRIPTION
The section `separation of concerns` on the authorization page currently does not show any separation => use actual separation of concerns.

<img width="732" height="872" alt="Screenshot 2025-12-16 at 14 03 45" src="https://github.com/user-attachments/assets/5e944390-3b9a-4a35-bd48-c64274e22ae3" />
