### PR TITLE
Fix (?) CXL constraint for no-description in constraints.md

### DIFF
--- a/guides/services/constraints.md
+++ b/guides/services/constraints.md
@@ -188,7 +188,7 @@ Annotate an element with `@assert: (<constraints>)` to specify checks to be appl
 annotate TravelService.Travels with {
 
   Description @assert: (case                                          // [!code focus]
-    when Description then 'Description must be specified'             // [!code focus]
+    when Description is null then 'Description must be specified'     // [!code focus]
     when trim(Description) = '' then 'Description must not be empty'  // [!code focus]
     when length(Description) < 3 then 'Description too short'         // [!code focus]
   end);                                                               // [!code focus]
@@ -406,7 +406,7 @@ For `@assert: (<constraints>)` annotations you always specify custom error messa
 annotate TravelService.Travels with {
 
   Description @assert: (case                                          // [!code focus]
-    when Description then 'Description must be specified'             // [!code focus]
+    when Description is null then 'Description must be specified'     // [!code focus]
     when trim(Description) = '' then 'Description must not be empty'  // [!code focus]
     when length(Description) < 3 then 'Description too short'         // [!code focus]
   end);                                                               // [!code focus]


### PR DESCRIPTION
In [the constraints section on @assert](https://cap.cloud.sap/docs/guides/services/constraints#assert-constraint), I couldn't understand what this was for:

```cds
Description @assert: (case
  when Description then 'Description must be specified'
  ...
);
```

As this code stands, it doesn't make much sense to me. I think perhaps the condition is meant to be `Description is null`.