### PR TITLE
use concrete version number for open rewrite call

### DIFF
--- a/java/migration.md
+++ b/java/migration.md
@@ -36,7 +36,7 @@ As migration is a one-time operation, run the OpenRewrite `recipes` as a command
 
 ```bash-vue
 mvn org.openrewrite.maven:rewrite-maven-plugin:run \
-  -Drewrite.recipeArtifactCoordinates=com.sap.cds:cds-services-recipes:{{ versions.java_services }} \
+  -Drewrite.recipeArtifactCoordinates=com.sap.cds:cds-services-recipes:5.0.0 \
   -Drewrite.activeRecipes=com.sap.cds.services.migrations.Cap_5.0
 ```
 


### PR DESCRIPTION
the migration name has a version, too but we can't use the placeholder here. Thus, I will also remove the other placeholder.