### PR TITLE
Exclude old MTX apis+migration from sitemap

### DIFF
--- a/guides/multitenancy/old-mtx-apis.md
+++ b/guides/multitenancy/old-mtx-apis.md
@@ -2,6 +2,7 @@
 synopsis: >
   API reference documentation for MTX Services.
 search: false
+sitemap: false
 ---
 
 

--- a/guides/multitenancy/old-mtx-migration.md
+++ b/guides/multitenancy/old-mtx-migration.md
@@ -2,11 +2,7 @@
 shorty: MTX Migration
 synopsis: >
   Explains how to migrate from <code>@sap/cds-mtx</code> (aka Old MTX) to 'streamlined' <code>@sap/cds-mtxs</code>.
-breadcrumbs:
-  - Cookbook
-  - Multitenancy
-  - Migration
-# layout: cookbook
+sitemap: false
 impl-variants: true
 ---
 


### PR DESCRIPTION
This is confusing in SAP4Me search.