### PR TITLE
Minor adjustments to mcp.md

### DIFF
--- a/guides/protocols/mcp.md
+++ b/guides/protocols/mcp.md
@@ -323,7 +323,7 @@ INFO com.sap.cds.adapter.mcp.McpServlet : Received MCP query request for entity 
 
 Whenever you start your application, the MCP adapter automatically registers all MCP endpoints with local MCP clients – currently supported for [Claude Code](https://code.claude.com/docs) and [Opencode](https://opencode.ai/) - so you can just go ahead and run queries from your MCP client without any additional configuration. This makes it super easy to test and interact with your services via MCP during development.
 
-During startup, the generated MCP servers and their URL are added to the client-specific configuration files like that:
+During startup, information about the MCP endpoints is added to the client-specific configuration files like that:
 
 ::: code-group
 ```json [~/.claude.json]

--- a/guides/protocols/mcp.md
+++ b/guides/protocols/mcp.md
@@ -116,9 +116,9 @@ annotate CatalogService with @mcp:'books'
 > From the perspective of a developer in a CAP-based project, `@mcp` is just another protocol for your services, similar to `@odata`, `@graphql`, `@rest`, or `@hcql`. The adapter takes care of the rest, with all the standard CAP features you know working out of the box also with MCP, including annotations like `@cds.query.limit`, etc.
 
 
-### Using Specific MCP Services
+### Tailored services for MCP use
 
-In case you want to serve tailor the entities or elements served via MCP you can also create specific services for MCP and annotate only those with `@mcp`. For example, you could create a `BooksService` that only exposes a subset of the entities of the `AdminService` like that:
+In case you want to tailor the entities or elements served via MCP you can also create specific services for MCP and annotate only those with `@mcp`. For example, you could create a `BooksService` that only exposes a subset of the entities of the `AdminService` like that:
 
 ::: code-group
 ```cds [srv/books-service.cds]

--- a/guides/protocols/mcp.md
+++ b/guides/protocols/mcp.md
@@ -324,7 +324,7 @@ INFO com.sap.cds.adapter.mcp.McpServlet : Received MCP query request for entity 
 Whenever you start your application, the MCP adapter automatically registers all MCP servers with local MCP clients – currently supported for [Claude Code](https://code.claude.com/docs) and [Opencode](https://opencode.ai/) - so you can just go ahead and run queries from your MCP client without any additional configuration. This makes it super easy to test and interact with your services via MCP during development.
 
 > [!tip] MCP servers
-> Note the distinction between the CAP server that listens on a certain port, and MCP servers which are just endpoints provided and served by the CAP server. We use the term "MCP server" despite this, to align with the MCP protocol terminology.
+> Note the distinction between the CAP server that listens on a certain port, and MCP servers which are just endpoints provided and served by the CAP server. We use the term "MCP server" despite this, to align with MCP terminology.
 
 During startup, information about the MCP server endpoints is added to the client-specific configuration files like that:
 

--- a/guides/protocols/mcp.md
+++ b/guides/protocols/mcp.md
@@ -3,7 +3,7 @@ synopsis: >
   Expose CAP services via the Model Context Protocol for seamless AI agent integration.
 ---
 
-# MCP Protocol Adapter <Beta />
+# Model Context Protocol Adapter <Beta />
 
 
 

--- a/guides/protocols/mcp.md
+++ b/guides/protocols/mcp.md
@@ -321,9 +321,12 @@ INFO com.sap.cds.adapter.mcp.McpServlet : Received MCP query request for entity 
 
 ### Autowired MCP Clients
 
-Whenever you start your application, the MCP adapter automatically registers all MCP endpoints with local MCP clients – currently supported for [Claude Code](https://code.claude.com/docs) and [Opencode](https://opencode.ai/) - so you can just go ahead and run queries from your MCP client without any additional configuration. This makes it super easy to test and interact with your services via MCP during development.
+Whenever you start your application, the MCP adapter automatically registers all MCP servers with local MCP clients – currently supported for [Claude Code](https://code.claude.com/docs) and [Opencode](https://opencode.ai/) - so you can just go ahead and run queries from your MCP client without any additional configuration. This makes it super easy to test and interact with your services via MCP during development.
 
-During startup, information about the MCP endpoints is added to the client-specific configuration files like that:
+> [!tip] MCP servers
+> Note the distinction between the CAP server that listens on a certain port, and MCP servers which are just endpoints provided and served by the CAP server. We use the term "MCP server" despite this, to align with the MCP protocol terminology.
+
+During startup, information about the MCP server endpoints is added to the client-specific configuration files like that:
 
 ::: code-group
 ```json [~/.claude.json]


### PR DESCRIPTION
Some minor mods to the MCP topic.

- Fixed a typo
- Reworded the "Using Specific MCP Services" heading
- Gnashed my teeth in angst over what to do about the phrase "MCP server" which is valid but potentially misleading (as they are not really separate servers, but endpoints served from the CAP server on 4004, for example), and ended up adding a "TIP" section which may help
- Re-titled the topic to avoid the tautology ("MCP Protocol" -> "Model Context Protocol Protocol") :-)