### PR TITLE
Minor CDL update to clarify @inner position

### DIFF
--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1236,7 +1236,7 @@ entity Foo @(
 entity Foo { /* elements */ }
 ```
 
-For an `@inner` annotation, only the syntax `@(...)` is available.
+For annotations at the `@inner` position, only the syntax `@(...)` is available.
 
 
 #### Using `annotate` Directives


### PR DESCRIPTION
It took me quite a while to work out what "For `@inner` annotations ..." meant (thinking there was a specific annotation of this name). So I've rephrased this to make the meaning clearer.