### PR TITLE
Clarification on using directive

### DIFF
--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -146,11 +146,10 @@ Within those strings, escape sequences from JavaScript, such as `\t` or `\u0020`
 
 #### The `using` Directive {#using}
 
-Using directives allows to import definitions from other CDS models. As shown in line three below, you optionally can specify local aliases to be used subsequently. You can import single definitions as well as several ones with a common namespace prefix.
+Using directives allows to import definitions from other CDS models. As shown in line 3 below, you optionally can specify local aliases to be used subsequently. You can import single definitions as well as several ones with a common namespace prefix.
 
 ::: code-group
 
-```cds [using-from.cds]
 using foo.bar.scoped.Bar from './contexts';
 using foo.bar.scoped.nested from './contexts';
 using foo.bar.scoped.nested as specified from './contexts';
@@ -172,8 +171,9 @@ entity Car : Bar { /*...*/ }
 
 > Also in the deconstructor variant of `using` shown in the previous example, specify fully qualified names.
 
-All definitions of the model proivided after `from` are imported, no matter which names are specified before `from`.
-The purpose of these names is only to make global names accessible locally.
+> [!important] Names do not restrict the import scope
+> All definitions of the model provided after `from` are imported, no matter which names are specified before `from`.
+> The purpose of these names is only to make global names accessible locally.
 
 
 

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -156,7 +156,7 @@ using foo.bar.scoped.nested as animal from './contexts';
 
 entity Car : Bar {}            //> : foo.bar.scoped.Bar
 entity Moo : nested.Zoo {}     //> : foo.bar.scoped.nested.Zoo
-entity Zoo : animal.Zoo {}  //> : foo.bar.scoped.nested.Zoo
+entity Zoo : animal.Zoo {}     //> : foo.bar.scoped.nested.Zoo
 ```
 
 :::

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -152,11 +152,11 @@ Using directives allows to import definitions from other CDS models. As shown in
 
 using foo.bar.scoped.Bar from './contexts';
 using foo.bar.scoped.nested from './contexts';
-using foo.bar.scoped.nested as specified from './contexts';
+using foo.bar.scoped.nested as animal from './contexts';
 
 entity Car : Bar {}            //> : foo.bar.scoped.Bar
 entity Moo : nested.Zoo {}     //> : foo.bar.scoped.nested.Zoo
-entity Zoo : specified.Zoo {}  //> : foo.bar.scoped.nested.Zoo
+entity Zoo : animal.Zoo {}  //> : foo.bar.scoped.nested.Zoo
 ```
 
 :::

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -146,7 +146,7 @@ Within those strings, escape sequences from JavaScript, such as `\t` or `\u0020`
 
 #### The `using` Directive {#using}
 
-Using directives allows to import definitions from other CDS models. As shown in line three below you can specify aliases to be used subsequently. You can import single definitions as well as several ones with a common namespace prefix. Optional: Choose a local alias.
+Using directives allows to import definitions from other CDS models. As shown in line three below, you optionally can specify local aliases to be used subsequently. You can import single definitions as well as several ones with a common namespace prefix.
 
 ::: code-group
 
@@ -172,6 +172,8 @@ entity Car : Bar { /*...*/ }
 
 > Also in the deconstructor variant of `using` shown in the previous example, specify fully qualified names.
 
+All definitions of the model proivided after `from` are imported, no matter which names are specified before `from`.
+The purpose of these names is only to make global names accessible locally.
 
 
 

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -146,7 +146,7 @@ Within those strings, escape sequences from JavaScript, such as `\t` or `\u0020`
 
 #### The `using` Directive {#using}
 
-Using directives allows to import definitions from other CDS models. As shown in line 3 below, you optionally can specify local aliases to be used subsequently. You can import single definitions as well as several ones with a common namespace prefix.
+Using directives allow to import definitions from other CDS models. As shown in line 3 below, you optionally can specify local aliases to be used subsequently. You can import single definitions as well as several ones with a common namespace prefix.
 
 ::: code-group
 


### PR DESCRIPTION
Clarify that the names provided in a `using´ directive don't influence what is imported into the model.

This change was triggered by stakeholder questions.