### PR TITLE
Fix config popup for strings with colons

### DIFF
--- a/.vitepress/theme/components/ConfigInspect.vue
+++ b/.vitepress/theme/components/ConfigInspect.vue
@@ -120,7 +120,7 @@
 
     pkgStr.value = JSON.stringify(pkg, null, 2)
     rcJsonStr.value = JSON.stringify(pkg.cds??{}, null, 2)
-    rcJsStr.value = 'exports.' + Object.keys(pkg.cds??{})[0] + ' = ' + (JSON.stringify(Object.values(pkg.cds??{})[0], null, 2)??'').replaceAll('"', '')
+    rcJsStr.value = 'exports.' + Object.keys(pkg.cds??{})[0] + ' = ' + (JSON.stringify(Object.values(pkg.cds??{})[0], null, 2)??'').replace(/"([^"]+)":/g, '$1:')
     rcYmlStr.value = yaml.stringify(pkg.cds)
 
     let envKey = fqn.replaceAll('_', '__').replaceAll(keyDel, '_')


### PR DESCRIPTION
`cds.requires.db.credentials.url: :memory:` is currently rendered incorrectly for the JS variant:
<img width="437" height="325" alt="Screenshot 2026-07-19 at 14 48 06" src="https://github.com/user-attachments/assets/0d79a30a-2031-4a3f-815a-05a4c3764d91" />

Fixed:

<img width="436" height="324" alt="Screenshot 2026-07-19 at 14 49 02" src="https://github.com/user-attachments/assets/4ebd061b-b299-410d-8113-839275077320" />
