### PR TITLE
Minor fixes to constraints.md

### DIFF
--- a/guides/services/constraints.md
+++ b/guides/services/constraints.md
@@ -20,7 +20,7 @@ Use annotations like `@assert` and `@mandatory` to declaratively add constraints
 
 ### Constraints Annotations
 
-Following is an excerpt from the [`@capire/xtravels`](https:/github.com/capire/xtravels/tree/main/srv/travel-constraints.cds) sample:
+Following is an excerpt from the [`@capire/xtravels`](https://github.com/capire/xtravels/tree/main/srv/travel-constraints.cds) sample:
 
 ::: code-group
 
@@ -211,7 +211,7 @@ annotate TravelService.Travels with {
 }
 ```
 
-We can also use **path expressions** to compare with data from **associated** entities. For example, this one is from anoter annotation on `TravelService.Bookings` in the [`@capire/xtravels`](https:/github.com/capire/xtravels/tree/main/srv/travel-constraints.cds) sample, that checks if all currencies specified in the list of bookings match the currency chosen in the travel header, refered to by the `Travel` association:
+We can also use **path expressions** to compare with data from **associated** entities. For example, this one is from anoter annotation on `TravelService.Bookings` in the [`@capire/xtravels`](https://github.com/capire/xtravels/tree/main/srv/travel-constraints.cds) sample, that checks if all currencies specified in the list of bookings match the currency chosen in the travel header, refered to by the `Travel` association:
 
 ```cds
 annotate TravelService.Bookings with {

--- a/guides/services/constraints.md
+++ b/guides/services/constraints.md
@@ -211,7 +211,7 @@ annotate TravelService.Travels with {
 }
 ```
 
-We can also use **path expressions** to compare with data from **associated** entities. For example, this one is from anoter annotation on `TravelService.Bookings` in the [`@capire/xtravels`](https://github.com/capire/xtravels/tree/main/srv/travel-constraints.cds) sample, that checks if all currencies specified in the list of bookings match the currency chosen in the travel header, refered to by the `Travel` association:
+We can also use **path expressions** to compare with data from **associated** entities. For example, this one is from another annotation on `TravelService.Bookings` in the [`@capire/xtravels`](https://github.com/capire/xtravels/tree/main/srv/travel-constraints.cds) sample, that checks if all currencies specified in the list of bookings match the currency chosen in the travel header, refered to by the `Travel` association:
 
 ```cds
 annotate TravelService.Bookings with {


### PR DESCRIPTION
missing slash after scheme in URL causes the target URL to be conflated, leading to e.g. `https://cap.cloud.sap/github.com/capire/xtravels/tree/main/srv/travel-constraints.cds` and a 404.

Also fixed a typo (anoter -> another).