### PR TITLE
Remove @data.product anno from xflights srv sample in cds-export section

### DIFF
--- a/tools/cds-cli.md
+++ b/tools/cds-cli.md
@@ -482,7 +482,7 @@ could look like this:
 ```cds [srv/data-service.cds]
 using { sap.capire.flights as my } from '../db/schema';
 
-@data.product @hcql @rest @odata
+@hcql @rest @odata
 service sap.capire.flights.data {
   @readonly entity Flights as projection on my.Flights;
   @readonly entity Airlines as projection on my.Airlines;


### PR DESCRIPTION
The annotation [was removed in the source](https://github.com/capire/xflights/commit/52edcaa5a7b779ee734fb62942c8959dbd5b2e48) so perhaps this should be realigned.