### PR TITLE
Remove feature parity hint in Postgres guide

### DIFF
--- a/guides/databases/postgres.md
+++ b/guides/databases/postgres.md
@@ -6,7 +6,7 @@ impl-variants: true
 
 <div class="impl node">
 
-This guide focuses on the new PostgreSQL Service provided through *[@cap-js/postgres](https://www.npmjs.com/package/@cap-js/postgres)*, which is based on the same new database services architecture as the new [SQLite Service](./sqlite). This architecture brings significantly enhanced feature sets and feature parity, as documented in the [*Features* section of the SQLite guidsqlite#featuresatures).
+This guide focuses on the new PostgreSQL Service provided through *[@cap-js/postgres](https://www.npmjs.com/package/@cap-js/postgres)*, which is based on the same new database services architecture as the new [SQLite Service](./sqlite).
 
 *Learn about migrating from the former `cds-pg` in the [Migration](#migration) chapter.*{.learn-more}
 


### PR DESCRIPTION
The guide it links to is not part of the `menu.md` any more. I think we can just remove the sentence as the new DB adapters were introduced some time ago and there's no equivalent section in published guides.

For cap/issues/20264