### PR TITLE
fix: support redirects ending with `/`

### DIFF
--- a/.vitepress/rewrites.js
+++ b/.vitepress/rewrites.js
@@ -18,7 +18,6 @@ export class Rewrites {
       for (let line of md.split('\n')) {
         let [,from,to] = /^[^[]*\[(.*)\]\((.*)\)/.exec(line) || []
         if (!from || !to) continue
-        if (from.at(-1) === '/') from = from.slice(0,-1)
         entries[from] = to
       }
     } catch {/* ignored */}


### PR DESCRIPTION
So that http://cap.cloud.sap/docs/about/ works again.
This one is referenced from https://me.sap.com/notes/3464370.