### PR TITLE
Remove vector dimension from examples

### DIFF
--- a/cds/types.md
+++ b/cds/types.md
@@ -13,27 +13,27 @@ status: released
 The following table lists the built-in types in CDS, and their most common mapping to
 ANSI SQL types, when deployed to a relational database (concrete mappings to specific databases may differ):
 
-| CDS Type            | Remarks                                                                | ANSI SQL       |
-|---------------------|------------------------------------------------------------------------|----------------|
-| `UUID`              | [RFC 4122](https://tools.ietf.org/html/rfc4122)-compliant UUIDs        | _NVARCHAR(36)_ |
-| `Boolean`           | Values: `true`, `false`, `null`, `0`, `1`                              | _BOOLEAN_      |
-| `Integer`           | Same as `Int32` by default                                             | _INTEGER_      |
-| `Int16`             | Signed 16-bit integer, range *[ -2<sup>15</sup> ... +2<sup>15</sup> )* | _SMALLINT_     |
-| `Int32`             | Signed 32-bit integer, range *[ -2<sup>31</sup> ... +2<sup>31</sup> )* | _INTEGER_      |
-| `Int64`             | Signed 64-bit integer, range *[ -2<sup>63</sup> ... +2<sup>63</sup> )* | _BIGINT_       |
-| `UInt8`             | Unsigned 8-bit integer, range *[ 0 ... 255 ]*                          | _TINYINT_      |
-| `Decimal`(`p`,`s`)  | Decimal with precision `p` and scale `s`                               | _DECIMAL_      |
-| `Double`            | Floating point with binary mantissa                                    | _DOUBLE_       |
-| `Date`              | e.g. `2022-12-31`                                                      | _DATE_         |
-| `Time`              | e.g. `23:59:59`                                                        | _TIME_         |
-| `DateTime`          | _sec_ precision                                                        | _TIMESTAMP_    |
-| `Timestamp`         | _µs_ precision, with up to 7 fractional digits                         | _TIMESTAMP_    |
-| `String` (`length`) | Default *length*: 255; on HANA: 5000                                   | _NVARCHAR_     |
-| `Binary` (`length`) | Default *length*: 255; on HANA: 5000                                   | _VARBINARY_    |
-| `Vector` (`length`) | for Vector Embeddings [-> see notes below](#vector-embeddings)                                                  | ( _DB-specific_ )  |
-| `LargeBinary`       | Unlimited binary data, usually streamed at runtime                     | _BLOB_         |
-| `LargeString`       | Unlimited textual data, usually streamed at runtime                    | _NCLOB_        |
-| `Map`               | Mapped to *NCLOB* for HANA.                                            | *JSON* type    |
+| CDS Type               | Remarks                                                                | ANSI SQL       |
+|------------------------|------------------------------------------------------------------------|----------------|
+| `UUID`                 | [RFC 4122](https://tools.ietf.org/html/rfc4122)-compliant UUIDs        | _NVARCHAR(36)_ |
+| `Boolean`              | Values: `true`, `false`, `null`, `0`, `1`                              | _BOOLEAN_      |
+| `Integer`              | Same as `Int32` by default                                             | _INTEGER_      |
+| `Int16`                | Signed 16-bit integer, range *[ -2<sup>15</sup> ... +2<sup>15</sup> )* | _SMALLINT_     |
+| `Int32`                | Signed 32-bit integer, range *[ -2<sup>31</sup> ... +2<sup>31</sup> )* | _INTEGER_      |
+| `Int64`                | Signed 64-bit integer, range *[ -2<sup>63</sup> ... +2<sup>63</sup> )* | _BIGINT_       |
+| `UInt8`                | Unsigned 8-bit integer, range *[ 0 ... 255 ]*                          | _TINYINT_      |
+| `Decimal`(`p`,`s`)     | Decimal with precision `p` and scale `s`                               | _DECIMAL_      |
+| `Double`               | Floating point with binary mantissa                                    | _DOUBLE_       |
+| `Date`                 | e.g. `2022-12-31`                                                      | _DATE_         |
+| `Time`                 | e.g. `23:59:59`                                                        | _TIME_         |
+| `DateTime`             | _sec_ precision                                                        | _TIMESTAMP_    |
+| `Timestamp`            | _µs_ precision, with up to 7 fractional digits                         | _TIMESTAMP_    |
+| `String` (`length`)    | Default *length*: 255; on HANA: 5000                                   | _NVARCHAR_     |
+| `Binary` (`length`)    | Default *length*: 255; on HANA: 5000                                   | _VARBINARY_    |
+| `Vector` (`dimension`) | for Vector Embeddings [-> see notes below](#vector-embeddings)         | ( _DB-specific_ ) |
+| `LargeBinary`          | Unlimited binary data, usually streamed at runtime                     | _BLOB_         |
+| `LargeString`          | Unlimited textual data, usually streamed at runtime                    | _NCLOB_        |
+| `Map`                  | Mapped to *NCLOB* for HANA.                                            | *JSON* type    |
 
 > [!info] Default String Lengths
 > Lengths can be omitted, in which case default lengths are used. While this is usual in initial phases of a project, productive apps should always use explicitly defined length. The respective default lengths are configurable through the config options

--- a/guides/databases/vector-embeddings.md
+++ b/guides/databases/vector-embeddings.md
@@ -12,11 +12,11 @@ Choose an embedding model that fits your use case and data (for example English 
 Use the [SAP Generative AI Hub](https://www.sap.com/products/artificial-intelligence/generative-ai-hub.html) for unified consumption of embedding models and LLMs across different vendors and open-source models. Check for available models on the [SAP AI Launchpad](https://help.sap.com/docs/ai-launchpad/sap-ai-launchpad-user-guide/models-and-scenarios-in-generative-ai-hub-fef463b24bff4f44a33e98bb1e4f3148#models).
 
 ## Add Embeddings to Your CDS Model
-Use the built-in CDL [Vector type](../../cds/types) in your CDS model to store embeddings. Set the vector dimensions to match the embedding model (for example, 768 for *SAP_GXY.20250407*).
+Use the built-in CDL [Vector type](../../cds/types) to store embeddings. Use `Vector` without specifying a dimension to simplify changing the embedding model. If you specify a vector dimension, make sure it matches the embedding model (for example, 768 for *SAP_GXY.20250407*).
 
 ```cds
 extend Incidents with {
-  embedding : Vector(768);
+  embedding : Vector;
 }
 ```
 
@@ -34,7 +34,7 @@ To generate vector embeddings on write in SAP HANA, you can use the [vector_embe
 ```cds
 extend Incidents with {
   @cds.api.ignore
-  embedding : Vector(768) = vector_embedding( 
+  embedding : Vector = vector_embedding( 
     'Title: ' || title || ', Summary: ' || summary, 
     'DOCUMENT', 'SAP_GXY.20250407'
   ) stored; 

--- a/java/cds-data.md
+++ b/java/cds-data.md
@@ -330,7 +330,7 @@ Map data can be nested and may contain nested maps and lists, which are serializ
 
 ## Vector Embeddings { #vector-embeddings }
 
-In CDS [vector embeddings](../guides/databases/vector-embeddings) are stored in elements of type `cds.Vector`:
+In CDS [vector embeddings](../guides/databases/vector-embeddings) are stored in elements of type `Vector`:
 
 CAP Java support the vector type on SAP HANA, as well as H2 and SQLite for local testing. On Postgres (beta) support for vectors requires the [pgvector](https://github.com/pgvector/pgvector) extension.
 

--- a/java/working-with-cql/query-api.md
+++ b/java/working-with-cql/query-api.md
@@ -1658,7 +1658,7 @@ To automatically generate vector embeddings on write in the database, you can de
 ```cds
 extend Incidents with {
   @cds.api.ignore
-  embedding : cds.Vector(768) = vector_embedding(
+  embedding : Vector = vector_embedding(
        'title: ' || title || ', summary: ' || summary,
        'DOCUMENT', 'SAP_GXY.20250407') stored;
 }


### PR DESCRIPTION
- `Vector` (`length`) -> `Vector` (`dimension`)
- Remove vector dimension from examples