### PR TITLE
fix local binding registry filename in reuse-and-compose.md

### DIFF
--- a/guides/integration/reuse-and-compose.md
+++ b/guides/integration/reuse-and-compose.md
@@ -594,9 +594,9 @@ You can cmd/ctrl-click or double click on that to see the file's content, and fi
 
 Whenever you start a CAP server with `cds watch`, this is what happens automatically:
 
-1. For all *provided* services, corresponding entries are written to _~/cds-services.json_ with respective `credentials`, namely the `url`.
+1. For all *provided* services, corresponding entries are written to _~/.cds-services.json_ with respective `credentials`, namely the `url`.
 
-2. For all *required* services, corresponding entries are fetched from _~/cds-services.json_. If found, the `credentials` are filled into the respective entry in `cds.env.requires.<service>`  [as introduced previously](#bindings-via-cds-env).
+2. For all *required* services, corresponding entries are fetched from _~/.cds-services.json_. If found, the `credentials` are filled into the respective entry in `cds.env.requires.<service>`  [as introduced previously](#bindings-via-cds-env).
 
 In effect, all the services that you start locally in separate processes automatically receive their required bindings so they can talk to each other out of the box.
 


### PR DESCRIPTION
The file starts with a dot and this was omitted in a couple of places in this section.