### PR TITLE
Fix external link icon for Safari

### DIFF
--- a/.vitepress/theme/styles.scss
+++ b/.vitepress/theme/styles.scss
@@ -358,6 +358,22 @@ img, video.bright {
   white-space: nowrap;
 }
 
+// Safari may render the invisible Unicode marker used by VitePress as tofu blocks.
+// Apply this workaround only to Safari-capable engines.
+@supports (font: -apple-system-body) and (-webkit-appearance: none) {
+  .vp-external-link-icon::after,
+  .external-link-icon-enabled :is(.vp-doc a[href*='://'], .vp-doc a[target='_blank']):not(:is(.no-icon, svg a, :has(img, svg)))::after {
+    content: '';
+    display: inline-block;
+    width: 11px;
+    height: 11px;
+    padding-left: 0;
+    margin-left: 4px;
+    line-height: 1;
+    vertical-align: text-top;
+  }
+}
+
 
 
 


### PR DESCRIPTION
Looked broken in Safari:
<img width="239" height="41" alt="image" src="https://github.com/user-attachments/assets/245e42f2-79ec-4052-bfc3-d43fb5e898b9" />


Root cause: VitePress uses an invisible Unicode character for the icon pseudo-element, and Safari can render that as square/tofu blocks with some fonts