### PR TITLE
fix: drop Node.js 20 references, recommend 22/24

### DIFF
--- a/get-started/get-help.md
+++ b/get-started/get-help.md
@@ -34,7 +34,7 @@ To start VS Code via the `code` CLI, users on macOS must first run a command (*S
 
 ### Check the Node.js version { #node-version}
 
-Run the latest LTS version of Node.js (even numbers: 20, 22, 24). Avoid odd versions, as some modules with native parts may not install. Check version with:
+Run the latest LTS version of Node.js (even numbers: 22, 24). Avoid odd versions, as some modules with native parts may not install. Check version with:
 
 ```sh
 node -v
@@ -335,7 +335,7 @@ To fix this, either switch the Node.js version using a Node version manager, or 
 ```xml
 <properties>
 		<!-- ... -->
-		<cds.install-node.nodeVersion>v20.11.0</cds.install-node.nodeVersion>
+		<cds.install-node.nodeVersion>v22.14.0</cds.install-node.nodeVersion>
 		<!-- ... -->
 	</properties>
 

--- a/get-started/get-help.md
+++ b/get-started/get-help.md
@@ -335,7 +335,7 @@ To fix this, either switch the Node.js version using a Node version manager, or 
 ```xml
 <properties>
 		<!-- ... -->
-		<cds.install-node.nodeVersion>v22.14.0</cds.install-node.nodeVersion>
+		<cds.install-node.nodeVersion>v24.14.1</cds.install-node.nodeVersion>
 		<!-- ... -->
 	</properties>
 


### PR DESCRIPTION
Node.js 20 reached end of life in April 2026. Update the get-help guide to no longer list it as a supported LTS version and bump the Maven pom.xml example to v24.14.1.