### PR TITLE
config: add anchor section to align build anchors with vs code anchors

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -47,7 +47,6 @@ const config = defineConfig({
     anchor: {
       // VS Code-compatible GitHub-style slugifier (mirrors markdown-language-features/src/slugify.ts)
       slugify: (str) => str
-        .replace(/\{[^}]*\}/g, '')
         .trim().toLowerCase()
         .replace(/[^\p{L}\p{N}\p{M}\s_-]/gu, '')
         .replace(/\s/g, '-'),

--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -44,6 +44,17 @@ const config = defineConfig({
     toc: {
       level: [2,3]
     },
+    anchor: {
+      slugify: (str) => str.replace(/\{[^}]*\}/g, '').normalize('NFKD')
+        .replace(/[\u0300-\u036F]/g, '')
+        .replace(/[\u0000-\u001f]/g, '')
+        .replace(/\./g, '')
+        .replace(/[\s~`!@#$%^&*()\-_+=[\]{}|\\;:"'\u2018\u2019\u201C\u201D<>,.?/]+/g, '-')
+        .replace(/-{2,}/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .replace(/^(\d)/, '_$1')
+        .toLowerCase()
+    },
     container: { // Doesn't seem to work yet
       infoLabel: 'Info',
       noteLabel: 'Note',

--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -2,12 +2,12 @@
 const base =  process.env.GH_BASE || '/docs/'
 
 // Construct vitepress config object...
-import { dirname, join, resolve } from 'node:path'
 import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitepress'
-import playground from './lib/cds-playground/index.js'
 import languages from './languages'
+import playground from './lib/cds-playground/index.js'
 import { Menu } from './menu.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -45,15 +45,12 @@ const config = defineConfig({
       level: [2,3]
     },
     anchor: {
-      slugify: (str) => str.replace(/\{[^}]*\}/g, '').normalize('NFKD')
-        .replace(/[\u0300-\u036F]/g, '')
-        .replace(/[\u0000-\u001f]/g, '')
-        .replace(/\./g, '')
-        .replace(/[\s~`!@#$%^&*()\-_+=[\]{}|\\;:"'\u2018\u2019\u201C\u201D<>,.?/]+/g, '-')
-        .replace(/-{2,}/g, '-')
-        .replace(/^-+|-+$/g, '')
-        .replace(/^(\d)/, '_$1')
-        .toLowerCase()
+      // VS Code-compatible GitHub-style slugifier (mirrors markdown-language-features/src/slugify.ts)
+      slugify: (str) => str
+        .replace(/\{[^}]*\}/g, '')
+        .trim().toLowerCase()
+        .replace(/[^\p{L}\p{N}\p{M}\s_-]/gu, '')
+        .replace(/\s/g, '-'),
     },
     container: { // Doesn't seem to work yet
       infoLabel: 'Info',
@@ -214,10 +211,10 @@ config.themeConfig.search = {
 
 // Add custom markdown renderers...
 import { dl } from '@mdit/plugin-dl'
-import * as MdAttrsPropagate from './lib/md-attrs-propagate'
-import * as MdTypedModels from './lib/md-typed-models'
 import * as MdLiveCode from './lib/cds-playground/md-live-code'
+import * as MdAttrsPropagate from './lib/md-attrs-propagate'
 import * as MdDiagramSvg from './lib/md-diagram-svg'
+import * as MdTypedModels from './lib/md-typed-models'
 
 config.markdown.config = md => {
   MdAttrsPropagate.install(md)

--- a/cds/_menu.md
+++ b/cds/_menu.md
@@ -1,10 +1,10 @@
 
 # [Definition Language (CDL)](cdl)
 
-  ## [Keywords & Identifiers](cdl#keywords-identifiers)
+  ## [Keywords & Identifiers](cdl#keywords--identifiers)
   ## [Built-in Types & Literals](cdl#built-in-types)
-  ## [Entities & Type Definitions](cdl#entities-type-definitions)
-  ## [Views & Projections](cdl#views-projections)
+  ## [Entities & Type Definitions](cdl#entities--type-definitions)
+  ## [Views & Projections](cdl#views--projections)
   ## [Associations](cdl#associations)
   ## [Annotations](cdl#annotations)
   ## [Aspects](cdl#aspects)

--- a/cds/annotations.md
+++ b/cds/annotations.md
@@ -38,9 +38,9 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
 |------------------|----------------------------------------------------------------------|
 | `@readonly `     | see [Input Validation](../guides/services/constraints#readonly)      |
 | `@mandatory`     | see [Input Validation](../guides/services/constraints#mandatory)     |
-| `@assert.target` | see [Input Validation](../guides/services/constraints#assert-target) |
-| `@assert.format` | see [Input Validation](../guides/services/constraints#assert-format) |
-| `@assert.range`  | see [Input Validation](../guides/services/constraints#assert-range)  |
+| `@assert.target` | see [Input Validation](../guides/services/constraints#asserttarget) |
+| `@assert.format` | see [Input Validation](../guides/services/constraints#assertformat) |
+| `@assert.range`  | see [Input Validation](../guides/services/constraints#assertrange)  |
 
 
 
@@ -56,21 +56,21 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
 | `@cds.api.ignore`    | see [OData](../guides/protocols/odata#omitting-elements-from-apis)                      |
 | `@cds.query.limit`   | see [Providing Services](../guides/services/served-ootb#annotation-cds-query-limit)     |
 | `@cds.localized`     | see [Localized Data](../guides/uis/localized-data#read-operations)                      |
-| `@cds.valid.from/to` | see [Temporal Data](../guides/domain/temporal-data#using-annotations-cds-valid-from-to) |
+| `@cds.valid.from/to` | see [Temporal Data](../guides/domain/temporal-data#using-annotations-cdsvalidfromto) |
 | `@cds.search`        | see [Search Capabilities](../guides/services/served-ootb#searching-data)                |
 
 ## Persistence
 
 | Annotation                | Description                                                                  |
 |---------------------------|------------------------------------------------------------------------------|
-| `@cds.persistence.exists` | see [Generating DDL Files](../guides/databases/cdl-to-ddl#cds-persistence-exists) |
-| `@cds.persistence.table`  | see [Generating DDL Files](../guides/databases/cdl-to-ddl#cds-persistence-table)  |
-| `@cds.persistence.skip`   | see [Generating DDL Files](../guides/databases/cdl-to-ddl#cds-persistence-skip)   |
+| `@cds.persistence.exists` | see [Generating DDL Files](../guides/databases/cdl-to-ddl#cdspersistenceexists) |
+| `@cds.persistence.table`  | see [Generating DDL Files](../guides/databases/cdl-to-ddl#cdspersistencetable)  |
+| `@cds.persistence.skip`   | see [Generating DDL Files](../guides/databases/cdl-to-ddl#cdspersistenceskip)   |
 | `@cds.persistence.mock`   | `false` excludes this entity from automatic mocking                          |
 | `@cds.on.insert`          | see [Providing Services](../guides/services/providing-services)              |
 | `@cds.on.update`          | see [Providing Services](../guides/services/providing-services)              |
-| `@sql.prepend`            | see [Generating DDL Files](../guides/databases/cdl-to-ddl#sql-prepend-append)     |
-| `@sql.append`             | see [Generating DDL Files](../guides/databases/cdl-to-ddl#sql-prepend-append)     |
+| `@sql.prepend`            | see [Generating DDL Files](../guides/databases/cdl-to-ddl#sqlprepend--append)     |
+| `@sql.append`             | see [Generating DDL Files](../guides/databases/cdl-to-ddl#sqlprepend--append)     |
 
 ## OData
 

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -25,7 +25,7 @@ The *Conceptual Definition Language (CDL)* is a human-readable language for defi
 
 
 
-- [Keywords & Identifiers](#keywords-identifiers)
+- [Keywords & Identifiers](#keywords--identifiers)
 - [Built-in Types](#built-in-types)
 - [Literals](#literals)
 - [Model Imports](#model-imports)
@@ -696,7 +696,7 @@ entity Orders {
 }
 ```
 
-To enforce your _enum_ values during runtime, use the [`@assert.range` annotation](../guides/services/constraints#assert-range).
+To enforce your _enum_ values during runtime, use the [`@assert.range` annotation](../guides/services/constraints#assertrange).
 For localization of enum values, model them as [code list](./common#adding-own-code-lists).
 
 <br>
@@ -858,7 +858,7 @@ Result result = service.run(Select.from("UsingView"), params);
 
 ### Runtime Views { #runtimeviews }
 
-To add or update CDS views without redeploying the database schema, annotate them with [@cds.persistence.skip](../guides/databases/cdl-to-ddl#cds-persistence-skip). This advises the CDS compiler to skip generating database views for these CDS views. Instead, CAP resolves them *at runtime* on each request. 
+To add or update CDS views without redeploying the database schema, annotate them with [@cds.persistence.skip](../guides/databases/cdl-to-ddl#cdspersistenceskip). This advises the CDS compiler to skip generating database views for these CDS views. Instead, CAP resolves them *at runtime* on each request. 
 
 Runtime views must be simple [projections](#as-projection-on), not using *aggregations*, *join*, *union* or *subqueries* in the *from* clause, but may have a *where* condition if they are only used to read.
 

--- a/cds/compiler/hdbcds-to-hdbtable.md
+++ b/cds/compiler/hdbcds-to-hdbtable.md
@@ -69,7 +69,7 @@ If the table doesn't contain much data, this process won't significantly impact 
 
 ## Annotations
 
-Annotations [`@sql.append/prepend`](../../guides/databases/cdl-to-ddl#sql-prepend-append) are used to generate native SQL clauses to the _.hdbtable_ files, or add native SAP HANA CDS clauses to the _.hdbcds_ files.
+Annotations [`@sql.append/prepend`](../../guides/databases/cdl-to-ddl#sqlprepend--append) are used to generate native SQL clauses to the _.hdbtable_ files, or add native SAP HANA CDS clauses to the _.hdbcds_ files.
 
 If you have used these annotations in your model, a simple switchover from `hdbcds` to `hdbtable` is unlikely as such an annotation written for `hdbcds` in general is not valid for `hdbtable`. You'll have to adapt your model before the migration.
 

--- a/cds/cqn.md
+++ b/cds/cqn.md
@@ -41,7 +41,7 @@ let results = await cds.run (query)
 ```
 
 Following is a detailed specification of the CQN as [TypeScript declarations](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html), including all query types and their properties,
-as well as the fundamental expression types. Find the [full CQN type definitions in the appendix below](#full-cqn-d-ts-file).
+as well as the fundamental expression types. Find the [full CQN type definitions in the appendix below](#full-cqndts-file).
 
 
 ## SELECT

--- a/cds/cxl.md
+++ b/cds/cxl.md
@@ -576,10 +576,10 @@ Following table gives an overview of the guaranteed supported operators in CXL:
 | `and`, `or` | Logical operators. | `x>1 or y<2` |
 
 > [!tip] Bivalent `==` and `!=` Operators
-> In addition to standard SQL's `=` and `<>` operators, CXL also supports `==` and `!=` as bivalent variants as opposed to the trivalent semantics of `=` and `<>` when it comes to null handling. Learn more about this in the [_Bivalent `==` and `!=` Operators_](../guides/databases/cap-level-dbs#bivalent-and-operators) section of the databases documentation.
+> In addition to standard SQL's `=` and `<>` operators, CXL also supports `==` and `!=` as bivalent variants as opposed to the trivalent semantics of `=` and `<>` when it comes to null handling. Learn more about this in the [_Bivalent `==` and `!=` Operators_](../guides/databases/cap-level-dbs#bivalent--and--operators) section of the databases documentation.
 
 > [!tip] Ternary `?:` Operator 
-> In addition to the standard SQL `case when then` expression, CXL also supports the ternary `?:` operator as a more concise syntax for simple case expressions. Learn more about this in the [_Ternary `?:` Operator_](../guides/databases/cap-level-dbs#ternary-operator) section of the databases documentation.
+> In addition to the standard SQL `case when then` expression, CXL also supports the ternary `?:` operator as a more concise syntax for simple case expressions. Learn more about this in the [_Ternary `?:` Operator_](../guides/databases/cap-level-dbs#ternary--operator) section of the databases documentation.
 
 
 

--- a/get-started/bookshop.md
+++ b/get-started/bookshop.md
@@ -686,7 +686,7 @@ While the generic providers serve most CRUD requests out of the box, you can add
 
 - Use [declarative constraints](#declarative-constraints) for most input validation cases, which are enforced by generic runtimes automatically.
 
-- Add [custom event handlers in Node.js](#custom-handlers-in-node-js) or [in Java](#custom-handlers-in-java) to CAP services for more complex programmatic logic, such as modifying response data, or handling [custom actions](#custom-actions).
+- Add [custom event handlers in Node.js](#custom-handlers-in-nodejs) or [in Java](#custom-handlers-in-java) to CAP services for more complex programmatic logic, such as modifying response data, or handling [custom actions](#custom-actions).
 
 > [!note] Choosing between Node.js and Java
 > The latter is the first time in this guide where you need to choose between Node.js and Java as your CAP runtime.

--- a/get-started/concepts.md
+++ b/get-started/concepts.md
@@ -711,7 +711,7 @@ In effect your service implementations stay agnostic to (wire) protocols, which 
 
 ![protocol-adapters.drawio](./assets/concepts/protocol-adapters.drawio.svg)
 
-The inbound and outbound adapters (and the framework services) effectively provide your inner core with the ***ports*** to the outside world, which always provide the same, hence *agnostic* style of API (indicated by the green arrows used in the previous graphic), as already introduced in [Local  /Remote](#local-remote).
+The inbound and outbound adapters (and the framework services) effectively provide your inner core with the ***ports*** to the outside world, which always provide the same, hence *agnostic* style of API (indicated by the green arrows used in the previous graphic), as already introduced in [Local  /Remote](#local--remote).
 
 Inbound:
 

--- a/get-started/feature-matrix.md
+++ b/get-started/feature-matrix.md
@@ -168,7 +168,7 @@ Following is an index of the features currently covered by CAP, with status and 
 
 | Outbound Protocol Support                                        | CDS <sup>1</sup> | Node.js | Java |
 |------------------------------------------------------------------|:----------------:|:-------:|:----:|
-| [REST/OpenAPI](../tools/apis/cds-import#cds-import-from-openapi) |       <X/>       |  <X/>   | <X/> |
+| [REST/OpenAPI](../tools/apis/cds-import#cdsimportfromopenapi) |       <X/>       |  <X/>   | <X/> |
 | OData V2                                                         |       <X/>       |  <X/>   | <X/> |
 | OData V4                                                         |       <X/>       |  <X/>   | <X/> |
 | GraphQL<sup>2</sup>                                              |       <C/>       |  <C/>   | <C/> |

--- a/get-started/get-help.md
+++ b/get-started/get-help.md
@@ -212,7 +212,7 @@ module.exports = cds.server
 |              | Explanation                                                                                                                                            |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | _Root Cause_ | Most probably, the service name in the `requires` section does not match the served service definition.                                                |
-| _Solution_   | Set the `.service` property in the respective `requires` entry. See [cds.connect()](../node.js/cds-connect#cds-requires-srv-service) for more details. |
+| _Solution_   | Set the `.service` property in the respective `requires` entry. See [cds.connect()](../node.js/cds-connect#cdsrequiressrvservice) for more details. |
 
 
 ### Why does my remote service call not work?

--- a/guides/databases/cdl-to-ddl.md
+++ b/guides/databases/cdl-to-ddl.md
@@ -465,7 +465,7 @@ CREATE TABLE BadNames (
 However, even though CAP allows this, and handles all accesses correctly, it is strongly discouraged to use such names in your CDS models, as that may lead to unexpected issues in several scenarios, not in control of CAP, such as native SQL queries, third-party tools, or integration with non-CAP applications.
 
 > [!warning]  DON'T use Database-Invalid Names!
-> It's **strongly discouraged** to use names that contain non-ASCII characters, or conflict with database reserved words. Even more avoid [delimited names](../../cds/cdl#keywords-identifiers) in CDS models in the first place, as that impacts readability of your models.
+> It's **strongly discouraged** to use names that contain non-ASCII characters, or conflict with database reserved words. Even more avoid [delimited names](../../cds/cdl#keywords--identifiers) in CDS models in the first place, as that impacts readability of your models.
 
 ###### reserved-words
 > [!tip] Lists of Reserved Words
@@ -611,7 +611,7 @@ CREATE TABLE Books ( ...
 :::
 
 > [!tip] Consider using <code>@assert.target</code> instead
-> Database constraints are meant to protect against data corruption due to programming errors. Prefer using the [`@assert.target`](../services/constraints#assert-target) for application-level input validation, which is more tuned for typical application scenarios, with error messages tailored for end users.
+> Database constraints are meant to protect against data corruption due to programming errors. Prefer using the [`@assert.target`](../services/constraints#asserttarget) for application-level input validation, which is more tuned for typical application scenarios, with error messages tailored for end users.
 
 #### `ON DELETE CASCADE`
 

--- a/guides/databases/h2.md
+++ b/guides/databases/h2.md
@@ -8,4 +8,4 @@ For local development and testing, CAP Java supports the [H2](https://www.h2data
 
 Learn more about the [features and limitations of using CAP with H2.](../../java/cqn-services/persistence-services#h2)
 
-There are various options of how to configure the [H2 database for local development and testing in CAP Java.](../../java/developing-applications/testing#setup-configuration)
+There are various options of how to configure the [H2 database for local development and testing in CAP Java.](../../java/developing-applications/testing#setup--configuration)

--- a/guides/databases/hana.md
+++ b/guides/databases/hana.md
@@ -51,7 +51,7 @@ The datasource for SAP HANA is then auto-configured based on available service b
 
 ::: tip Prefer `cds add`
 
-... as documented in the [deployment guide](../deploy/to-cf#_1-sap-hana-database), which also does the equivalent of `npm add @cap-js/hana` but in addition cares for updating `mta.yaml` and other deployment resources.
+... as documented in the [deployment guide](../deploy/to-cf#1-sap-hana-database), which also does the equivalent of `npm add @cap-js/hana` but in addition cares for updating `mta.yaml` and other deployment resources.
 
 :::
 
@@ -477,7 +477,7 @@ If this is not desired, annotate these generated entities with `@cds.persistence
 
 
 ### Native Database Clauses {#schema-evolution-native-db-clauses}
-Not all clauses supported by SQL can directly be written in CDL syntax. To use native database clauses also in a CAP CDS model, you can provide arbitrary SQL snippets with the annotations [`@sql.prepend` and `@sql.append`](cdl-to-ddl#sql-prepend-append). In this section, we're focusing on schema evolution specific details.
+Not all clauses supported by SQL can directly be written in CDL syntax. To use native database clauses also in a CAP CDS model, you can provide arbitrary SQL snippets with the annotations [`@sql.prepend` and `@sql.append`](cdl-to-ddl#sqlprepend--append). In this section, we're focusing on schema evolution specific details.
 
 Schema evolution requires that any changes are applied by corresponding ALTER statements. See [ALTER TABLE statement reference](https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-sql-reference-guide/alter-table-statement-data-definition?version=2024_1_QRC) for more information. A new migration version is generated whenever an `@sql.append` or `@sql.prepend` annotation is added, changed, or removed. ALTER statements define the individual changes that create the final database schema. This schema has to match the schema defined by the TABLE statement in the _.hdbmigrationtable_ artifact.
 Please note that the compiler doesn't evaluate or process these SQL snippets. Any snippet is taken as is and inserted into the TABLE statement and the corresponding ALTER statement. The deployment fails in case of syntax errors.

--- a/guides/databases/new-dbs.md
+++ b/guides/databases/new-dbs.md
@@ -44,7 +44,7 @@ npm add @cap-js/hana
 <!-- REVISIT: A bit confusing to prefer the non-copiable variant that doesn't get its own code fence -->
 ::: details Prefer `cds add hana` ...
 
-... which also does the equivalent of `npm add @cap-js/hana` but in addition cares for updating `mta.yaml` and other deployment resources as documented in the [deployment guide](../deploy/to-cf#_1-sap-hana-database).
+... which also does the equivalent of `npm add @cap-js/hana` but in addition cares for updating `mta.yaml` and other deployment resources as documented in the [deployment guide](../deploy/to-cf#1-sap-hana-database).
 
 :::
 

--- a/guides/databases/postgres.md
+++ b/guides/databases/postgres.md
@@ -6,7 +6,7 @@ This guide focuses on the new PostgreSQL Service provided through *[@cap-js/post
 CAP Java 3 is tested on [PostgreSQL](https://www.postgresql.org/) 16 and most CAP features are supported on PostgreSQL.
 
 
-*Learn about migrating from the former `cds-pg` in the [Migration](#migration-from-cds-pg-in-node-js) chapter.*{.learn-more}
+*Learn about migrating from the former `cds-pg` in the [Migration](#migration-from-cds-pg-in-nodejs) chapter.*{.learn-more}
 [Learn more about features and limitations of using CAP Java with PostgreSQL.](../../java/cqn-services/persistence-services#postgresql){.learn-more}
 
 

--- a/guides/domain/index.md
+++ b/guides/domain/index.md
@@ -251,7 +251,7 @@ entity name {
 }
 ```
 
-[Learn more about entity definitions.](../../cds/cdl#entities-type-definitions){.learn-more}
+[Learn more about entity definitions.](../../cds/cdl#entities--type-definitions){.learn-more}
 
 
 
@@ -265,7 +265,7 @@ entity ProjectedEntity as select from BaseEntity {
 };
 ```
 
-[Learn more about views and projections.](../../cds/cdl#views-projections){.learn-more}
+[Learn more about views and projections.](../../cds/cdl#views--projections){.learn-more}
 
 
 
@@ -289,7 +289,7 @@ entity Books {
 ##### Don't: {.bad}
 
 - Don't use binary data as keys!
-- [Don't interpret UUIDs!](#don-t-interpret-uuids)
+- [Don't interpret UUIDs!](#dont-interpret-uuids)
 
 #### Prefer Simple, Technical Keys
 

--- a/guides/multitenancy/index.md
+++ b/guides/multitenancy/index.md
@@ -676,7 +676,7 @@ There are several ways to update the database schema of a multitenant applicatio
 * For **CAP Java** applications, schema updates should be done as described in the respective [Java Guide](../../java/multitenancy#database-update).
 * For **CAP Node.js** applications, you can use either of the following as shown in the examples below:
   - the `cds-mtx upgrade` command from a terminal
-  - the [MTX Sidecar API](mtxs#upgrade-tenants-→-jobs)
+  - the [MTX Sidecar API](mtxs#upgrade-tenants--jobs)
   - via a [CloudFoundry hook](https://help.sap.com/docs/btp/sap-business-technology-platform/module-hooks)
   - via a [CloudFoundry task](https://tutorials.cloudfoundry.org/cf4devs/advanced-concepts/tasks/)
   - via a [Kubernetes job](https://kubernetes.io/docs/concepts/workloads/controllers/job/)

--- a/guides/security/authentication.md
+++ b/guides/security/authentication.md
@@ -336,7 +336,7 @@ Integration tests running in production profile should verify that unauthenticat
 <div class="impl node">
 
 [Learn more about testing with authenticated endpoints.](../../node.js/cds-test#authentication){.learn-more}
-[Learn more about testing.](../../node.js/cds-test#testing-with-cds-test){.learn-more}
+[Learn more about testing.](../../node.js/cds-test#testing-with-cdstest){.learn-more}
 
 </div>
 
@@ -1290,7 +1290,7 @@ module.exports = function custom_auth (req, res, next) {
 -->
 
 :::tip
-In case you want to customize the `cds.context.user`, check out [this example](../../node.js/cds-serve#customization-of-cds-context-user).
+In case you want to customize the `cds.context.user`, check out [this example](../../node.js/cds-serve#customization-of-cdscontextuser).
 :::
 
 </div>

--- a/guides/security/authorization.md
+++ b/guides/security/authorization.md
@@ -180,7 +180,7 @@ annotate ShopService.ReplicationAction with @(requires: 'system-user');
 
 In this example, the `BrowseBooksService` service is open for authenticated but not for anonymous users. A user who has the `Vendor` _or_ `ProcurementManager` role is allowed to access the `ShopService.Books` entity. Unbound action `ShopService.ReplicationAction` can only be triggered by a technical user.
 ::: tip
-When restricting service access through `@requires`, the service's metadata endpoints (that is, `/$metadata` as well as the service root `/`) are restricted by default as well. If you require public metadata, you can disable the check with [a custom express middleware](../../node.js/cds-serve#add-mw-pos) using the [privileged user](../../node.js/authentication#privileged-user) (Node.js) or through config <Config java>cds.security.authentication.authenticateMetadataEndpoints = false</Config> (Java), respectively. Please be aware that the `/$metadata` endpoint is *not* checking for authorizations implied by `@restrict` annotation.
+When restricting service access through `@requires`, the service's metadata endpoints (that is, `/$metadata` as well as the service root `/`) are restricted by default as well. If you require public metadata, you can disable the check with [a custom express middleware](../../node.js/cds-serve#addmw-pos) using the [privileged user](../../node.js/authentication#privileged-user) (Node.js) or through config <Config java>cds.security.authentication.authenticateMetadataEndpoints = false</Config> (Java), respectively. Please be aware that the `/$metadata` endpoint is *not* checking for authorizations implied by `@restrict` annotation.
 :::
 
 

--- a/guides/security/data-protection.md
+++ b/guides/security/data-protection.md
@@ -637,7 +637,7 @@ The adapters also transform the HTTP requests into a corresponding CQN statement
 Access control is performed on basis of CQN level according to the CDS model and hence HTTP Verb Tampering attacks are avoided. Also HTTP method override, using `X-Http-Method-Override` or `X-Http-Method` header, is not accepted by the runtime.
 
 The OData protocol allows to encode field values in query parameters of the request URL or in the response headers. This is, for example, used to specify:
-- [Pagination (implicit sort order)](../services/served-ootb#pagination-sorting)
+- [Pagination (implicit sort order)](../services/served-ootb#pagination--sorting)
 - [Searching Data](../services/served-ootb#searching-data)
 - Filtering
 

--- a/guides/services/consuming-services.md
+++ b/guides/services/consuming-services.md
@@ -146,7 +146,7 @@ This adds the API in CDS format to the _srv/external_ folder and also copies the
 
 <div class="impl node">
 
-Further, it adds the API as an external service to your _package.json_. You use this declaration later to connect to the remote service [using a destination](#use-destinations-with-node-js).
+Further, it adds the API as an external service to your _package.json_. You use this declaration later to connect to the remote service [using a destination](#use-destinations-with-nodejs).
 
 ```json
 "cds": {
@@ -1501,7 +1501,7 @@ You can change the destination lookup behavior as follows:
 ```
 
 
-Setting the [`selectionStrategy`](https://sap.github.io/cloud-sdk/docs/js/features/connectivity/destination#multi-tenancy) property for the [destination options](#use-destinations-with-node-js) to `alwaysProvider`, you can ensure that the destination is always read from your provider subaccount. With that you ensure that a subscriber cannot overwrite your destination.
+Setting the [`selectionStrategy`](https://sap.github.io/cloud-sdk/docs/js/features/connectivity/destination#multi-tenancy) property for the [destination options](#use-destinations-with-nodejs) to `alwaysProvider`, you can ensure that the destination is always read from your provider subaccount. With that you ensure that a subscriber cannot overwrite your destination.
 
 Set the destination option `jwt` to `null`, if you don't want to pass the request's JWT to SAP Cloud SDK. Passing the request's JWT to SAP Cloud SDK has implications on, amongst others, the effective defaults for selection strategy and isolation level. In rare cases, these defaults are not suitable, for example when the request to the upstream server does not depend on the current user. Please see [Authentication and JSON Web Token (JWT) Retrieval](https://sap.github.io/cloud-sdk/docs/js/features/connectivity/destinations#authentication-and-json-web-token-jwt-retrieval) for more details.
 

--- a/guides/uis/fiori.md
+++ b/guides/uis/fiori.md
@@ -266,7 +266,7 @@ entity TravelService.Travels.drafts : TravelService.Travels { ... }
 ```
 :::
 
-You can access this entity definition from the model at runtime, for example, to add custom handlers to draft events or to access draft data. In a CAP Node.js service implementation, use the [`.drafts`](../../node.js/cds-reflect#drafts) reference as a shortcut to access the draft entity:
+You can access this entity definition from the model at runtime, for example, to add custom handlers to draft events or to access draft data. In a CAP Node.js service implementation, use the [`.drafts`](../../node.js/cds-reflect#-drafts) reference as a shortcut to access the draft entity:
 
 ```js
 const { Travels } = this.entities
@@ -401,7 +401,7 @@ Select.from(FOO).where(o -> o.ID().eq(201) .and( //> reads draft data
 );
 ```
 
-In CAP Node.js, use the [`Foo.drafts`](../../node.js/cds-reflect#drafts) references to access draft data:
+In CAP Node.js, use the [`Foo.drafts`](../../node.js/cds-reflect#-drafts) references to access draft data:
 
 ```js {3}
 const { Foo } = this.entities
@@ -409,7 +409,7 @@ SELECT.from (Foo, 201)          // reads active data only
 SELECT.from (Foo.drafts, 201)  // reads draft data, if exists
 ```
 
-Even better, use [`req.subject`](../../node.js/events#subject), which automatically resolves to the correct entity instance - active or draft - based on the current request context. For example, in custom action handlers triggered for both active and draft data:
+Even better, use [`req.subject`](../../node.js/events#-subject), which automatically resolves to the correct entity instance - active or draft - based on the current request context. For example, in custom action handlers triggered for both active and draft data:
 
 ```js
 this.on ('approveTravel', req => UPDATE (req.subject) .with ({ status: 'A' }))
@@ -634,7 +634,7 @@ The Cache Control feature is currently supported only on the Java runtime.
 
 In addition to adding [restrictions on services, entities, and actions/functions](../security/authorization#restrictions), there are cases where you want to hide certain UI elements for specific users. You can do this using annotations such as `@UI.Hidden` or `@UI.CreateHidden` together with `$edmJson` pointing to a singleton.
 
-First, define the [singleton](../protocols/odata#singletons) in your service and annotate it with [`@cds.persistence.skip`](../databases/cdl-to-ddl#cds-persistence-skip) so that no database artifact is created:
+First, define the [singleton](../protocols/odata#singletons) in your service and annotate it with [`@cds.persistence.skip`](../databases/cdl-to-ddl#cdspersistenceskip) so that no database artifact is created:
 
 ```cds
 @odata.singleton @cds.persistence.skip

--- a/java/change-tracking.md
+++ b/java/change-tracking.md
@@ -213,7 +213,7 @@ Elements from the `@changelog` annotation value must always be prefixed by the a
 :::warning Validation required
 If the target of the association is missing, for example, when an entity is updated with the ID for a customer
 that does not exist, the changelog entry is not created. You need to validate
-such cases in the custom code or use annotations, for example, [`@assert.target`](../guides/services/constraints#assert-target).
+such cases in the custom code or use annotations, for example, [`@assert.target`](../guides/services/constraints#asserttarget).
 :::
 
 ### Caveats of Identifiers

--- a/java/event-queues.md
+++ b/java/event-queues.md
@@ -524,7 +524,7 @@ A startup log entry shows the configured version:
 2024-12-19T11:21:33.253+01:00 INFO 3420 --- [main] cds.services.impl.utils.BuildInfo : application.deployment.version: 1.0.0-SNAPSHOT
 ```
 
-To bypass the version check for a specific custom outbox, set [`cds.outbox.services.MyCustomOutbox.checkVersion: false`](./developing-applications/properties#cds-outbox-services-<key>-checkVersion).
+To bypass the version check for a specific custom outbox, set [`cds.outbox.services.MyCustomOutbox.checkVersion: false`](./developing-applications/properties#cds-outbox).
 
 
 ## Troubleshooting

--- a/java/messaging.md
+++ b/java/messaging.md
@@ -470,7 +470,7 @@ Example:
 }
 ```
 
-[Learn more about _default-env.json_.](../node.js/cds-env#in-default-env-json){.learn-more}
+[Learn more about _default-env.json_.](../node.js/cds-env#in-default-envjson){.learn-more}
 
 
 #### VCAP_SERVICES Template for SAP Event Mesh

--- a/java/working-with-cql/query-execution.md
+++ b/java/working-with-cql/query-execution.md
@@ -223,7 +223,7 @@ long deleteCount = service.run(delete).rowCount();
 
 ## Views and Projections { #views }
 
-With CDS [views](../../cds/cdl#views-projections) you can derive new entities from existing ones, for example to rename or exclude certain elements, or to add [virtual elements](../../cds/cdl#virtual-elements-in-views) for specific use cases.
+With CDS [views](../../cds/cdl#views--projections) you can derive new entities from existing ones, for example to rename or exclude certain elements, or to add [virtual elements](../../cds/cdl#virtual-elements-in-views) for specific use cases.
 
 From the CDS model the CDS compiler generates [DDL](../../guides/databases/cdl-to-ddl) files, which include SQL views for the CDS views. These views are deployed to the [database](../cqn-services/persistence-services#database-support) and used by the CAP runtime to read data.
 

--- a/node.js/_menu.md
+++ b/node.js/_menu.md
@@ -2,8 +2,8 @@
 
 # [cds. compile()](cds-compile)
 
-  ## [cds. compile()](cds-compile#cds-compile)
-  ## [cds. compile.to ...](cds-compile#cds-compile-to)
+  ## [cds. compile()](cds-compile#cds-compile-)
+  ## [cds. compile.to ...](cds-compile#cds-compile-to-)
   ## [cds. load()](cds-compile#cds-load)
   ## [cds. parse()](cds-compile#cds-parse)
   ## [cds. minify()](cds-compile#cds-minify)

--- a/node.js/app-services.md
+++ b/node.js/app-services.md
@@ -113,7 +113,7 @@ This method is adding request handlers for handling managed data, as documented 
 
 ### _static_ handle_paging() {.method}
 
-This method is adding request handlers for paging & implicit sorting, as documented in the [Providing Services guide](../guides/services/served-ootb#pagination-sorting).
+This method is adding request handlers for paging & implicit sorting, as documented in the [Providing Services guide](../guides/services/served-ootb#pagination--sorting).
 
 
 

--- a/node.js/authentication.md
+++ b/node.js/authentication.md
@@ -17,7 +17,7 @@ uacp: This page is linked from the Help Portal at https://help.sap.com/products/
 [user]: #cds-user
 [`cds.context.user`]: #cds-user
 
-Represents the currently logged-in user as filled into [`cds.context.user`](events#user) by authentication middlewares.
+Represents the currently logged-in user as filled into [`cds.context.user`](events#-user) by authentication middlewares.
 Simply create instances of `cds.User` or of subclasses thereof in custom middlewares.
 For example:
 
@@ -429,7 +429,7 @@ export default function custom_auth(req: Req, res: Response, next: NextFunction)
 }
 ```
 
-[Learn more about customizing the user ID in this example.](cds-serve#customization-of-cds-context-user){.learn-more}
+[Learn more about customizing the user ID in this example.](cds-serve#customization-of-cdscontextuser){.learn-more}
 
 
 ## Authentication in Production

--- a/node.js/best-practices.md
+++ b/node.js/best-practices.md
@@ -251,7 +251,7 @@ Handling CSRF at the _App Router_ level ensures consistency across instances. Th
 
 With _Cross-Origin Resource Sharing_ (CORS) the server that hosts the UI can tell the browser about servers it trusts to provide resources. In addition, so-called "preflight" requests tell the browser if the cross-origin server will process a request with a specific method and a specific origin.
 
-If not running in production, CAP's [built-in server.js](cds-server#built-in-server-js) allows all origins.
+If not running in production, CAP's [built-in server.js](cds-server#built-in-serverjs) allows all origins.
 
 #### Custom CORS Implementation
 
@@ -368,7 +368,7 @@ The following articles might be of interest:
 
 ## Timestamps
 
-When using [timestamps](events#timestamp) (for example for managed dates) the Node.js runtime offers a way to easily deal with that without knowing the format of the time string. The `req` object contains a property `timestamp` that holds the current time (specifically `new Date()`, which is comparable to `CURRENT_TIMESTAMP` in SQL). It also stays the same until the request finished, so if it is used in multiple places in the same transaction or request it will always be the same.
+When using [timestamps](events#-timestamp) (for example for managed dates) the Node.js runtime offers a way to easily deal with that without knowing the format of the time string. The `req` object contains a property `timestamp` that holds the current time (specifically `new Date()`, which is comparable to `CURRENT_TIMESTAMP` in SQL). It also stays the same until the request finished, so if it is used in multiple places in the same transaction or request it will always be the same.
 
 Example:
 
@@ -379,7 +379,7 @@ srv.before("UPDATE", "EntityName", (req) => {
 });
 ```
 
-Internally the [timestamp](events#timestamp) is a JavaScript `Date` object, that is converted to the right format, when sent to the database. So if in any case a date string is needed, the best solution would be to initialize a Date object, that is then translated to the correct UTC String for the database.
+Internally the [timestamp](events#-timestamp) is a JavaScript `Date` object, that is converted to the right format, when sent to the database. So if in any case a date string is needed, the best solution would be to initialize a Date object, that is then translated to the correct UTC String for the database.
 
 
 ## Decimals and Int64 as Strings { #decimals-int64 }

--- a/node.js/cds-compile.md
+++ b/node.js/cds-compile.md
@@ -102,7 +102,7 @@ let csn = cds.compile ({
 
 
 
-### Additional Options
+### Additional [Options](#additional-options)
 
 You can pass additional options like so:
 
@@ -248,7 +248,7 @@ const doc = cds.compile.to.asyncapi(csn_file)
 ## cds. load (files) {.method #cds-load }
 
 Loads and parses a model from one or more files into a single effective model.
-It's essentially a [shortcut to `cds.compile ([...])`](#cds-compile). In addition emits event `cds 'loaded'`.
+It's essentially a [shortcut to `cds.compile ([...])`](#cds-compile-). In addition emits event `cds 'loaded'`.
 
 Declaration:
 
@@ -287,7 +287,7 @@ The three main methods are offered as classic functions, as well as [tagged temp
 ### cds. parse. cdl() {.method #parse-cdl }
 
 Parses a source string in _[CDL](../cds/cdl)_ syntax and returns it as a parsed model according to the [_CSN spec_](../cds/csn). Supports tagged template strings as well as plain string arguments.
-It's essentially a [shortcut to `cds.compile (..., {flavor:'parsed'})`](#cds-compile).
+It's essentially a [shortcut to `cds.compile (..., {flavor:'parsed'})`](#cds-compile-).
 
 Examples:
 ```js

--- a/node.js/cds-compile.md
+++ b/node.js/cds-compile.md
@@ -102,7 +102,7 @@ let csn = cds.compile ({
 
 
 
-### Additional [Options](#additional-options)
+### Additional Options
 
 You can pass additional options like so:
 

--- a/node.js/cds-connect.md
+++ b/node.js/cds-connect.md
@@ -58,7 +58,7 @@ const db2 = await cds.connect.to ({
 
 ### cds. services {#cds-connect-caching .property}
 
-When connecting to a service using `cds.connect.to()`, the service instance is cached in [`cds.services`](cds-facade#cds-services) under the service name. This means that subsequent calls to `cds.connect.to()` with the same service name will all return the same instance. As services constructed by [`cds.serve`](cds-serve#cds-serve) are registered with [`cds.services`](cds-facade#cds-services) as well, a connect finds and returns them as local service connections.
+When connecting to a service using `cds.connect.to()`, the service instance is cached in [`cds.services`](cds-facade#cds-services) under the service name. This means that subsequent calls to `cds.connect.to()` with the same service name will all return the same instance. As services constructed by [`cds.serve`](cds-serve#cds-serve-) are registered with [`cds.services`](cds-facade#cds-services) as well, a connect finds and returns them as local service connections.
 
 You can also access cached service instance like this:
 

--- a/node.js/cds-facade.md
+++ b/node.js/cds-facade.md
@@ -183,7 +183,7 @@ Known values for `cds.cli.command` are `add`, `build`, `compile`, `deploy`, `imp
 
 ### cds. entities {.property}
 
-Convenience shortcut to [`cds.model.entities`](cds-reflect#entities).
+Convenience shortcut to [`cds.model.entities`](cds-reflect#-entities).
 Returns an iterable dictionary of entity definitions in the model, which can be used like this:
 
 - Accessing named entities directly:

--- a/node.js/cds-i18n.md
+++ b/node.js/cds-i18n.md
@@ -60,7 +60,7 @@ ORDER_EXCEEDS_STOCK = The order of {quantity} books exceeds available stock {sto
 
 ### Direct Usage
 
-In addition, you can use both standard bundles directly in your code, with [`<bundle>.at(key)`](#at-key) the central method to obtain localized texts:
+In addition, you can use both standard bundles directly in your code, with [`<bundle>.at(key)`](#at-key-) the central method to obtain localized texts:
 
 ```js
 [dev] cds repl
@@ -137,7 +137,7 @@ function cds.i18n.bundle4 (file : string, options?)
 function cds.i18n.bundle4 (model : CSN, options?)
 ```
 
-Factory method to create instances of  [`I18nBundle`](#i18nbundle). The first argument is either a string used as the bundle's [`file`/`basename`](#–-file-basename), or a CDS model.
+Factory method to create instances of  [`I18nBundle`](#i18nbundle). The first argument is either a string used as the bundle's [`file`/`basename`](#-file--basename), or a CDS model.
 
 ```js
 const b1 = cds.i18n.bundle4('foo')
@@ -278,7 +278,7 @@ You can alternatively pass in a CSN definition instead of an i18n key to look up
 
 ### `key4 (csn)` {.method}
 
-This method is used by [`bundle.at()`](#at-key) to determine an i18n key for a CSN definition. In essence, the implementation works like that:
+This method is used by [`bundle.at()`](#at-key-) to determine an i18n key for a CSN definition. In essence, the implementation works like that:
 
 ```js
 const a = csn['@title']
@@ -299,7 +299,7 @@ return a.match(/{i18n>(.+)}/)[1]
 function texts4 (locale: string) => Texts
 ```
 
-This method is used by [`bundle.at()`](#at-key) to obtain the set of translated texts for a specific locale.
+This method is used by [`bundle.at()`](#at-key-) to obtain the set of translated texts for a specific locale.
 For example, try this in `cds repl`: {.indent}
 
 ```js
@@ -417,8 +417,8 @@ An array of root directories up to which to recurse up the filesystem hierarchy 
 
 ### – `leafs` {.property}
 
-The leafs of the filesystem hierarchy to start fetch i18n folders recursively. Determined by `model?.$sources.map(path.dirname)`  if a [`model`](#–-model) (or [`cds.model`](cds-facade#cds-model)) is given.  <br/>
-*Default*: [`roots`](#–-roots). {.indent}
+The leafs of the filesystem hierarchy to start fetch i18n folders recursively. Determined by `model?.$sources.map(path.dirname)`  if a [`model`](#-model) (or [`cds.model`](cds-facade#cds-model)) is given.  <br/>
+*Default*: [`roots`](#-roots). {.indent}
 
 ### – `folders` {.property}
 

--- a/node.js/cds-ql.md
+++ b/node.js/cds-ql.md
@@ -82,7 +82,7 @@ const { Books } = cds.entities
 let q1 = SELECT.from (Books) .where `ID=${201}`
 ```
 
-[Learn more about using reflected definitions from a service's model](core-services#entities){.learn-more}
+[Learn more about using reflected definitions from a service's model](core-services#-entities){.learn-more}
 
 ####  Not Locked in to SQL
 

--- a/node.js/cds-reflect.md
+++ b/node.js/cds-reflect.md
@@ -137,8 +137,8 @@ for (let each of m.entities('my.bookshop')) console.log (each.name)
 ```
 
 > [!info]
-> Note: In the dictionaries returned by `.entities` there are no entries for [`.texts`](#texts) entities, as these are generated, and hence living in a shadow world. They did show up in former releases, which caused a lot of confusion, and was fixed since cds 9.6.
-> They are always accessible via the main entity's [`.texts`](#texts) property, e.g. `Books.texts`.
+> Note: In the dictionaries returned by `.entities` there are no entries for [`.texts`](#-texts) entities, as these are generated, and hence living in a shadow world. They did show up in former releases, which caused a lot of confusion, and was fixed since cds 9.6.
+> They are always accessible via the main entity's [`.texts`](#-texts) property, e.g. `Books.texts`.
 
 
 ### each() {#each .method }
@@ -254,11 +254,11 @@ All objects of a linked model containing CSN definitions are instances of this c
 
 For example, that applies to:
 
-- *`cds.model` [.definitions](#definitions), [.services](#services), [.entities](#entities)*
-- *`cds.service` [.entities](#entities-1), [.events](#events), [.actions](#actions-1)*
-- *`cds.entity`  [.keys](#keys), [.associations](#associations), [.compositions](#compositions), [.actions](#actions)*
-- *`cds.struct` [.elements](#elements)* (hence also *`cds.entity` .elements*)
-- *`cds.Association` [.foreignKeys](#foreignkeys)*
+- *`cds.model` [.definitions](#-definitions), [.services](#-services), [.entities](#-entities)*
+- *`cds.service` [.entities](#-entities-1), [.events](#-events), [.actions](#-actions-1)*
+- *`cds.entity`  [.keys](#-keys), [.associations](#-associations), [.compositions](#-compositions), [.actions](#-actions)*
+- *`cds.struct` [.elements](#-elements)* (hence also *`cds.entity` .elements*)
+- *`cds.Association` [.foreignKeys](#-foreignkeys)*
 
 Instances of `LinkedDefinitions` allow both, object-style access, as well as array-like access.
 For example:

--- a/node.js/cds-server.md
+++ b/node.js/cds-server.md
@@ -10,7 +10,7 @@ status: released
 
 
 
-CAP Node.js servers are bootstrapped through a [built-in `server.js` module](#built-in-server-js), which can be accessed through [`cds.server`](#cds-server). You can plug-in custom logic to the default bootstrapping choreography using a [custom `server.js`](#custom-server-js) in your project.
+CAP Node.js servers are bootstrapped through a [built-in `server.js` module](#built-in-serverjs), which can be accessed through [`cds.server`](#cds-server). You can plug-in custom logic to the default bootstrapping choreography using a [custom `server.js`](#custom-server-js) in your project.
 
 
 
@@ -85,8 +85,8 @@ module.exports = async function cds_server(options) {
 ### cds. server() {.method}
 
 This is essentially a shortcut getter to `require('@sap/cds/server')`, that is, it loads and returns
-the [built-in `server.js`](#built-in-server-js) implementation.
-You'd mainly use this in [custom `server.js`](#custom-server-js) to delegate to the default implementation, [as shown below](#override-cds-server).
+the [built-in `server.js`](#built-in-serverjs) implementation.
+You'd mainly use this in [custom `server.js`](#custom-server-js) to delegate to the default implementation, [as shown below](#override-cdsserver).
 
 
 
@@ -265,7 +265,7 @@ The built-in CORS middleware can be enabled explicitly with <Config>cds.server.c
 
 The default generic _index.html_ page is not served if `NODE_ENV` is set to `production`. Set <Config>cds.server.index: true</Config> to activate explicitly also in production-like test environments, for example for deployed PoCs. You must not do this in real production environments!
 
-[See the **Generic *index.html*** page in action.](../get-started/bookshop#generic-index-html) {.learn-more}
+[See the **Generic *index.html*** page in action.](../get-started/bookshop#generic-indexhtml) {.learn-more}
 
 
 

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -75,13 +75,13 @@ Let's analyze the highlighted the code above line by line:
 ```js :line-numbers=2
 const ... cds.test... // > loads the cds-test module
 ```
-- By accessing [`cds.test`](#class-cds-test-test) the `cds-test` module is loaded, which ensures that...
+- By accessing [`cds.test`](#class-cdstesttest) the `cds-test` module is loaded, which ensures that...
 - Functions like [`describe`](https://vitest.dev/api/describe.html), [`test`](https://vitest.dev/api/test.html), [`it`](https://vitest.dev/api/test.html), etc. are made available in test scope.
 
 ```js :line-numbers=2
 const { GET, ... } = cds.test ('@capire/bookshop')
 ```
-- Calling the [`cds.test()`](#cds-test) function launches a CAP server for the given CAP project.
+- Calling the [`cds.test()`](#cdstest) function launches a CAP server for the given CAP project.
 
 ```js :line-numbers=3
 defaults.auth = { username: 'alice' }
@@ -171,7 +171,7 @@ To keep your tests portable across different test runners, it's recommended to a
 ### Dos and Don'ts
 
 ::: danger Don't load `cds.env` before `cds.test()`
-To ensure [`cds.env`](cds-env), and hence all plugins, are loaded from the test's target folder, the call to [`cds.test()`](#cds-test) is the first thing you do in your tests. Any references to [`cds`](cds-facade) sub modules or any imports of which have to go after.  → See also: [`CDS_TEST_ENV_CHECK`.](#cds-test-env-check)
+To ensure [`cds.env`](cds-env), and hence all plugins, are loaded from the test's target folder, the call to [`cds.test()`](#cdstest) is the first thing you do in your tests. Any references to [`cds`](cds-facade) sub modules or any imports of which have to go after.  → See also: [`CDS_TEST_ENV_CHECK`.](#cds_test_env_check)
 :::
 
 ::: warning Keep it simple, stupid!
@@ -181,14 +181,14 @@ Using these bells and whistles might also cause conflicts with generic features 
 :::
 
 ::: tip  Avoid `process.chdir()` -> prefer `cds.test.in()`
-CAP servers need to be launched from a specific project home directory. Don't use `process.chdir()` for this, as that may leave test containers in failed state, leading to failing subsequent tests. -> Specify the target folder in the call to [`cds.test()`](#cds-test), or use [`cds.test.in()`](#test-in-folder) instead.
+CAP servers need to be launched from a specific project home directory. Don't use `process.chdir()` for this, as that may leave test containers in failed state, leading to failing subsequent tests. -> Specify the target folder in the call to [`cds.test()`](#cdstest), or use [`cds.test.in()`](#test-in-folder-) instead.
 :::
 
 
 
 ## Class `cds.test.Test`
 
-Instances of this class are returned by [`cds.test()`](#cds-test), for example:
+Instances of this class are returned by [`cds.test()`](#cdstest), for example:
 
 ```js
 const test = cds.test()
@@ -207,7 +207,7 @@ test.run().in(_dirname)
 
 ### cds.test() {.method}
 
-This method is the most convenient way to start a test server. It's actually just a convenient shortcut to construct a new instance of class `Test` and call [`test.run()`](#test-run), defined as follows:
+This method is the most convenient way to start a test server. It's actually just a convenient shortcut to construct a new instance of class `Test` and call [`test.run()`](#test-run-), defined as follows:
 
 ```js
 const { Test } = cds.test
@@ -391,7 +391,7 @@ The implementation redirects any console operations in a `beforeAll()` hook, cle
 
 ### test. run (...) {.method}
 
-This is the method behind [`cds.test()`](#cds-test) to start a CDS server, that is the following are equivalent:
+This is the method behind [`cds.test()`](#cdstest) to start a CDS server, that is the following are equivalent:
 
 ```js
 cds.test(...)
@@ -412,7 +412,7 @@ cds.test('serve','srv/cat-service.cds')
 cds.test('serve','CatalogService')
 ```
 
-You can optionally add [`test.in(folder)`](#test-in-folder) in fluent style to run the test in a specific folder:
+You can optionally add [`test.in(folder)`](#test-in-folder-) in fluent style to run the test in a specific folder:
 
 ```js
 cds.test('serve','srv/cat-service.cds').in('/cap/samples/bookshop')
@@ -435,7 +435,7 @@ cds.test().in('/cap/samples/bookshop') //> equivalent
 
 ### test. in (folder, ...) {.method}
 
-Safely switches [`cds.root`](cds-facade#cds-root) to the specified target folder. Most frequently you'd use it in combination with starting a server with [`cds.test()`](#cds-test) in fluent style like that:
+Safely switches [`cds.root`](cds-facade#cds-root) to the specified target folder. Most frequently you'd use it in combination with starting a server with [`cds.test()`](#cdstest) in fluent style like that:
 
 ```js
 let test = cds.test(...).in(__dirname)
@@ -460,7 +460,7 @@ cds.test(__dirname)               //> target folder: __dirname
 
 This would result in the test server started from `__dirname`, but erroneously using `cds.env` loaded from `./`.
 
-As these mistakes end up in hard-to-resolve follow up errors, [`test.in()`](#test-in-folder) can detect this if environment variable `CDS_TEST_ENV_CHECK` is set. The previous code will then result into an error like that:
+As these mistakes end up in hard-to-resolve follow up errors, [`test.in()`](#test-in-folder-) can detect this if environment variable `CDS_TEST_ENV_CHECK` is set. The previous code will then result into an error like that:
 
 ```sh
 CDS_TEST_ENV_CHECK=y jest cds.test.test.js

--- a/node.js/core-services.md
+++ b/node.js/core-services.md
@@ -258,7 +258,7 @@ await srv.read ('GET','/Books/206')
 await srv.send ('submitOrder', { book:206, quantity:1 })
 ```
 
-[Using typed APIs for actions and functions](../guides/services/custom-actions#calling-actions-functions):
+[Using typed APIs for actions and functions](../guides/services/custom-actions#calling-actions--functions):
 
 ```js
 await srv.submitOrder({ book:206, quantity:1 })
@@ -353,7 +353,7 @@ function constructor (
 )
 ```
 
->  *Arguments fill in equally named properties [`name`](#name), [`model`](#model), [`options`](#options).*
+>  *Arguments fill in equally named properties [`name`](#-name), [`model`](#-model), [`options`](#-options).*
 
 **Don't override the constructor** in subclasses, rather override [`srv.init()`](#srv-init).
 
@@ -420,7 +420,7 @@ for (let d of this.entities) //... d is a CSN definition
 
 #### Similarity _and_ difference to `cds.entities`
 
-These properties are very similar in nature and behavior to [`cds.entities`](cds-facade#cds-entities), which is a sortcut to [`cds.model.entities`](cds-reflect#entities). However, note this difference:
+These properties are very similar in nature and behavior to [`cds.entities`](cds-facade#cds-entities), which is a sortcut to [`cds.model.entities`](cds-reflect#-entities). However, note this difference:
 
 While both of these work with [`cds.entities`](cds-facade#cds-entities):
 ```js
@@ -535,7 +535,7 @@ class BooksService extends cds.ApplicationService {
 
 **Argument `entity`** can be one of:
 
-- A `CSN definition` of an entity served by this service → i.e., from [`this.entities`](#entities)
+- A `CSN definition` of an entity served by this service → i.e., from [`this.entities`](#-entities)
 - A `string` corresponding to the _name_ of an entity served by this service
 - A `path`  navigating from a served entity to associated ones → e.g., `Books/author`
 
@@ -691,9 +691,9 @@ Books.data = {
 
 ::: details Noteworthy in these examples...
 
-- The `READ` handler is using the [`req.target`](./events.md#target) property which points to the CSN definition of the entity addressed by the incoming request → matching one of `Books` or `Authors` we obtained from [`this.entities`](#entities) above.
+- The `READ` handler is using the [`req.target`](./events.md#-target) property which points to the CSN definition of the entity addressed by the incoming request → matching one of `Books` or `Authors` we obtained from [`this.entities`](#-entities) above.
 
-- The `UPDATE` handler is using the [`req.params`](./events.md#params) property which provides access to passed in entity keys.
+- The `UPDATE` handler is using the [`req.params`](./events.md#-params) property which provides access to passed in entity keys.
 
 :::
 
@@ -820,7 +820,7 @@ Use this method to send synchronous requests to a service for execution.
 -  `method` is an HTTP method
 -  `path` can be an arbitrary URL, starting with a leading `'/'`, it is passed to a service without any modification as a string
 
-To call bound / unbound actions and functions from the service, further variants of `srv.send` are additionally supported, as described in the section [Calling Actions / Functions](../guides/services/custom-actions#calling-actions-functions). Basically, use the action or function name instead of the HTTP method.
+To call bound / unbound actions and functions from the service, further variants of `srv.send` are additionally supported, as described in the section [Calling Actions / Functions](../guides/services/custom-actions#calling-actions--functions). Basically, use the action or function name instead of the HTTP method.
 
 Examples:
 

--- a/node.js/events.md
+++ b/node.js/events.md
@@ -88,7 +88,7 @@ this.on ('*', req => {
 ```
 
 Keep in mind that multiple requests (that is, instances of `cds.Request`) may share the same incoming HTTP request and outgoing HTTP response (for example, in case of an OData batch request).
-See sections [`req`](#req) and [`res`](#res) of `cds.Request` to learn more about accessing the request and response objects of individual requests within an incoming batch request.
+See sections [`req`](#-req) and [`res`](#-res) of `cds.Request` to learn more about accessing the request and response objects of individual requests within an incoming batch request.
 
 
 
@@ -155,7 +155,7 @@ On the other hand, setting `req.user` in a custom authentication middleware is d
 
 
 
-Class [`cds.Event`] represents event messages in [asynchronous messaging](messaging), providing access to the [event](#event) name, payload [data](#data), and optional [headers](#headers). It also serves as **the base class for [`cds.Request`](#cds-request)** and hence for all synchronous interactions.
+Class [`cds.Event`] represents event messages in [asynchronous messaging](messaging), providing access to the [event](#-event) name, payload [data](#-data), and optional [headers](#-headers). It also serves as **the base class for [`cds.Request`](#cds-request)** and hence for all synchronous interactions.
 
 
 
@@ -242,7 +242,7 @@ Additional note about OData: For requests that are part of a changeset, the even
 
 
 
-Class `cds.Request` extends [`cds.Event`] with additional features to represent and deal with synchronous requests to services in [event handlers](./core-services#srv-handle-event), such as the [query](#query), additional [request parameters](#params), the [authenticated user](#user), and [methods to send responses](#req-reply-results).
+Class `cds.Request` extends [`cds.Event`] with additional features to represent and deal with synchronous requests to services in [event handlers](./core-services#srv-handle-event), such as the [query](#-query), additional [request parameters](#-params), the [authenticated user](#-user), and [methods to send responses](#req-reply-results).
 
 
 [Router]: https://expressjs.com/en/4x/api.html#router
@@ -254,13 +254,13 @@ Class `cds.Request` extends [`cds.Event`] with additional features to represent 
 
 ### . req {.property}
 
-Provides access to the express request object of individual requests within an incoming batch request. For convenience, in the case of non-batch requests, it points to the same request object as [`req.http.req`](#http).
+Provides access to the express request object of individual requests within an incoming batch request. For convenience, in the case of non-batch requests, it points to the same request object as [`req.http.req`](#-http).
 
 
 
 ### . res {.property}
 
-Provides access to the express response object of individual requests within an incoming batch request. For convenience, in the case of non-batch requests, it points to the same response object as [`req.http.res`](#http).
+Provides access to the express response object of individual requests within an incoming batch request. For convenience, in the case of non-batch requests, it points to the same response object as [`req.http.res`](#-http).
 
 
 
@@ -294,7 +294,7 @@ For example:
 
 {style="font-style:italic;width:80%;"}
 
-[See also `req.path` to learn how to access full navigation paths.](#path){.learn-more}
+[See also `req.path` to learn how to access full navigation paths.](#-path){.learn-more}
 [See _Entity Definitions_ in the CSN reference.](../cds/csn#entity-definitions){.learn-more}
 [Learn more about linked models and definitions.](cds-reflect){.learn-more}
 
@@ -303,7 +303,7 @@ For example:
 ### . path {.property}
 
 Captures the full canonicalized path information of incoming requests with navigation.
-For requests without navigation, `req.path` is identical to [`req.target.name`](#target) (or [`req.entity`](#entity), which is a shortcut for that).
+For requests without navigation, `req.path` is identical to [`req.target.name`](#-target) (or [`req.entity`](#-entity), which is a shortcut for that).
 
 Examples based on [cap/samples/bookshop AdminService](https://github.com/capire/bookshop/blob/main/srv/admin-service.cds):
 
@@ -314,14 +314,14 @@ Examples based on [cap/samples/bookshop AdminService](https://github.com/capire/
 | Books(201)/author | AdminService.Books/author | AdminService.Authors |
 {style="font-style:italic"}
 
-[See also `req.target`](#target){.learn-more}
+[See also `req.target`](#-target){.learn-more}
 
 
 
 
 ### . entity {.property}
 
-This is a convenience shortcut to [`msg.target.name`](#target).
+This is a convenience shortcut to [`msg.target.name`](#-target).
 
 
 

--- a/tools/apis/cds-build.md
+++ b/tools/apis/cds-build.md
@@ -65,7 +65,7 @@ The CDS build system auto-detects all required build tasks by invoking the stati
 The compiled CSN model can be accessed using the asynchronous methods `model()` or `basemodel()`.
 
 - The method `model()` returns a CSN model for the scope defined by the `options.model` setting. If [feature toggles](../../guides/extensibility/feature-toggles) are enabled, this model also includes any toggled feature enhancements.
-- To get a CSN model without features, use the method `baseModel()` instead. The model can be used as input for further [model processing](../../node.js/cds-compile#cds-compile-to), like `to.edmx`, `to.hdbtable`, `for.odata`, etc.
+- To get a CSN model without features, use the method `baseModel()` instead. The model can be used as input for further [model processing](../../node.js/cds-compile#cds-compile-to-), like `to.edmx`, `to.hdbtable`, `for.odata`, etc.
 - Use [`cds.reflect`](../../node.js/cds-reflect) to access advanced query and filter functionality on the CDS model.
 
 ## Add build task type to cds schema <Since version="7.6.0" package="@sap/cds-dk" />

--- a/tools/cds-cli.md
+++ b/tools/cds-cli.md
@@ -258,7 +258,7 @@ The result could look like this for a typical _Books_ entity from the _Bookshop_
 - `author.ID` refers to a key from the _...Authors.json_ file that is created at the same time.  If the _Authors_ entity is excluded, though, no such foreign key would be created, which cuts the association off.
 - Data for _compositions_, like the `texts` composition to `Books.texts`, is always created.
 - A random unique number for each record, _29894036_ here, is added to each string property, to help you correlate properties more easily.
-- Data for elements annotated with a regular expression using [`assert.format`](../guides/services/constraints#assert-format) can be generated using the NPM package [randexp](https://www.npmjs.com/package/randexp), which you need to installed manually.
+- Data for elements annotated with a regular expression using [`assert.format`](../guides/services/constraints#assertformat) can be generated using the NPM package [randexp](https://www.npmjs.com/package/randexp), which you need to installed manually.
 - Other constraints like [type formats](../cds/types), [enums](../cds/cdl#enums), and [validation constraints](../guides/services/constraints) are respected as well, in a best effort way.
 :::
 
@@ -397,7 +397,7 @@ Compiles the specified models to [CSN](../cds/csn) or other formats.
 
 [See simple examples in the getting started page](../get-started/bookshop).{.learn-more}
 
-[For the set of built-in compile 'formats', see the `cds.compile.to` API](../node.js/cds-compile#cds-compile-to).{.learn-more}
+[For the set of built-in compile 'formats', see the `cds.compile.to` API](../node.js/cds-compile#cds-compile-to-).{.learn-more}
 
 
 In addition, the following formats are available:

--- a/tools/cds-typer.md
+++ b/tools/cds-typer.md
@@ -455,7 +455,7 @@ const { Books } = require('../@cds-models/sap/capire/bookshop')
 const { Books } = require('#cds-models/sap/capire/bookshop')
 ```
 
-These imports will behave like [`cds.entities('sap.capire.bookshop')`](../node.js/cds-reflect#entities) during runtime, but offer you code completion and type hinting at design time:
+These imports will behave like [`cds.entities('sap.capire.bookshop')`](../node.js/cds-reflect#-entities) during runtime, but offer you code completion and type hinting at design time:
 
 ```js twoslash
 // @noErrors


### PR DESCRIPTION
Previously the build replaced `.` in headers with `-`. VS Code's autocomplete just omitted/ignored the `.` character. With this change the anchors in VS Code a re aligned with the build result (actually the other way around)

**Not working:**
- Headers with decorators, like `{.property}`