### PR TITLE
feat: standard vector database functions

### DIFF
--- a/guides/databases/cap-level-dbs.md
+++ b/guides/databases/cap-level-dbs.md
@@ -163,6 +163,8 @@ SELECT firstName || ' ' || lastName as fullName from Authors;
 - `l2normalize(x)` -> Vector
 - `vector_embedding(field, kind?, model?)` -> Vector
 
+For `vector_embedding`, `kind` defaults to `'DOCUMENT'` and `model` to `'SAP_GXY.20250407'`; use the `vectorEmbeddingDefaultModel` and `vectorEmbeddingHanaDefaultRemoteSource` compiler options to change these defaults.
+
 > [!warning] HANA and PostgreSQL only
 > Vector functions require SAP HANA Cloud or PostgreSQL with [pgvector](https://github.com/pgvector/pgvector). On SQLite and H2, they are emulated via user-defined functions for local testing.
 

--- a/guides/databases/cap-level-dbs.md
+++ b/guides/databases/cap-level-dbs.md
@@ -156,6 +156,17 @@ SELECT firstName || ' ' || lastName as fullName from Authors;
 - `seconds_between(x,y)` -> number
 
 
+### Vector Functions
+
+- `cosine_similarity(x,y)` -> number
+- `l2distance(x,y)` -> number
+- `l2normalize(x)` -> Vector
+- `vector_embedding(field, kind?, model?)` -> Vector
+
+> [!warning] HANA and PostgreSQL only
+> Vector functions require SAP HANA Cloud or PostgreSQL with [pgvector](https://github.com/pgvector/pgvector). On SQLite and H2, they are emulated via user-defined functions for local testing.
+
+
 ### Aggregate Functions
 
 - `avg(x)`, `average(x)`

--- a/guides/databases/cap-level-dbs.md
+++ b/guides/databases/cap-level-dbs.md
@@ -164,7 +164,7 @@ SELECT firstName || ' ' || lastName as fullName from Authors;
 - `vector_embedding(field, kind?, model?)` -> Vector
 
 > [!warning] HANA and PostgreSQL only
-> Vector functions require SAP HANA Cloud or PostgreSQL with [pgvector](https://github.com/pgvector/pgvector). On SQLite and H2, they are emulated via user-defined functions for local testing.
+> Vector functions require SAP HANA Cloud or PostgreSQL with [pgvector](https://github.com/pgvector/pgvector).
 
 
 ### Aggregate Functions


### PR DESCRIPTION
adding functions which will become available with next compiler v7

Java emulates those functions for `h2` and `sqlite` via UDFs, node does not yet support them