### PR TITLE
Document tenant-specific IAS host injection in RequestContext

### DIFF
--- a/guides/security/cap-users.md
+++ b/guides/security/cap-users.md
@@ -1529,13 +1529,13 @@ Avoid iterating through all subscriber tenants to perform tenant-specific tasks.
 Instead, prefer a task-based approach which processes specific subscriber tenants selectively.
 :::
 
-When creating a new RequestContext in a background thread (without propagating an existing request), you must manually inject the tenant-specific IAS host to use IAS-based Remote Services. Unlike inherited request contexts that automatically carry authentication details, a fresh asynchronous request lacks the IAS host information required for remote service calls. The host can be retrieved from a `TenantInfo` object provided for example by the `TenantProviderService`.
+To use IAS-based Remote Services in background executions, you must in addition manually inject the tenant-specific IAS host into the created Request Context. Unlike inherited request contexts that automatically carry authentication details, a fresh Request Context lacks the IAS host information required for remote service calls. The host can be retrieved from a `TenantInfo` object provided for example by the `TenantProviderService`.
 
 ```java
 TenantInto tenantInfo = ...;
 String tenantHost = tenantInfo.get("subscriber").get("tenantHost");
 runtime.requestContext().systemUser(tenantId).modifyUser(user->user.setAdditionalAttribute("iss", tenantHost)).run((reqContext) -> {
-…
+… //call remote service
 });
 ```
 

--- a/guides/security/cap-users.md
+++ b/guides/security/cap-users.md
@@ -1529,6 +1529,16 @@ Avoid iterating through all subscriber tenants to perform tenant-specific tasks.
 Instead, prefer a task-based approach which processes specific subscriber tenants selectively.
 :::
 
+When creating a new RequestContext in a background thread (without propagating an existing request), you must manually inject the tenant-specific IAS host to use IAS-based Remote Services. Unlike inherited request contexts that automatically carry authentication details, a fresh asynchronous request lacks the IAS host information required for remote service calls. The host can be retrieved from a `TenantInfo` object provided for example by the `TenantProviderService`.
+
+```java
+TenantInto tenantInfo = ...;
+String tenantHost = tenantInfo.get("subscriber").get("tenantHost");
+runtime.requestContext().systemUser(tenantId).modifyUser(user->user.setAdditionalAttribute("iss", tenantHost)).run((reqContext) -> {
+…
+});
+```
+
 </div>
 
 <div class="impl node">

--- a/guides/security/cap-users.md
+++ b/guides/security/cap-users.md
@@ -1529,7 +1529,7 @@ Avoid iterating through all subscriber tenants to perform tenant-specific tasks.
 Instead, prefer a task-based approach which processes specific subscriber tenants selectively.
 :::
 
-To use IAS-based Remote Services in background executions, you must in addition manually inject the tenant-specific IAS host into the created Request Context. Unlike inherited request contexts that automatically carry authentication details, a fresh Request Context lacks the IAS host information required for remote service calls. The host can be retrieved from a `TenantInfo` object provided for example by the `TenantProviderService`.
+To use IAS-based Remote Services in background executions, you might in addition need to manually inject the tenant-specific IAS host into the created Request Context. If the background execution is initialized with a fresh Request Context, it will not carry inherited authentication details from a previous Request Context and thereby lacks the IAS host information required for remote service calls. The host can be retrieved from a `TenantInfo` object provided for example by the `TenantProviderService`.
 
 ```java
 TenantInto tenantInfo = ...;


### PR DESCRIPTION
Added instructions for injecting tenant-specific IAS host in background threads.