### PR TITLE
fix styles

### DIFF
--- a/.vitepress/theme/components/cds-playground/LiveCode.vue
+++ b/.vitepress/theme/components/cds-playground/LiveCode.vue
@@ -219,7 +219,7 @@ onMounted(() => { metaKey.value = /(Mac|iPhone|iPad)/i.test(navigator?.userAgent
 
 .editor-row .editor {
   flex: 1;
-  min-width: 0;
+  min-width: 0 !important;
 }
 
 .editor {


### PR DESCRIPTION
Fix live-code styles after https://github.com/capire/docs/commit/1ed1f55bdacdaa894a05ca70ffdd473a953c6ff2
Currently hovering moves the evaluate button further right
