### PR TITLE
chore: fetch Java artifacts w/o credentials

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,6 @@ jobs:
           SITE_HOSTNAME: https://cap.js.org
           VITE_CAPIRE_PREVIEW: true
           VITE_CAPIRE_EXTRA_ASSETS: true
-          MAVEN_HOST: https://common.repositories.cloud.sap/artifactory/build.releases
-          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
       - run: npm test
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -62,9 +62,6 @@ jobs:
         run: |
           npm ci
           .github/java-properties/update-properties.js
-        env:
-          MAVEN_HOST: https://common.repositories.cloud.sap/artifactory/build.releases
-          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
 
       - name: Check for changes
         run: |


### PR DESCRIPTION
Use Maven Central again that doesn't require creds. Let's see if this is good enough, i.e. if we hit a rate limit at all.