### PR TITLE
cds-services-archetype: Changed default JDK version to 25

### DIFF
--- a/java/migration.md
+++ b/java/migration.md
@@ -144,7 +144,7 @@ The `cds-services-archetype` is used by the `@sap/cds-dk` to generate initial CA
 
 #### Default JDK version
 
-The initial JDK version in a new CAP Java projects has been changed to JDK 25. The minimum required JDK is still 17, this is not changed.
+The default JDK version in a new CAP Java projects has been changed to JDK **25**. The minimum required JDK version is still 17, this has not been changed.
 
 ### Removed repackaged Olingo Dependencies { #removed-olingo-4-to-5 }
 

--- a/java/migration.md
+++ b/java/migration.md
@@ -144,7 +144,7 @@ The `cds-services-archetype` is used by the `@sap/cds-dk` to generate initial CA
 
 #### Default JDK version
 
-The default JDK version in a new CAP Java projects has been changed to JDK **25**. The minimum required JDK version is still 17, this has not been changed.
+The default JDK version of new CAP Java projects has been changed to JDK **25**. The minimum required JDK version is still 17, this has not been changed.
 
 ### Removed repackaged Olingo Dependencies { #removed-olingo-4-to-5 }
 

--- a/java/migration.md
+++ b/java/migration.md
@@ -138,6 +138,14 @@ None
 3. Changed default value of properties:
 None
 
+### Changes in the `cds-services-archetype`
+
+The `cds-services-archetype` is used by the `@sap/cds-dk` to generate initial CAP Java projects.
+
+#### Default JDK version
+
+The initial JDK version in a new CAP Java projects has been changed to JDK 25. The minimum required JDK is still 17, this is not changed.
+
 ### Removed repackaged Olingo Dependencies { #removed-olingo-4-to-5 }
 
 The internally used maven modules `repackaged/odata-v4-lib` and `repackaged/odata-v2-lib` are removed from the delivery. If the project directly references these modules and doesn't compile after migrating to CAP Java 5.x, there are 3 options to keep the compatibility of the code base:

--- a/java/migration.md
+++ b/java/migration.md
@@ -142,9 +142,9 @@ None
 
 The `cds-services-archetype` is used by the `@sap/cds-dk` to generate initial CAP Java projects.
 
-#### Default JDK version
+#### Default JDK Version
 
-The default JDK version of new CAP Java projects has been changed to JDK **25**. The minimum required JDK version is still 17, this has not been changed.
+The default JDK version of new CAP Java projects has been changed to JDK **25**. The minimum required JDK version hasn't changed and is still 17.
 
 ### Removed repackaged Olingo Dependencies { #removed-olingo-4-to-5 }
 


### PR DESCRIPTION
BLI: https://github.wdf.sap.corp/cds-java/home/issues/2645