### PR TITLE
Add concrete logger example for application.yaml

### DIFF
--- a/java/operating-applications/observability.md
+++ b/java/operating-applications/observability.md
@@ -99,6 +99,11 @@ logging.level.my.loggers.order.Consolidation: INFO
 
 # Turn off all loggers matching org.springframework.*:
 logging.level.org.springframework: OFF
+
+# Turn on debug logging for sql statements and messaging:
+logging.level:
+  com.sap.cds.persistence.sql: DEBUG
+  com.sap.cds.messaging: DEBUG
 ```
 :::
 


### PR DESCRIPTION
Currently we don't show any cds specific loggers in the `application.yaml` example. Users reading capire are expecting to find CAP specific information. Adding an example for some of the most used settings.