### PR TITLE
Clean up and revise frontmatter like `synopsis`

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -164,7 +164,7 @@ config.themeConfig.search = {
         tokenize: text => text.split( /[\n\r #%*,=/:;?[\]{}()&]+/u ), // simplified charset: removed [-_.@] and non-english chars (diacritics etc.)
         processTerm: (term, fieldName) => {
           term = term.trim().toLowerCase().replace(/^\.+/, '').replace(/\.+$/, '')
-          const stopWords = ['frontmatter', '$frontmatter.synopsis', 'and', 'about', 'but', 'now', 'the', 'with', 'you']
+          const stopWords = ['frontmatter', '$frontmatter.description', 'and', 'about', 'but', 'now', 'the', 'with', 'you']
           if (term.length < 2 || stopWords.includes(term))  return false
 
           if (fieldName === 'text') {

--- a/.vitepress/theme/components/IndexList.vue
+++ b/.vitepress/theme/components/IndexList.vue
@@ -11,7 +11,7 @@
   <dl class="index" v-else>
     <template v-for="p in pages" :key="p.url">
       <dt><a :href="p.url">{{ p.title }}</a></dt>
-      <dd v-html="p.frontmatter?.synopsis || ''"></dd>
+      <dd v-html="p.frontmatter?.description || ''"></dd>
     </template>
   </dl>
 </template>

--- a/.vitepress/theme/components/indexFilter.ts
+++ b/.vitepress/theme/components/indexFilter.ts
@@ -31,7 +31,7 @@ export default (pages:ContentDataCustom[], basePath:string):ContentDataCustom[] 
       url: p.url,
       title: p.title,
       frontmatter: {
-        synopsis: p.frontmatter.synopsis
+        description: p.frontmatter.description
       },
       // this data is inlined in each index page, so omit unnecessary data
       src:undefined, html:undefined, excerpt:undefined

--- a/cds/annotations.md
+++ b/cds/annotations.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   Find here a reference and glossary of common annotations intrinsically supported by the CDS compiler and runtimes.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html
 ---
 
 # Common Annotations
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 [Learn more about the syntax of annotations.](./cdl#annotations){.learn-more}
 

--- a/cds/annotations.md
+++ b/cds/annotations.md
@@ -3,7 +3,6 @@
 shorty: Annotations
 synopsis: >
   Find here a reference and glossary of common annotations intrinsically supported by the CDS compiler and runtimes.
-status: released
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html
 ---
 

--- a/cds/annotations.md
+++ b/cds/annotations.md
@@ -1,5 +1,4 @@
 ---
-# layout: cds-ref
 shorty: Annotations
 synopsis: >
   Find here a reference and glossary of common annotations intrinsically supported by the CDS compiler and runtimes.

--- a/cds/annotations.md
+++ b/cds/annotations.md
@@ -1,5 +1,4 @@
 ---
-shorty: Annotations
 synopsis: >
   Find here a reference and glossary of common annotations intrinsically supported by the CDS compiler and runtimes.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html

--- a/cds/aspects.md
+++ b/cds/aspects.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Discusses the differences of the mixin-based approach of Aspects to inheritance as known from languages like Java.
 ---
 

--- a/cds/aspects.md
+++ b/cds/aspects.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Discusses the differences of the mixin-based approach of Aspects to inheritance as known from languages like Java.
-status: released
 ---
 
 # Aspect-Oriented Modeling

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1,5 +1,4 @@
 ---
-# shorty: Definition Language
 synopsis: >
   Specification of the definition language used to model data models and services in an easy and user-centric syntax. Includes a reference and overview of all CDS concepts and features with compact examples.
 #permalink: /cds/cdl/

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1,6 +1,6 @@
 ---
 synopsis: >
-  Specification of the definition language used to model data models and services in an easy and user-centric syntax. Includes a reference and overview of all CDS concepts and features with compact examples.
+  Specification of the definition language used to model data models and services in an easy, user-centric syntax, including a reference and overview of all CDS concepts and features with compact examples.
 #permalink: /cds/cdl/
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html
 ---
@@ -284,7 +284,7 @@ CDL supports line-end, block comments, and *doc* comments as in Java and JavaScr
 /** doc comment */
 ```
 
-#### Doc Comments 
+#### Doc Comments
 
 A multi-line comment of the form `/** … */` at an [annotation position](#annotation-targets) is considered a *doc comment*:
 
@@ -450,7 +450,7 @@ type EmailAddress : { kind:String; address:String; }
 
 > Keywords `many` and `array of` are mere syntax variants with identical semantics and implementations.
 
-When deployed to SQL databases, such fields are mapped to [LargeString](./types) columns and the data is stored denormalized as JSON array. 
+When deployed to SQL databases, such fields are mapped to [LargeString](./types) columns and the data is stored denormalized as JSON array.
 With OData V4, arrayed types are rendered as `Collection` in the EDM(X).
 
 
@@ -857,7 +857,7 @@ Result result = service.run(Select.from("UsingView"), params);
 
 ### Runtime Views { #runtimeviews }
 
-To add or update CDS views without redeploying the database schema, annotate them with [@cds.persistence.skip](../guides/databases/cdl-to-ddl#cdspersistenceskip). This advises the CDS compiler to skip generating database views for these CDS views. Instead, CAP resolves them *at runtime* on each request. 
+To add or update CDS views without redeploying the database schema, annotate them with [@cds.persistence.skip](../guides/databases/cdl-to-ddl#cdspersistenceskip). This advises the CDS compiler to skip generating database views for these CDS views. Instead, CAP resolves them *at runtime* on each request.
 
 Runtime views must be simple [projections](#as-projection-on), not using *aggregations*, *join*, *union* or *subqueries* in the *from* clause, but may have a *where* condition if they are only used to read.
 
@@ -933,7 +933,7 @@ entity Addresses {
 ```
 
 
-### Managed (To-One) Associations 
+### Managed (To-One) Associations
 ###### managed-associations
 
 For to-one associations, CDS can automatically resolve and add requisite foreign key elements from the target's primary keys and implicitly add respective join conditions.

--- a/cds/cdl.md
+++ b/cds/cdl.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Specification of the definition language used to model data models and services in an easy, user-centric syntax, including a reference and overview of all CDS concepts and features with compact examples.
 #permalink: /cds/cdl/
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html

--- a/cds/common.md
+++ b/cds/common.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Introduces <i>@sap/cds/common</i>, a prebuilt CDS model shipped with <i>@sap/cds</i> that provides common types and aspects.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html
 ---

--- a/cds/common.md
+++ b/cds/common.md
@@ -1,5 +1,4 @@
 ---
-# layout: cds-ref
 synopsis: >
   Introduces <i>@sap/cds/common</i>, a prebuilt CDS model shipped with <i>@sap/cds</i> that provides common types and aspects.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html

--- a/cds/compiler/hdbcds-to-hdbtable.md
+++ b/cds/compiler/hdbcds-to-hdbtable.md
@@ -1,6 +1,5 @@
 ---
 # layout: cds-ref
-status: released
 ---
 
 # Moving From _.hdbcds_ To _.hdbtable_

--- a/cds/compiler/hdbcds-to-hdbtable.md
+++ b/cds/compiler/hdbcds-to-hdbtable.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Step-by-step instructions for migrating SAP HANA database deployments from the deprecated `hdbcds` format to `hdbtable`.
+---
 
 # Moving From _.hdbcds_ To _.hdbtable_
 

--- a/cds/compiler/hdbcds-to-hdbtable.md
+++ b/cds/compiler/hdbcds-to-hdbtable.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Step-by-step instructions for migrating SAP HANA database deployments from the deprecated `hdbcds` format to `hdbtable`.
 ---
 

--- a/cds/compiler/hdbcds-to-hdbtable.md
+++ b/cds/compiler/hdbcds-to-hdbtable.md
@@ -1,6 +1,3 @@
----
-# layout: cds-ref
----
 
 # Moving From _.hdbcds_ To _.hdbtable_
 

--- a/cds/compiler/v2.md
+++ b/cds/compiler/v2.md
@@ -5,7 +5,6 @@ synopsis: >
   we expect that all projects have already upgraded. If in doubt, run `cds v` to find out which version of the CAP modules you have in use.
 
 # layout: cds-ref
-status: released
 ---
 
 <!-- Keep this page, as _many_ links point to it! -->

--- a/cds/compiler/v2.md
+++ b/cds/compiler/v2.md
@@ -1,8 +1,6 @@
 ---
 synopsis: >
-  This document describes the upgrade to compiler version 2, released March 2021. As both compiler version 1 and version 2 are out of maintenance by now,
-  we expect that all projects have already upgraded. If in doubt, run `cds v` to find out which version of the CAP modules you have in use.
-
+  Describes the upgrade to CDS compiler version 2 (released March 2021), which is now out of maintenance and expected to already be in use by all projects.
 ---
 
 <!-- Keep this page, as _many_ links point to it! -->
@@ -633,7 +631,7 @@ CAP Java supports using CDS models that have been compiled with the CDS complier
 
 For every entity that has *localized* elements the CDS compiler [behind the scenes](../../guides/uis/localized-data#behind-the-scenes) generates a corresponding "texts" entity that holds the translated texts. The name of this entity changes with CDS compiler v2.
 
-::: warning 
+::: warning
 With compiler v1 the "texts" entity is generated with the suffix `_texts`, while the compiler v2 uses the suffix `.texts`!
 :::
 
@@ -708,7 +706,7 @@ CAP Java allows to [provide initial data](../../guides/databases/initial-data) t
 mv bookshop-Books_texts.csv bookshop-Books.texts.csv
 ```
 
-::: warning 
+::: warning
 If a CSV file has already been deployed to a productive SAP HANA schema it can't be renamed any longer. To support this situation cds deploy as well as the CSV data loader in CAP Java still suppport CSV files with a `_texts` suffix.
 :::
 
@@ -751,7 +749,7 @@ In this example, the return type of the `cancel` function is automatically expos
 
 With compiler v1 this change was also reflected in the CSN. With compiler v2 this is not the case any longer.
 
-::: warning 
+::: warning
 If types are used in a service that are defined outside of the service the [generated accessor interface](../../java/cds-data#generated-accessor-interfaces) will change when upgrading from compiler v1 to v2!
 :::
 
@@ -835,7 +833,7 @@ OData, however, does not support anonymous types. Hence, the compiler will autom
 
 In this example the compiler generated the type `Person_emails` in the OData service `hr`.
 
-::: warning 
+::: warning
 If an inline defined type is used in a service the [generated accessor interface](../../java/cds-data#generated-accessor-interfaces) will change (an inner interface is generated) when upgrading from compiler v1 to v2!
 :::
 

--- a/cds/compiler/v2.md
+++ b/cds/compiler/v2.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Describes the upgrade to CDS compiler version 2 (released March 2021), which is now out of maintenance and expected to already be in use by all projects.
 ---
 
@@ -7,7 +7,7 @@ synopsis: >
 
 # Upgrade to Compiler v2
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 CDS compiler version 2 brings numerous improvements, which allow us to significantly streamline model processing going forward.
 Changes mostly affect internal implementations of the compiler and nonpublic parts of the artifacts produced by the compiler (CSN, EDMX, ...), hence are unlikely to be observed by users of CDS.

--- a/cds/compiler/v2.md
+++ b/cds/compiler/v2.md
@@ -4,7 +4,6 @@ synopsis: >
   This document describes the upgrade to compiler version 2, released March 2021. As both compiler version 1 and version 2 are out of maintenance by now,
   we expect that all projects have already upgraded. If in doubt, run `cds v` to find out which version of the CAP modules you have in use.
 
-# layout: cds-ref
 ---
 
 <!-- Keep this page, as _many_ links point to it! -->

--- a/cds/compiler/v2.md
+++ b/cds/compiler/v2.md
@@ -1,5 +1,4 @@
 ---
-shorty: Compiler v2
 synopsis: >
   This document describes the upgrade to compiler version 2, released March 2021. As both compiler version 1 and version 2 are out of maintenance by now,
   we expect that all projects have already upgraded. If in doubt, run `cds v` to find out which version of the CAP modules you have in use.

--- a/cds/cql.md
+++ b/cds/cql.md
@@ -1,5 +1,4 @@
 ---
-# layout: cds-ref
 shorty: Query Language
 synopsis: >
   Specification of the CDS Query Language (aka CQL) which is an extension of the standard SQL SELECT statement.

--- a/cds/cql.md
+++ b/cds/cql.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Specification of the CDS Query Language (aka CQL) which is an extension of the standard SQL SELECT statement.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html
 ---
@@ -420,14 +420,14 @@ where the corresponding type can be deduced:
 type Status : String enum { open; closed; in_progress; };
 
 entity OpenOrder as projection on Order {
-  
+
   case status when #open        then 0
               when #in_progress then 1 end
     as status_int : Integer,
 
   (status = #in_progress ? 'is in progress' : 'is open')
-    as status_txt : String,  
-    
+    as status_txt : String,
+
 } where status = #open or status = #in_progress;
 ```
 

--- a/cds/cql.md
+++ b/cds/cql.md
@@ -1,5 +1,4 @@
 ---
-shorty: Query Language
 synopsis: >
   Specification of the CDS Query Language (aka CQL) which is an extension of the standard SQL SELECT statement.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html

--- a/cds/cqn.md
+++ b/cds/cqn.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Specification of the Core Query Notation (CQN) format that is used to capture queries as plain JavaScript objects.
 ---
 

--- a/cds/cqn.md
+++ b/cds/cqn.md
@@ -1,5 +1,4 @@
 ---
-shorty: Query Notation
 synopsis: >
   Specification of the Core Query Notation (CQN) format that is used to capture queries as plain JavaScript objects.
 ---

--- a/cds/cqn.md
+++ b/cds/cqn.md
@@ -3,7 +3,6 @@
 shorty: Query Notation
 synopsis: >
   Specification of the Core Query Notation (CQN) format that is used to capture queries as plain JavaScript objects.
-status: released
 ---
 
 # Query Notation (CQN)

--- a/cds/cqn.md
+++ b/cds/cqn.md
@@ -1,5 +1,4 @@
 ---
-# layout: cds-ref
 shorty: Query Notation
 synopsis: >
   Specification of the Core Query Notation (CQN) format that is used to capture queries as plain JavaScript objects.

--- a/cds/csn.md
+++ b/cds/csn.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Specification of CSN, CDS' canonical format for representing CDS models as plain JavaScript objects, similar to <a href="https://json-schema.org" target="_blank" rel="noopener noreferrer">JSON Schema</a>.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html
 ---

--- a/cds/csn.md
+++ b/cds/csn.md
@@ -1,5 +1,4 @@
 ---
-shorty: Schema Notation
 synopsis: >
   Specification of CSN, CDS' canonical format for representing CDS models as plain JavaScript objects, similar to <a href="https://json-schema.org" target="_blank" rel="noopener noreferrer">JSON Schema</a>.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html

--- a/cds/csn.md
+++ b/cds/csn.md
@@ -1,5 +1,4 @@
 ---
-# layout: cds-ref
 shorty: Schema Notation
 synopsis: >
   Specification of CSN, CDS' canonical format for representing CDS models as plain JavaScript objects, similar to <a href="https://json-schema.org" target="_blank" rel="noopener noreferrer">JSON Schema</a>.

--- a/cds/cxl.md
+++ b/cds/cxl.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Specification of the CDS Expression Language (CXL) used to capture expressions in CDS.
 ---
 
@@ -121,7 +121,7 @@ This syntax diagram describes the possible expressions:
 > [Operators](#xpr),
 > [Literals](#val),
 > [Functions](#func),
-> 
+>
 > Used in:
 > [Calculated Elements](#in-calculated-elements),
 > [Annotations](#in-annotations),
@@ -249,8 +249,8 @@ Compared to the previous example, we now use the expression directly in the quer
 to calculate the total value of all books in stock.
 
 
-## Path Expressions (`ref`) 
-###### ref 
+## Path Expressions (`ref`)
+###### ref
 
 A `ref` (short for reference) is used to refer to an element within the model.
 It can be used to navigate along path segments. Such a navigation is often
@@ -260,7 +260,7 @@ referred to as a **path expression**.
 
 > Using:
 > [Infix Filters](#infix-filters)
-> 
+>
 > Used in:
 > [Expressions](#expr)
 
@@ -400,7 +400,7 @@ This allows you to specify conditions on subsets of associated entities, enablin
 
 An infix in linguistics refers to a letter or group of letters that are added in the middle of a word to make a new word.
 
-If we apply this terminology to path expressions, an infix filter condition is an expression 
+If we apply this terminology to path expressions, an infix filter condition is an expression
 that is applied to a path segment of a path expression.
 This allows you to filter the target of an association based on certain criteria.
 
@@ -408,7 +408,7 @@ This allows you to filter the target of an association based on certain criteria
 
 > Using:
 > [Expressions](#expr)
-> 
+>
 > Used in:
 > [Path Expressions](#ref)
 
@@ -554,7 +554,7 @@ As depicted in below excerpt of the syntax diagram for `expr`, CXL supports all 
 
 > Using:
 > [Expressions](#expr)
-> 
+>
 > Used in:
 > [Expressions](#expr)
 
@@ -578,7 +578,7 @@ Following table gives an overview of the guaranteed supported operators in CXL:
 > [!tip] Bivalent `==` and `!=` Operators
 > In addition to standard SQL's `=` and `<>` operators, CXL also supports `==` and `!=` as bivalent variants as opposed to the trivalent semantics of `=` and `<>` when it comes to null handling. Learn more about this in the [_Bivalent `==` and `!=` Operators_](../guides/databases/cap-level-dbs#bivalent--and--operators) section of the databases documentation.
 
-> [!tip] Ternary `?:` Operator 
+> [!tip] Ternary `?:` Operator
 > In addition to the standard SQL `case when then` expression, CXL also supports the ternary `?:` operator as a more concise syntax for simple case expressions. Learn more about this in the [_Ternary `?:` Operator_](../guides/databases/cap-level-dbs#ternary--operator) section of the databases documentation.
 
 
@@ -590,7 +590,7 @@ Following table gives an overview of the guaranteed supported operators in CXL:
 
 > Using:
 > [Expressions](#expr)
-> 
+>
 > Used in:
 > [Expressions](#expr)
 

--- a/cds/cxn.md
+++ b/cds/cxn.md
@@ -1,5 +1,4 @@
 ---
-shorty: Expressions
 synopsis: >
   Specification of the Core Expression Notation (CXN) used to capture expressions as plain JavaScript objects.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html

--- a/cds/cxn.md
+++ b/cds/cxn.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Specification of the Core Expression Notation (CXN) used to capture expressions as plain JavaScript objects.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html
 ---
@@ -135,10 +135,10 @@ Examples:
 
 ```js
 [dev] cds repl
-> cds.parse.expr(`x<9`)  == 
+> cds.parse.expr(`x<9`)  ==
 {xpr:[ {ref:['x']}, '<', {val:9} ]}
 
-> cds.parse.expr(`x<9 and (y=1 or z=2)`)  == 
+> cds.parse.expr(`x<9 and (y=1 or z=2)`)  ==
 {xpr:[
   {ref:['x']}, '<', {val:9}, 'and', {xpr:[
     {ref:['y']}, '=', {val:1}, 'or', {ref:['z']}, '=', {val:2}

--- a/cds/cxn.md
+++ b/cds/cxn.md
@@ -1,5 +1,4 @@
 ---
-# layout: cds-ref
 shorty: Expressions
 synopsis: >
   Specification of the Core Expression Notation (CXN) used to capture expressions as plain JavaScript objects.

--- a/cds/index.md
+++ b/cds/index.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Core Data Services (CDS) is CAP's modeling language for declaratively capturing service definitions, data models, queries, and expressions.
+---
 
 # Core Data Services (CDS)
 Language Reference Documentation

--- a/cds/index.md
+++ b/cds/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Core Data Services (CDS) is CAP's modeling language for declaratively capturing service definitions, data models, queries, and expressions.
 ---
 

--- a/cds/index.md
+++ b/cds/index.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Core Data Services (CDS)
 Language Reference Documentation

--- a/cds/models.md
+++ b/cds/models.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   Introduces the fundamental principles of CDS models.
 ---
 
 
 # On The Nature of Models
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 
 ## Metaphysics of Languages
@@ -18,17 +18,17 @@ For example, a *data model describes the type structure (commonly also called *'
 
 ### Representations
 
-Models can come in different *representations*, which follow different *syntaxes*. For example, we use the *CDL* syntax for *human-readable* representations of CDS models, while CSN is an *object notation*, that is a special form of *syntax*, used for *machine-readable* representations of CDS models. 
+Models can come in different *representations*, which follow different *syntaxes*. For example, we use the *CDL* syntax for *human-readable* representations of CDS models, while CSN is an *object notation*, that is a special form of *syntax*, used for *machine-readable* representations of CDS models.
 
-::: details On CSN representations... 
+::: details On CSN representations...
 
-We can go one meta-level further and distinguish between different representations of CSN representations: in a Node.js process at runtime they are just native in-memory JavaScript objects, when shared they are serialized to JSON format, which can in turn be translated to YAML, and so forth. When we create CSN objects at runtime, they could be plain JavaScript code. 
+We can go one meta-level further and distinguish between different representations of CSN representations: in a Node.js process at runtime they are just native in-memory JavaScript objects, when shared they are serialized to JSON format, which can in turn be translated to YAML, and so forth. When we create CSN objects at runtime, they could be plain JavaScript code.
 
 :::
 
 ### Reflections
 
-CDS models can be compiled to other languages, that play in the same fields, yet not covering the same information, but rather with some loss of information — we call these '*reflections*'. 
+CDS models can be compiled to other languages, that play in the same fields, yet not covering the same information, but rather with some loss of information — we call these '*reflections*'.
 
 Examples are:
 

--- a/cds/models.md
+++ b/cds/models.md
@@ -2,7 +2,6 @@
 # layout: cds-ref
 synopsis: >
   Introduces the fundamental principles of CDS models.
-status: released
 ---
 
 

--- a/cds/models.md
+++ b/cds/models.md
@@ -1,5 +1,4 @@
 ---
-# layout: cds-ref
 synopsis: >
   Introduces the fundamental principles of CDS models.
 ---

--- a/cds/types.md
+++ b/cds/types.md
@@ -1,5 +1,4 @@
 ---
-shorty: Built-in Types
 synopsis: >
   Find here a brief overview of the predefined types shipped with CDS.
 ---

--- a/cds/types.md
+++ b/cds/types.md
@@ -1,5 +1,4 @@
 ---
-# layout: cds-ref
 shorty: Built-in Types
 synopsis: >
   Find here a brief overview of the predefined types shipped with CDS.

--- a/cds/types.md
+++ b/cds/types.md
@@ -3,7 +3,6 @@
 shorty: Built-in Types
 synopsis: >
   Find here a brief overview of the predefined types shipped with CDS.
-status: released
 ---
 
 

--- a/cds/types.md
+++ b/cds/types.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Find here a brief overview of the predefined types shipped with CDS.
 ---
 

--- a/get-started/bookshop.md
+++ b/get-started/bookshop.md
@@ -1,5 +1,4 @@
 ---
-notebook: true
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html
 ---
 

--- a/get-started/bookshop.md
+++ b/get-started/bookshop.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   A step-by-step walkthrough building a simple bookshop application to gain hands-on experience with core CAP concepts and best practices.
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html
 ---

--- a/get-started/bookshop.md
+++ b/get-started/bookshop.md
@@ -1,4 +1,6 @@
 ---
+synopsis: >
+  A step-by-step walkthrough building a simple bookshop application to gain hands-on experience with core CAP concepts and best practices.
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html
 ---
 

--- a/get-started/concepts.md
+++ b/get-started/concepts.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   An overview of CAP's primary building blocks and core concepts, such as domain-driven modeling, service-centric runtimes, and querying.
 ---
 

--- a/get-started/concepts.md
+++ b/get-started/concepts.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  An overview of CAP's primary building blocks and core concepts, such as domain-driven modeling, service-centric runtimes, and querying.
+---
 
 # Core Concepts of CAP
 Cloud Scale by Design  {.subtitle}
@@ -701,7 +705,7 @@ Your application models are your services, also served automatically by generic 
 
 Behind the scene - that is, in the **outer hexagon** containing stuff, you as an application developer should not see - the CAP runtime employs Protocol Adapters, which translate requests from (and to) low-level protocols like HTTP, REST, OData, GraphQL, ... to protocol-agnostic CAP requests and queries for inbound and outbound communication.
 
---> ***Inbound*** Communication 
+--> ***Inbound*** Communication
 : Requests your application *receives*.
 
 --> ***Outbound*** Communication

--- a/get-started/concepts.md
+++ b/get-started/concepts.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Core Concepts of CAP
 Cloud Scale by Design  {.subtitle}

--- a/get-started/feature-matrix.md
+++ b/get-started/feature-matrix.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 <script setup>
   import { h } from 'vue'

--- a/get-started/feature-matrix.md
+++ b/get-started/feature-matrix.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   An index of CAP features, with their status and availability across Node.js and Java, including what's planned or in development.
 ---
 

--- a/get-started/feature-matrix.md
+++ b/get-started/feature-matrix.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  An index of CAP features, with their status and availability across Node.js and Java, including what's planned or in development.
+---
 
 <script setup>
   import { h } from 'vue'

--- a/get-started/features.md
+++ b/get-started/features.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Introduction to CAP
 

--- a/get-started/features.md
+++ b/get-started/features.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   An introduction to CAP's value propositions, explaining what the framework is and the benefits it brings to enterprise-grade cloud application development.
 ---
 

--- a/get-started/features.md
+++ b/get-started/features.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  An introduction to CAP's value propositions, explaining what the framework is and the benefits it brings to enterprise-grade cloud application development.
+---
 
 # Introduction to CAP
 

--- a/get-started/get-help.md
+++ b/get-started/get-help.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Support channels and troubleshooting FAQs for getting help with CAP, including how to ask questions, report issues, and file feature requests.
 outline: 2
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/d2ee648522044ea19d3b5126c29692b5.html

--- a/get-started/get-help.md
+++ b/get-started/get-help.md
@@ -1,4 +1,6 @@
 ---
+synopsis: >
+  Support channels and troubleshooting FAQs for getting help with CAP, including how to ask questions, report issues, and file feature requests.
 outline: 2
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/d2ee648522044ea19d3b5126c29692b5.html
 ---

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Set up your local development environment with Node.js, cds-dk, and optional tools like Java and Visual Studio Code to start building CAP applications.
 ---
 

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Getting Started
 Jumpstart & Grow as You Go... {.subtitle}

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Set up your local development environment with Node.js, cds-dk, and optional tools like Java and Visual Studio Code to start building CAP applications.
+---
 
 # Getting Started
 Jumpstart & Grow as You Go... {.subtitle}

--- a/get-started/learn-more.md
+++ b/get-started/learn-more.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  An overview of learning resources for CAP, including the capire documentation, samples, tutorials, and podcasts.
+---
 
 # Learning Sources
 Capire, Samples, Tutorials, Podcasts, ... {.subtitle}
@@ -21,8 +25,8 @@ It's organized as follows:
 
 <table>
    <thead>
-      <tr> 
-         <th>Section</th> <th>Description</th> 
+      <tr>
+         <th>Section</th> <th>Description</th>
       </tr>
    </thead>
    <tbody>
@@ -33,7 +37,7 @@ It's organized as follows:
             <li> <a href="../guides/deploy/"> Deploy </a> </li>
          </ul></td>
          <td><ul>
-            Guides that walk you through the most common tasks 
+            Guides that walk you through the most common tasks
             in CAP-based development and deployment.
          </ul></td>
       </tr>
@@ -66,7 +70,7 @@ It's organized as follows:
 
 #### Callouts and Alerts
 
-We use [GitHub-flavored alerts](https://vitepress.dev/guide/markdown#github-flavored-alerts) to highlight important information in our documentation. 
+We use [GitHub-flavored alerts](https://vitepress.dev/guide/markdown#github-flavored-alerts) to highlight important information in our documentation.
 Here are the different types of alerts or callouts you may encounter:
 
 > [!info]
@@ -76,7 +80,7 @@ Here are the different types of alerts or callouts you may encounter:
 > Useful information that users should know even when skimming content.
 
 > [!tip]
-> Helpful advice for doing things better or more easily. 
+> Helpful advice for doing things better or more easily.
 
 > [!important]
 > Key information users need to know to achieve their goal.

--- a/get-started/learn-more.md
+++ b/get-started/learn-more.md
@@ -1,7 +1,3 @@
----
-status: released
-
----
 
 # Learning Sources
 Capire, Samples, Tutorials, Podcasts, ... {.subtitle}

--- a/get-started/learn-more.md
+++ b/get-started/learn-more.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   An overview of learning resources for CAP, including the capire documentation, samples, tutorials, and podcasts.
 ---
 

--- a/guides/databases/cap-level-dbs.md
+++ b/guides/databases/cap-level-dbs.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  Reference of portable CQL functions and operators that the CDS compiler translates to database-specific native SQL equivalents.
+---
+
 # CAP-Level Database Support
 
 CAP supports a number of portable functions and operators in CQL. The compiler automatically translates these to the best-possible database-specific native SQL equivalents. You can safely use these in CDS view definitions and runtime queries expressed in CQL.

--- a/guides/databases/cap-level-dbs.md
+++ b/guides/databases/cap-level-dbs.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference of portable CQL functions and operators that the CDS compiler translates to database-specific native SQL equivalents.
 ---
 

--- a/guides/databases/cdl-to-ddl.md
+++ b/guides/databases/cdl-to-ddl.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Explains how CDS models are compiled to database-specific DDL artifacts like SQL `CREATE TABLE` statements.
 ---
 

--- a/guides/databases/cdl-to-ddl.md
+++ b/guides/databases/cdl-to-ddl.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  Explains how CDS models are compiled to database-specific DDL artifacts like SQL `CREATE TABLE` statements.
+---
+
 # CDL Compilation to Database-Specific DDLs
 
 Databases are deployed based on the entity definitions in your CDS models. This guide explains how that works under the hood, focusing on the compilation of CDS models to database-specific artifacts like SQL `CREATE TABLE` statements for relational databases.

--- a/guides/databases/h2.md
+++ b/guides/databases/h2.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to use the H2 in-memory database for local development and testing in CAP Java.
 ---
 

--- a/guides/databases/h2.md
+++ b/guides/databases/h2.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How to use the H2 in-memory database for local development and testing in CAP Java.
+---
 
 # Using H2 for Development in CAP Java
 

--- a/guides/databases/hana-native.md
+++ b/guides/databases/hana-native.md
@@ -1,5 +1,4 @@
 ---
-label: Native SAP HANA
 synopsis: >
   Create or use an existing database object (table, view, table function, calculation view) and make use of it in your CDS model, for instance for exposing it in an OData service.
 ---

--- a/guides/databases/hana-native.md
+++ b/guides/databases/hana-native.md
@@ -1,11 +1,11 @@
 ---
-synopsis: >
+description: >
   Create or use an existing database object (table, view, table function, calculation view) and make use of it in your CDS model, for instance for exposing it in an OData service.
 ---
 
 # Using Native SAP HANA Artifacts
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ## Introduction
 

--- a/guides/databases/hana-native.md
+++ b/guides/databases/hana-native.md
@@ -2,7 +2,6 @@
 label: Native SAP HANA
 synopsis: >
   Create or use an existing database object (table, view, table function, calculation view) and make use of it in your CDS model, for instance for exposing it in an OData service.
-status: released
 ---
 
 # Using Native SAP HANA Artifacts

--- a/guides/databases/hana.md
+++ b/guides/databases/hana.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to set up and configure SAP HANA Cloud as the productive database for CAP applications.
 ---
 

--- a/guides/databases/hana.md
+++ b/guides/databases/hana.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How to set up and configure SAP HANA Cloud as the productive database for CAP applications.
+---
 
 # Using SAP HANA Cloud for Production
 

--- a/guides/databases/hana.md
+++ b/guides/databases/hana.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Using SAP HANA Cloud for Production
 

--- a/guides/databases/index.md
+++ b/guides/databases/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Overview of how CAP handles database integration generically, from CDS-model compilation to deployment and runtime querying, across supported databases.
 ---
 

--- a/guides/databases/index.md
+++ b/guides/databases/index.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Overview of how CAP handles database integration generically, from CDS-model compilation to deployment and runtime querying, across supported databases.
+---
 
 # CAP-Level Database Integration
 
@@ -37,19 +41,19 @@ The illustration below shows what happens automatically under the hood:
 
 The following guides explain the details of CAP-level database integration, which are mostly database-agnostic, and apply to all supported databases:
 
-[ CAP-Level Database Integration ](cap-level-dbs.md) 
+[ CAP-Level Database Integration ](cap-level-dbs.md)
 : How database-agnostic CDS models in CDL format are compiled to native DDL statements for different databases.
 
-[ CQL Compiled to SQL ](cdl-to-ddl.md) 
+[ CQL Compiled to SQL ](cdl-to-ddl.md)
 : How database-agnostic CDS queries in CQL format are compiled to native SQL statements for different databases.
 
-[ Adding Initial Data ](initial-data.md) 
+[ Adding Initial Data ](initial-data.md)
 : How to provide initial data and test data using CSV files, which are loaded into the database automatically.
 
-[ Schema Evolution ](schema-evolution.md) 
+[ Schema Evolution ](schema-evolution.md)
 : How to manage schema changes with appropriate schema evolution strategies for development and production.
 
-[ Performance Guide ](performance.md) 
+[ Performance Guide ](performance.md)
 : Pointing out performance considerations, and common pitfalls.
 
 

--- a/guides/databases/initial-data.md
+++ b/guides/databases/initial-data.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to add `.csv` files to fill your database with initial and test data, automatically loaded by the CAP runtime.
 ---
 

--- a/guides/databases/initial-data.md
+++ b/guides/databases/initial-data.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  How to add `.csv` files to fill your database with initial and test data, automatically loaded by the CAP runtime.
+---
+
 # Adding Initial Data
 
 You can add `.csv` files to fill your database with initial data and test data. The runtime automatically loads these files whenever you bootstrap a database, run `cds watch` in development, or deploy and upgrade for production.

--- a/guides/databases/new-dbs.md
+++ b/guides/databases/new-dbs.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Instructions on how to set up and use databases with CAP applications, with out-of-the-box support for SAP HANA, SQLite, H2, and PostgreSQL.
+---
 
 # Using Databases
 

--- a/guides/databases/new-dbs.md
+++ b/guides/databases/new-dbs.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Instructions on how to set up and use databases with CAP applications, with out-of-the-box support for SAP HANA, SQLite, H2, and PostgreSQL.
 ---
 

--- a/guides/databases/performance.md
+++ b/guides/databases/performance.md
@@ -1,7 +1,11 @@
+---
+synopsis: >
+  Considerations and advice for CDS modeling with a focus on database query performance, such as avoiding UNION statements.
+---
 
 # Performance Considerations for CDS Modeling
 
- Find here some considerations and advice for CDS modeling with performance focus. 
+ Find here some considerations and advice for CDS modeling with performance focus.
  {.abstract}
 
 
@@ -117,7 +121,7 @@ Polymorphism done right, also results in simplified view building. Assume you wa
 Using the (de-) normalized version:
 
 ```cds
-view FruitsByVendor as select from Fruit { 
+view FruitsByVendor as select from Fruit {
   ID, description, vendor
 } where vendor.description = 'TopFruitCompany';
 ```
@@ -200,7 +204,7 @@ GET http://localhost/odata/OrderItemsViewAssoc?$expand=Items&$select=OrderNo,Ite
 First sort on the `OrdersItems` and then join back to the `OrdersHeaders` with the help of an association:
 
 ```cds
-view SortedOrdersAssoc as select {*, Header.OrderNo, Header.buyer, Header.currency } as Flatten 
+view SortedOrdersAssoc as select {*, Header.OrderNo, Header.buyer, Header.currency } as Flatten
 from (
   select from OrdersItems {*} order by OrdersItems.title
 );

--- a/guides/databases/performance.md
+++ b/guides/databases/performance.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Considerations and advice for CDS modeling with a focus on database query performance, such as avoiding UNION statements.
 ---
 

--- a/guides/databases/performance.md
+++ b/guides/databases/performance.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Performance Considerations for CDS Modeling
 

--- a/guides/databases/postgres.md
+++ b/guides/databases/postgres.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How to set up and use PostgreSQL as a database for CAP applications via the `@cap-js/postgres` service.
+---
 
 # Using PostgreSQL
 

--- a/guides/databases/postgres.md
+++ b/guides/databases/postgres.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to set up and use PostgreSQL as a database for CAP applications via the `@cap-js/postgres` service.
 ---
 

--- a/guides/databases/schema-evolution.md
+++ b/guides/databases/schema-evolution.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How CAP's built-in schema evolution support updates database schemas to reflect changes in CDS models without losing existing data.
 ---
 

--- a/guides/databases/schema-evolution.md
+++ b/guides/databases/schema-evolution.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  How CAP's built-in schema evolution support updates database schemas to reflect changes in CDS models without losing existing data.
+---
+
 # Schema Evolution
 
 Schema evolution is the capability of a database to adapt its schema (tables, columns, indexes, constraints, etc.) to changes in the data model over time, without losing existing data. CAP provides built-in support for schema evolution across the supported databases, allowing developers to modify their CDS models and have the underlying database schema updated accordingly.
@@ -19,10 +24,10 @@ You can see this in action when you run `cds deploy`, which generates the necess
 cds deploy --dry
 ```
 ```sql [=> output]
-DROP TABLE IF EXISTS sap_capire_bookshop_Authors; 
-DROP TABLE IF EXISTS sap_capire_bookshop_Books; 
-DROP TABLE IF EXISTS sap_capire_bookshop_Genres; 
-... 
+DROP TABLE IF EXISTS sap_capire_bookshop_Authors;
+DROP TABLE IF EXISTS sap_capire_bookshop_Books;
+DROP TABLE IF EXISTS sap_capire_bookshop_Genres;
+...
 CREATE TABLE sap_capire_bookshop_Authors ...;
 CREATE TABLE sap_capire_bookshop_Books ...;
 CREATE TABLE sap_capire_bookshop_Genres ...;
@@ -37,9 +42,9 @@ In addition to dropping and recreating tables in-place, you can and should also 
 ## Schema Evolution by CAP
 
 
-In production environments, you can't use a drop-create strategy, as it would result in data loss. CAP provides mechanisms to handle schema evolution in a more controlled manner, by generating migration scripts that you can review and apply to the database. 
+In production environments, you can't use a drop-create strategy, as it would result in data loss. CAP provides mechanisms to handle schema evolution in a more controlled manner, by generating migration scripts that you can review and apply to the database.
 
-Let's simulate the workflow with the [@capire/bookshop](https://github.com/capire/bookshop) example. 
+Let's simulate the workflow with the [@capire/bookshop](https://github.com/capire/bookshop) example.
 
 1. Capture the current state of the database schema:
    ```shell
@@ -176,13 +181,13 @@ This enables automatic schema migration when you run `cds deploy` in production-
 
 - Before applying any changes, CAP compares the new state of the CDS models with the stored state and translates any differences into appropriate SQL statements to migrate the schema.
 
-> [!important] 
+> [!important]
 > CAP applies only non-lossy changes automatically. If it detects lossy changes, `cds deploy` aborts with respective errors and includes comments in the generated SQL script, similar to the general approach described above.
 
 
 ## Schema Evolution by HDI
 
-When deploying to SAP HANA, the so-called HANA Deployment Infrastructure (HDI) handles schema evolution automatically. 
+When deploying to SAP HANA, the so-called HANA Deployment Infrastructure (HDI) handles schema evolution automatically.
 
 HDI manages the lifecycle of database artifacts and applies necessary schema changes based on the deployed CDS models. This includes creating, altering, or dropping database objects as needed to align with the current CDS model.
 
@@ -192,7 +197,7 @@ Learn more about that in the [SAP HANA](hana.md) guide, section [HDI Schema Evol
 
 ## Liquibase for Java Projects
 
-For Java-based CAP projects, you can also use [Liquibase](https://www.liquibase.org/) to control when, where, and how you deploy database changes. 
+For Java-based CAP projects, you can also use [Liquibase](https://www.liquibase.org/) to control when, where, and how you deploy database changes.
 
 ::: tip Liquibase license change
 Please be aware that Liquibase [changed its license to  Functional Source License (FSL)](https://www.liquibase.com/blog/liquibase-community-for-the-future-fsl) with release 5.0. You need to check if this license is compatible with your application.

--- a/guides/databases/sqlite.md
+++ b/guides/databases/sqlite.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How to set up and use SQLite as the recommended in-memory database for fast CAP development and testing.
+---
 
 # Using SQLite for Development
 
@@ -24,11 +28,11 @@ Essentially this is doing the following:
 - For CAP Java projects, it adds a Maven dependency for the SQLite JDBC driver.
 - If MTA deployment is used, it adds an SQLite service to the `mta.yaml` file.
 
-> [!tip] 
+> [!tip]
 > Using `cds add sqlite` is the recommended way to set up SQLite in your CAP projects, as it covers both CAP Node.js and CAP Java projects in one step, as well as requisite additions for MTA deployment, if applicable.
 
 
-### Manual Setup for Node.js 
+### Manual Setup for Node.js
 
 Run this if you want to manually set up SQLite for CAP Node.js projects, instead of using `cds add sqlite`:
 
@@ -80,12 +84,12 @@ Using in-memory databases is the most recommended option for local inner-loop de
 Node.js projects don't require any build steps to prepare SQLite usage. Instead all necessary artifacts are created on-the-fly when running `cds watch`, indicated by the log output like this:
 
 ```log
-[cds] - connect to db > sqlite { url: ':memory:' } 
+[cds] - connect to db > sqlite { url: ':memory:' }
   > init from db/data/sap.capire.bookshop-Authors.csv
   > init from db/data/sap.capire.bookshop-Books.csv
   > init from db/data/sap.capire.bookshop-Books.texts.csv
   > init from db/data/sap.capire.bookshop-Genres.csv
-/> successfully deployed to in-memory database. 
+/> successfully deployed to in-memory database.
 ```
 
 ### In CAP Java Projects
@@ -139,7 +143,7 @@ spring:
 
 ## Using Persistent Databases
 
-You can also use persistent SQLite databases. In this case, the database is deployed and initialized by `cds deploy` and not by the CAP runtimes. 
+You can also use persistent SQLite databases. In this case, the database is deployed and initialized by `cds deploy` and not by the CAP runtimes.
 
 Follow these steps to use a file-based SQLite database:
 

--- a/guides/databases/sqlite.md
+++ b/guides/databases/sqlite.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to set up and use SQLite as the recommended in-memory database for fast CAP development and testing.
 ---
 

--- a/guides/databases/vector-embeddings.md
+++ b/guides/databases/vector-embeddings.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to store and generate vector embeddings in CDS models to enable semantic search and other generative AI features.
 ---
 # Vector Embeddings

--- a/guides/databases/vector-embeddings.md
+++ b/guides/databases/vector-embeddings.md
@@ -1,5 +1,6 @@
 ---
-label: Vector Embeddings
+synopsis: >
+  How to store and generate vector embeddings in CDS models to enable semantic search and other generative AI features.
 ---
 # Vector Embeddings
 
@@ -34,10 +35,10 @@ To generate vector embeddings on write in SAP HANA, you can use the [vector_embe
 ```cds
 extend Incidents with {
   @cds.api.ignore
-  embedding : Vector = vector_embedding( 
-    'Title: ' || title || ', Summary: ' || summary, 
+  embedding : Vector = vector_embedding(
+    'Title: ' || title || ', Summary: ' || summary,
     'DOCUMENT', 'SAP_GXY.20250407'
-  ) stored; 
+  ) stored;
 }
 ```
 
@@ -92,7 +93,7 @@ var similarity = CQL.cosineSimilarity(CQL.get(Incidents.EMBEDDING), embedding);
 
 // Find Incidents related to user question ordered by relevance
 Select.from(INCIDENTS)
-   .columns(i -> similarity.times(100).as("relevance"), 
+   .columns(i -> similarity.times(100).as("relevance"),
             i -> i.ID(), i -> i.title(), i -> i.summary(), i -> i.date())
    .where(i -> similarity.gt(0.75))
    .orderBy(i -> i.get("relevance").desc());

--- a/guides/deploy/build.md
+++ b/guides/deploy/build.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   The guide provides an overview of custom build processes for CAP projects, explaining how to tailor the standard build process to specific project requirements.
-status: released
 ---
 
 # Customizing `cds build`

--- a/guides/deploy/build.md
+++ b/guides/deploy/build.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   The guide provides an overview of custom build processes for CAP projects, explaining how to tailor the standard build process to specific project requirements.
 ---
 

--- a/guides/deploy/cicd.md
+++ b/guides/deploy/cicd.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   A comprehensive guide to implementing continuous integration and continuous deployment (CI/CD) for CAP projects using best practices, tools, and services.
-status: released
 ---
 
 # Deploy using CI/CD Pipelines

--- a/guides/deploy/cicd.md
+++ b/guides/deploy/cicd.md
@@ -1,10 +1,10 @@
 ---
-synopsis: >
+description: >
   A comprehensive guide to implementing continuous integration and continuous deployment (CI/CD) for CAP projects using best practices, tools, and services.
 ---
 
 # Deploy using CI/CD Pipelines
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 [[toc]]
 

--- a/guides/deploy/health-checks.md
+++ b/guides/deploy/health-checks.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   The guide provides an overview of health checks that are available on Cloud Foundry and Kubernetes, how to configure them, as well as the respective defaults of the two CAP stacks.
 ---
 

--- a/guides/deploy/health-checks.md
+++ b/guides/deploy/health-checks.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   The guide provides an overview of health checks that are available on Cloud Foundry and Kubernetes, how to configure them, as well as the respective defaults of the two CAP stacks.
-status: released
 ---
 
 # Health Checks

--- a/guides/deploy/index.md
+++ b/guides/deploy/index.md
@@ -1,4 +1,6 @@
 ---
+synopsis: >
+  Overview of deployment options for CAP applications.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html and https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html
 ---
 

--- a/guides/deploy/index.md
+++ b/guides/deploy/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Overview of deployment options for CAP applications.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html and https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html
 ---

--- a/guides/deploy/microservices.md
+++ b/guides/deploy/microservices.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   A guide on deploying SAP Cloud Application Programming Model (CAP) applications as microservices to the SAP BTP Cloud Foundry environment.
-status: released
 ---
 
 # Microservices with CAP

--- a/guides/deploy/microservices.md
+++ b/guides/deploy/microservices.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   A guide on deploying SAP Cloud Application Programming Model (CAP) applications as microservices to the SAP BTP Cloud Foundry environment.
 ---
 

--- a/guides/deploy/to-cf.md
+++ b/guides/deploy/to-cf.md
@@ -1,11 +1,11 @@
 ---
-synopsis: >
+description: >
   A comprehensive guide on deploying applications built with SAP Cloud Application Programming Model (CAP) to SAP BTP Cloud Foundry environment.
 ---
 
 # Deploy to Cloud Foundry
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 [[toc]]
 

--- a/guides/deploy/to-cf.md
+++ b/guides/deploy/to-cf.md
@@ -1,6 +1,6 @@
 ---
 synopsis: >
-  A comprehensive guide on deploying applications built with SAP Cloud Application Programming Model (CAP)  to SAP BTP Cloud Foundry environment.
+  A comprehensive guide on deploying applications built with SAP Cloud Application Programming Model (CAP) to SAP BTP Cloud Foundry environment.
 ---
 
 # Deploy to Cloud Foundry

--- a/guides/deploy/to-kyma.md
+++ b/guides/deploy/to-kyma.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   A step-by-step guide on how to deploy a CAP (Cloud Application Programming Model) application to Kyma Runtime of SAP Business Technology Platform.
 impl-variants: true
 # uacp: Used as link target from Help Portal at https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/29c25e504fdb4752b0383d3c407f52a6.html and https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/e4a7559baf9f4e4394302442745edcd9.html

--- a/guides/deploy/to-kyma.md
+++ b/guides/deploy/to-kyma.md
@@ -2,11 +2,6 @@
 label: Deploy to Kyma/K8s
 synopsis: >
   A step-by-step guide on how to deploy a CAP (Cloud Application Programming Model) application to Kyma Runtime of SAP Business Technology Platform.
-breadcrumbs:
-  - Cookbook
-  - Deployment
-  - Deploy to Kyma
-status: released
 impl-variants: true
 # uacp: Used as link target from Help Portal at https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/29c25e504fdb4752b0383d3c407f52a6.html and https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/e4a7559baf9f4e4394302442745edcd9.html
 ---

--- a/guides/deploy/to-kyma.md
+++ b/guides/deploy/to-kyma.md
@@ -1,5 +1,4 @@
 ---
-label: Deploy to Kyma/K8s
 synopsis: >
   A step-by-step guide on how to deploy a CAP (Cloud Application Programming Model) application to Kyma Runtime of SAP Business Technology Platform.
 impl-variants: true

--- a/guides/domain/index.md
+++ b/guides/domain/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Introduction to the basics of domain modeling with CDS, complemented with recommended best practices for capturing the essential objects of your domain.
 ---
 

--- a/guides/domain/index.md
+++ b/guides/domain/index.md
@@ -2,7 +2,6 @@
 synopsis: >
   Most projects start with capturing the essential objects of their domain in a respective domain model.
   Find here an introduction to the basics of domain modeling with CDS, complemented with recommended best practices.
-status: released
 ---
 
 # Domain Modeling

--- a/guides/domain/index.md
+++ b/guides/domain/index.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
-  Most projects start with capturing the essential objects of their domain in a respective domain model.
-  Find here an introduction to the basics of domain modeling with CDS, complemented with recommended best practices.
+  Introduction to the basics of domain modeling with CDS, complemented with recommended best practices for capturing the essential objects of your domain.
 ---
 
 # Domain Modeling

--- a/guides/domain/temporal-data.md
+++ b/guides/domain/temporal-data.md
@@ -1,5 +1,4 @@
 ---
-index: 53
 synopsis: >
   CAP provides out-of-the-box support for declaring and serving date-effective entities with application-controlled validity, in particular to serve as-of-now and time-travel queries.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html

--- a/guides/domain/temporal-data.md
+++ b/guides/domain/temporal-data.md
@@ -1,6 +1,5 @@
 ---
 index: 53
-# layout: cookbook
 synopsis: >
   CAP provides out-of-the-box support for declaring and serving date-effective entities with application-controlled validity, in particular to serve as-of-now and time-travel queries.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html

--- a/guides/domain/temporal-data.md
+++ b/guides/domain/temporal-data.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   CAP provides out-of-the-box support for declaring and serving date-effective entities with application-controlled validity, in particular to serve as-of-now and time-travel queries.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html
 ---
 
 # Temporal Data
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 Temporal data allows you to maintain information relating to past, present, and future application time.
 Built-in support for temporal data follows the general principle of CDS to capture intent with models while staying conceptual, concise, and comprehensive, and minimizing pollution by technical artifacts.

--- a/guides/events/core-concepts.md
+++ b/guides/events/core-concepts.md
@@ -2,7 +2,6 @@
 title: Core Eventing in CAP
 synopsis: >
   This guides introduces CAP's intrinsic support for emitting and receiving events in the very core of the runtimes' processing models.
-status: released
 ---
 
 # Core Eventing in CAP

--- a/guides/events/core-concepts.md
+++ b/guides/events/core-concepts.md
@@ -1,13 +1,13 @@
 ---
 title: Core Eventing in CAP
-synopsis: >
+description: >
   This guides introduces CAP's intrinsic support for emitting and receiving events in the very core of the runtimes' processing models.
 ---
 
 # Core Eventing in CAP
 
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 [[toc]]
 
@@ -204,7 +204,7 @@ It produces a trace output like that:
 
 As apparent from the output, both, the two bookshop services `CatalogService` and `AdminService` as well as our new `ReviewsService`, are served in the same process (mocked, as the `ReviewsService` is configured as required service in _[bookstore/package.json](https://github.com/capire/bookstore/blob/main/package.json#L30-L31)_).
 
-### 2. Add Reviews 
+### 2. Add Reviews
 
 Now, open [http://localhost:4004/reviews](http://localhost:4004/reviews) to display the Vue.js UI that is provided with the reviews service sample:
 
@@ -225,7 +225,7 @@ Now, open [http://localhost:4004/reviews](http://localhost:4004/reviews) to disp
 
 Which means the `ReviewsService` emitted a `reviewed` message that was received by the enhanced `CatalogService`.
 
-### 3. Check Ratings 
+### 3. Check Ratings
 
 Open [http://localhost:4004/bookshop](http://localhost:4004/bookshop) to see the list of books served by `CatalogService` and refresh to see the updated average rating and reviews count:
 

--- a/guides/events/event-hub.md
+++ b/guides/events/event-hub.md
@@ -1,9 +1,9 @@
 ---
-synopsis: >
+description: >
   Using SAP Cloud Application Event Hub service on SAP Business Technology Platform (BTP) as a messaging channel in CAP applications.
 ---
 
-# Messaging via SAP Cloud Application Event Hub 
+# Messaging via SAP Cloud Application Event Hub
 
 [SAP Cloud Application Event Hub](https://help.sap.com/docs/event-broker) is the new default offering for messaging in SAP Business Technology Platform (SAP BTP).
 CAP provides out-of-the-box support for SAP Cloud Application Event Hub, and automatically handles many things behind the scenes, so that application coding stays agnostic and focused on conceptual messaging.
@@ -191,7 +191,7 @@ modules:
     provides:
       - name: incidents-srv-api
         properties:
-          url: ${default-url} 
+          url: ${default-url}
     requires: #[!code focus:10]
       - name: incidents-ias #[!code ++]
         parameters: #[!code ++]

--- a/guides/events/event-hub.md
+++ b/guides/events/event-hub.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Using SAP Cloud Application Event Hub service on SAP Business Technology Platform (BTP) as a messaging channel in CAP applications.
-status: released
 ---
 
 # Messaging via SAP Cloud Application Event Hub 

--- a/guides/events/event-mesh.md
+++ b/guides/events/event-mesh.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Using SAP Event Mesh service on SAP Business Technology Platform (BTP) as a messaging channel in CAP applications.
-status: released
 ---
 
 # Messaging via SAP Event Mesh 

--- a/guides/events/event-mesh.md
+++ b/guides/events/event-mesh.md
@@ -1,9 +1,9 @@
 ---
-synopsis: >
+description: >
   Using SAP Event Mesh service on SAP Business Technology Platform (BTP) as a messaging channel in CAP applications.
 ---
 
-# Messaging via SAP Event Mesh 
+# Messaging via SAP Event Mesh
 
 CAP provides out-of-the-box support for [SAP Event Mesh](https://help.sap.com/docs/event-mesh), and automatically handles many things behind the scenes, so that application coding stays agnostic and focused on conceptual messaging.
 

--- a/guides/events/event-queues.md
+++ b/guides/events/event-queues.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Transactional Event Queues let you persist events and scheduled tasks in the same database transaction as your business data, then process them asynchronously with retries and a dead letter queue.
-status: released
 ---
 
 # Transactional Event Queues

--- a/guides/events/event-queues.md
+++ b/guides/events/event-queues.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Transactional Event Queues let you persist events and scheduled tasks in the same database transaction as your business data, then process them asynchronously with retries and a dead letter queue.
 ---
 
@@ -153,7 +153,7 @@ CqnService xflights = OutboxService.unboxed(outboxedXFlights);
 
 
 ### By Configuration
-  
+
   > [!note] Node.js only
   > Outboxing required services by configuration is available in Node.js only.
 

--- a/guides/events/index.md
+++ b/guides/events/index.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
-  CAP provides intrinsic support for emitting and receiving events.
-  This is complemented by Messaging Services connecting to message brokers to exchange event messages across remote services.
+  Introduces CAP's intrinsic support for emitting and receiving events, complemented by Messaging Services that connect to message brokers to exchange event messages with remote services.
 ---
 
 # Events and Messaging

--- a/guides/events/index.md
+++ b/guides/events/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Introduces CAP's intrinsic support for emitting and receiving events, complemented by Messaging Services that connect to message brokers to exchange event messages with remote services.
 ---
 

--- a/guides/events/index.md
+++ b/guides/events/index.md
@@ -2,7 +2,6 @@
 synopsis: >
   CAP provides intrinsic support for emitting and receiving events.
   This is complemented by Messaging Services connecting to message brokers to exchange event messages across remote services.
-status: released
 ---
 
 # Events and Messaging

--- a/guides/events/is-aem.md
+++ b/guides/events/is-aem.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   CAP provides out-of-the-box support for SAP Integration Suite, advanced event mesh, via CAP plugins for Node.js and Java.
 ---
 

--- a/guides/events/is-aem.md
+++ b/guides/events/is-aem.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   CAP provides out-of-the-box support for SAP Integration Suite, advanced event mesh, via CAP plugins for Node.js and Java.
-status: released
 ---
 
 # Messaging via SAP Integration Suite, Advanced Event Mesh

--- a/guides/events/messaging.md
+++ b/guides/events/messaging.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   How CAP's Messaging Services connect to message brokers to exchange event messages with remote services, complementing CAP's intrinsic event support.
 ---
 
 # CAP-level Messaging
 
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 [[toc]]
 

--- a/guides/events/messaging.md
+++ b/guides/events/messaging.md
@@ -2,7 +2,6 @@
 synopsis: >
   CAP provides intrinsic support for emitting and receiving events.
   This is complemented by Messaging Services connecting to message brokers to exchange event messages across remote services.
-status: released
 ---
 
 # CAP-level Messaging

--- a/guides/events/messaging.md
+++ b/guides/events/messaging.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
-  CAP provides intrinsic support for emitting and receiving events.
-  This is complemented by Messaging Services connecting to message brokers to exchange event messages across remote services.
+  How CAP's Messaging Services connect to message brokers to exchange event messages with remote services, complementing CAP's intrinsic event support.
 ---
 
 # CAP-level Messaging
@@ -56,7 +55,7 @@ For quick tests during development, CAP provides a simple file-based messaging s
 In our samples, you find that in [@capire/reviews/package.json](https://github.com/capire/reviews/blob/main/package.json) as well as [@capire/bookstore/package.json](https://github.com/capire/bookstore/blob/main/package.json), which you'll run in the next step as separate processes.
 
 
-### 2. Start the `reviews` Service and `bookstore` Separately 
+### 2. Start the `reviews` Service and `bookstore` Separately
 
 First start the `reviews` service separately:
 

--- a/guides/events/s4.md
+++ b/guides/events/s4.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Receiving events from SAP S/4HANA Cloud systems via SAP Event Mesh as well as SAP Cloud Application Event Hub.
 ---
 

--- a/guides/events/s4.md
+++ b/guides/events/s4.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Receiving events from SAP S/4HANA Cloud systems via SAP Event Mesh as well as SAP Cloud Application Event Hub.
-status: released
 ---
 
 

--- a/guides/extensibility/customization.md
+++ b/guides/extensibility/customization.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This guide explains how subscribers of SaaS applications can extend these on tenant level, thereby customizing them for their specific needs.
 ---
 

--- a/guides/extensibility/customization.md
+++ b/guides/extensibility/customization.md
@@ -1,5 +1,4 @@
 ---
-# layout: cookbook
 shorty: Extend SaaS Apps
 synopsis: >
   This guide explains how subscribers of SaaS applications can extend these on tenant level, thereby customizing them for their specific needs.

--- a/guides/extensibility/customization.md
+++ b/guides/extensibility/customization.md
@@ -1,5 +1,4 @@
 ---
-shorty: Extend SaaS Apps
 synopsis: >
   This guide explains how subscribers of SaaS applications can extend these on tenant level, thereby customizing them for their specific needs.
 ---

--- a/guides/extensibility/customization.md
+++ b/guides/extensibility/customization.md
@@ -3,12 +3,6 @@
 shorty: Extend SaaS Apps
 synopsis: >
   This guide explains how subscribers of SaaS applications can extend these on tenant level, thereby customizing them for their specific needs.
-breadcrumbs:
-  - Cookbook
-  - Extensibility
-  - Extending SaaS Apps
-#notebook: true
-status: released
 ---
 
 # Extending SaaS Applications

--- a/guides/extensibility/feature-toggles.md
+++ b/guides/extensibility/feature-toggles.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   Toggled features are pre-built extensions built by the provider of a SaaS application, which can be switched on selectively per subscriber.
 impl-variants: true  # to enable Node.js/Java toggle
 ---
 
 # Feature Toggles
 
-{{$frontmatter?.synopsis}}
+{{$frontmatter?.description}}
 
 <ImplVariantsHint />
 

--- a/guides/extensibility/index.md
+++ b/guides/extensibility/index.md
@@ -1,5 +1,4 @@
 ---
-index: 77
 synopsis: >
   Learn here about intrinsic capabilities to extend your applications in verticalization
   and customization scenarios.

--- a/guides/extensibility/index.md
+++ b/guides/extensibility/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Learn here about intrinsic capabilities to extend your applications in verticalization
   and customization scenarios.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html
@@ -7,7 +7,7 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
 
 # Extensibility
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 Extensibility of CAP applications is greatly fueled by **CDS Aspects**, which allow to easily extend existing models with new fields, entities, relationships, or new or overridden annotations [&rarr; Learn more about using CDS Aspects in the Domain Modeling guide](../domain/index#separation-of-concerns).
 

--- a/guides/extensibility/index.md
+++ b/guides/extensibility/index.md
@@ -1,8 +1,5 @@
 ---
 index: 77
-breadcrumbs:
-  - Cookbook
-  - Extensibility
 synopsis: >
   Learn here about intrinsic capabilities to extend your applications in verticalization
   and customization scenarios.

--- a/guides/index.md
+++ b/guides/index.md
@@ -1,6 +1,3 @@
----
-status: released
----
 # The CAP Cookbook
 Recipes for CAP Development { .subtitle}
 

--- a/guides/index.md
+++ b/guides/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   An index of Cookbook guides covering the most prominent tasks in CAP application development, from domain modeling to deployment.
 ---
 

--- a/guides/index.md
+++ b/guides/index.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  An index of Cookbook guides covering the most prominent tasks in CAP application development, from domain modeling to deployment.
+---
+
 # The CAP Cookbook
 Recipes for CAP Development { .subtitle}
 

--- a/guides/integration/calesi.md
+++ b/guides/integration/calesi.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Introduces the 'Calesi' pattern for integrating remote services as CAP services, consumed as if they were local and mocked out of the box.
+---
 
 # CAP-Level Service Integration
 The *'Calesi'* Pattern {.subtitle}

--- a/guides/integration/calesi.md
+++ b/guides/integration/calesi.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Introduces the 'Calesi' pattern for integrating remote services as CAP services, consumed as if they were local and mocked out of the box.
 ---
 

--- a/guides/integration/data-federation.md
+++ b/guides/integration/data-federation.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  Core concepts and techniques for federating and integrating data from multiple external data sources in CAP applications.
+---
+
 # CAP-level Data Federation
 
 CAP applications can integrate and federate data from multiple external data sources, enabling close access to distributed data. This guide provides an overview of the core concepts and techniques for implementing data federation in CAP applications, and how CAP helps solving this generically, and thus serving data federation out of the box.

--- a/guides/integration/data-federation.md
+++ b/guides/integration/data-federation.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Core concepts and techniques for federating and integrating data from multiple external data sources in CAP applications.
 ---
 

--- a/guides/integration/index.md
+++ b/guides/integration/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Overview of CAP-level service integration, data federation, and platform integration patterns available to CAP projects.
 ---
 

--- a/guides/integration/index.md
+++ b/guides/integration/index.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  Overview of CAP-level service integration, data federation, and platform integration patterns available to CAP projects.
+---
+
 # Services & Platform Integration
 
 CAP applications integrate at multiple levels — from reusing services and data within your application, to connecting with external microservices, to leveraging platform services for identity, storage, and observability. The guides in this section covers the various CAP-level service integration and data federation patterns, as well as platform capabilities available to your CAP projects.

--- a/guides/integration/inner-loops.md
+++ b/guides/integration/inner-loops.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How swapping production-grade services with local mocks enables fast inner-loop development and decoupled parallel work across teams.
+---
 
 # Inner-Loop Development
 

--- a/guides/integration/inner-loops.md
+++ b/guides/integration/inner-loops.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How swapping production-grade services with local mocks enables fast inner-loop development and decoupled parallel work across teams.
 ---
 

--- a/guides/integration/platform/attachments.md
+++ b/guides/integration/platform/attachments.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to integrate the SAP Business Technology Platform Attachment Service to manage file attachments in CAP applications.
 ---
 

--- a/guides/integration/platform/attachments.md
+++ b/guides/integration/platform/attachments.md
@@ -1,25 +1,30 @@
+---
+synopsis: >
+  How to integrate the SAP Business Technology Platform Attachment Service to manage file attachments in CAP applications.
+---
+
 # Adding Attachments to Your CAP Application
- 
+
  You can use the Attachment Service provided by SAP Business Technology Platform to manage file attachments in your CAP applications. This guide explains how to integrate the Attachment Service into your CAP application.
- 
+
  ## Prerequisites
- 
+
  - A CAP project set up on SAP Business Technology Platform.
  - Access to the SAP Business Technology Platform Cockpit.
  - Basic knowledge of CAP and Node.js.
- 
+
  ## Steps to Integrate Attachment Service
- 
+
  1. **Enable Attachment Service**: In the SAP Business Technology Platform Cockpit, navigate to your subaccount and enable the Attachment Service.
- 
+
  2. **Install Required Packages**: In your CAP project, install the necessary packages for working with attachments. You can use the following command:
- 
+
     ```bash
     npm install @sap/cds-srv-attachments
     ```
- 
+
  3. **Configure Attachment Service**: In your `package.json` file, add the Attachment Service configuration under the `cds` section:
- 
+
     ```json
     "cds": {
       "requires": {
@@ -29,9 +34,9 @@
       }
     }
     ```
- 
+
  4. **Define Attachment Entity**: In your CDS model, define an entity for attachments. For example:
- 
+
     ```cds
     entity Attachments {
       key ID : UUID;
@@ -40,11 +45,11 @@
       MimeType: String;
     }
     ```
- 
+
  5. **Implement Attachment Logic**: In your service implementation file (for example, `srv/your-service.js`), implement the logic to handle attachment operations such as upload, download, and delete.
- 
+
  6. **Test Your Application**: Run your CAP application and test the attachment functionality to ensure everything is working as expected.
- 
+
  ## Conclusion
- 
+
  By following these steps, you can successfully integrate the Attachment Service into your CAP application, allowing you to manage file attachments efficiently. For more detailed information, refer to the official SAP documentation on the Attachment Service.

--- a/guides/integration/platform/audit-logging.md
+++ b/guides/integration/platform/audit-logging.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to integrate CAP applications with the SAP Audit Logging Service to record security-relevant events.
 ---
 

--- a/guides/integration/platform/audit-logging.md
+++ b/guides/integration/platform/audit-logging.md
@@ -1,39 +1,44 @@
+---
+synopsis: >
+  How to integrate CAP applications with the SAP Audit Logging Service to record security-relevant events.
+---
+
 # Integration with SAP Audit Logging Service
- 
+
  The [SAP Audit Logging Service](https://help.sap.com/docs/SAP_AUDIT_LOGGING_SERVICE) enables you to record security-relevant events in your applications running on SAP Business Technology Platform (SAP BTP). This guide explains how to integrate your CAP application with the Audit Logging Service.
- 
+
  ## Prerequisites
- 
+
  To use the Audit Logging Service, ensure that:
- 
+
  - Your SAP BTP subaccount has the Audit Logging Service instance created.
  - Your CAP application is bound to the Audit Logging Service instance using a service key.
- 
+
  ## Setting Up Audit Logging in Your CAP Application
- 
+
  1. **Install the Required Package**:
- 
+
     Ensure that you have the `@sap/audit-logging` package installed in your CAP project:
- 
+
     ```bash
     npm install @sap/audit-logging
     ```
- 
+
  2. **Configure the Audit Logger**:
- 
+
     In your application code, configure the audit logger using the service credentials from the service key:
- 
+
     ```javascript
     const { AuditLogger } = require('@sap/audit-logging');
     const auditLogger = new AuditLogger({
       // Provide necessary configuration options here
     });
     ```
- 
+
  3. **Log Events**:
- 
+
     Use the audit logger to log security-relevant events in your application:
- 
+
     ```javascript
     auditLogger.logEvent({
       eventType: 'USER_LOGIN',
@@ -43,7 +48,7 @@
       }
     });
     ```
- 
+
  ## Further Reading
- 
+
  For more detailed information on configuring and using the SAP Audit Logging Service, refer to the [official documentation](https://help.sap.com/docs/SAP_AUDIT_LOGGING_SERVICE).

--- a/guides/integration/platform/ias-xsuaa.md
+++ b/guides/integration/platform/ias-xsuaa.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  How CAP applications can be configured to use SAP Identity Authentication Service (IAS) and/or SAP XSUAA for authentication and authorization.
+---
+
 # Identity & Authentication
 
 The SAP Cloud Platform provides two main services for identity management and authentication: **SAP Identity Authentication Service (IAS)** and **SAP Authorization and Trust Management Service (XSUAA)**.
@@ -9,7 +14,7 @@ CAP applications can be configured to use either or both of these services for h
 SAP IAS is a cloud-based identity provider that offers single sign-on (SSO) capabilities and identity federation.
 It allows users to authenticate using various methods, including social logins, enterprise identity providers, and multi-factor authentication.
 
-When integrated with CAP applications, IAS can serve as the primary identity provider, managing user identities and authentication flows. 
+When integrated with CAP applications, IAS can serve as the primary identity provider, managing user identities and authentication flows.
 
 To integrate IAS with a CAP application, you typically need to configure the application to trust IAS as an identity provider and set up the necessary SSO protocols (for example, SAML, OAuth2).
 For more details on configuring IAS with CAP applications, refer to the [SAP IAS documentation](https://help.sap.com/viewer/product/SAP_IDENTITY_AUTHENTICATION/).
@@ -21,7 +26,7 @@ To set up XSUAA with a CAP application, you need to create an XSUAA service inst
 For more information on configuring XSUAA with CAP applications, refer to the [SAP XSUAA documentation](https://help.sap.com/viewer/product/SAP_AUTHORIZATION_AND_TRUST_MANAGEMENT/).
 ## Integration Scenarios
 CAP applications can be configured to use IAS, XSUAA, or both services depending on the requirements.
-Common scenarios include:  
+Common scenarios include:
 - **Using IAS for SSO and XSUAA for Authorization**: In this scenario, IAS handles user authentication and SSO, while XSUAA manages user roles and permissions within the CAP application.
 - **Using XSUAA as the Primary Identity Provider**: In this case, XSUAA handles both authentication and authorization for the CAP application.
 - **Federating Identities between IAS and XSUAA**: This involves configuring trust relationships between IAS and XSUAA to allow seamless authentication and authorization across services.

--- a/guides/integration/platform/ias-xsuaa.md
+++ b/guides/integration/platform/ias-xsuaa.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How CAP applications can be configured to use SAP Identity Authentication Service (IAS) and/or SAP XSUAA for authentication and authorization.
 ---
 

--- a/guides/integration/platform/notifications.md
+++ b/guides/integration/platform/notifications.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  How to integrate the SAP Business Technology Platform notification service to send notifications from CAP applications.
+---
+
 # Notifications in SAP Business Technology Platform
 SAP Business Technology Platform (BTP) provides a notification service that allows you to send notifications to users through various channels, such as email, SMS, or push notifications. In CAP, you can integrate with the notification service to enhance user engagement and communication.{.abstract}
 ## Setting Up the Notification Service
@@ -22,7 +27,7 @@ module.exports = async function sendEmailNotification(userEmail, subject, messag
     body: message,
     type: 'email'
   };
-  
+
   try {
     await sendNotification(notification);
     console.log('Notification sent successfully');

--- a/guides/integration/platform/notifications.md
+++ b/guides/integration/platform/notifications.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to integrate the SAP Business Technology Platform notification service to send notifications from CAP applications.
 ---
 

--- a/guides/integration/platform/telemetry.md
+++ b/guides/integration/platform/telemetry.md
@@ -1,10 +1,15 @@
+---
+synopsis: >
+  How to set up telemetry in CAP applications to collect, export, and monitor performance and usage data on SAP Business Technology Platform.
+---
+
 # Telemetry Integration in SAP Business Technology Platform
 Telemetry in SAP Business Technology Platform (BTP) allows you to collect, analyze, and visualize performance and usage data from your applications. In CAP, you can integrate telemetry services to monitor your application's health and performance effectively.
 {.abstract}
 ## Setting Up Telemetry in CAP
 To set up telemetry in your CAP application, follow these steps:
 1. **Enable Telemetry Service**: In your SAP BTP cockpit, enable the telemetry service for your subaccount.
-2. **Bind the Service to Your Application**: Update your `mta.yaml` or `manifest.yml` file to include the service binding for the telemetry service.  
+2. **Bind the Service to Your Application**: Update your `mta.yaml` or `manifest.yml` file to include the service binding for the telemetry service.
 3. **Install Required Dependencies**: Ensure that your CAP application has the necessary dependencies to interact with the telemetry service. You may need to install specific npm packages or Java libraries depending on your runtime.
 ## Collecting Telemetry Data
 Once you have set up the telemetry service, you can start collecting telemetry data in your CAP application. Here are some common practices:

--- a/guides/integration/platform/telemetry.md
+++ b/guides/integration/platform/telemetry.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to set up telemetry in CAP applications to collect, export, and monitor performance and usage data on SAP Business Technology Platform.
 ---
 

--- a/guides/integration/plugins-guide.md
+++ b/guides/integration/plugins-guide.md
@@ -1,2 +1,6 @@
+---
+synopsis: >
+  Guide for developers who want to build CAP plugins.
+---
 
-# CAP Plugins Developers Guide 
+# CAP Plugins Developers Guide

--- a/guides/integration/plugins-guide.md
+++ b/guides/integration/plugins-guide.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Guide for developers who want to build CAP plugins.
 ---
 

--- a/guides/integration/reuse-and-compose.md
+++ b/guides/integration/reuse-and-compose.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to reuse and compose solutions from modular CAP projects, adapting imported content with solution-specific projections and extensions.
 ---
 

--- a/guides/integration/reuse-and-compose.md
+++ b/guides/integration/reuse-and-compose.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How to reuse and compose solutions from modular CAP projects, adapting imported content with solution-specific projections and extensions.
+---
 
 # CAP Service Composition
 

--- a/guides/integration/service-bindings.md
+++ b/guides/integration/service-bindings.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  How CAP runtimes use service bindings to connect to required services at runtime, based on declared configuration and injected credentials.
+---
+
 # Service Bindings
 
 Service bindings configure connectivity to required services. CAP runtimes use them to connect to these services at runtime, using credentials injected from the binding environment, such as `url`, and authentication details.

--- a/guides/integration/service-bindings.md
+++ b/guides/integration/service-bindings.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How CAP runtimes use service bindings to connect to required services at runtime, based on declared configuration and injected credentials.
 ---
 

--- a/guides/multitenancy/index.md
+++ b/guides/multitenancy/index.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   Introducing the fundamental concepts of multitenancy, underpinning SaaS solutions in CAP. It describes how to run and test apps in multitenancy mode with minimized setup and overhead.
 impl-variants: true
 ---
 
 # Deploy Multitenant SaaS Applications
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 [[toc]]
 

--- a/guides/multitenancy/mtxs.md
+++ b/guides/multitenancy/mtxs.md
@@ -3,7 +3,6 @@
 label: MTX Reference
 synopsis: >
   API reference for multitenancy and extensibility.
-status: released
 ---
 
 # MTX Services Reference

--- a/guides/multitenancy/mtxs.md
+++ b/guides/multitenancy/mtxs.md
@@ -1,11 +1,11 @@
 ---
-synopsis: >
+description: >
   API reference for multitenancy and extensibility.
 ---
 
 # MTX Services Reference
 
-{{$frontmatter?.synopsis}}
+{{$frontmatter?.description}}
 
 <style scoped lang="scss">
   h3 code + em { color: #666; font-weight: normal; }

--- a/guides/multitenancy/mtxs.md
+++ b/guides/multitenancy/mtxs.md
@@ -1,6 +1,4 @@
 ---
-
-label: MTX Reference
 synopsis: >
   API reference for multitenancy and extensibility.
 ---

--- a/guides/multitenancy/old-mtx-apis.md
+++ b/guides/multitenancy/old-mtx-apis.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   API reference documentation for MTX Services.
 search: false
 sitemap: false
@@ -9,7 +9,7 @@ sitemap: false
 
 # Old MTX Reference
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 All APIs receive and respond with JSON payloads. Application-specific logic (for example, scope checks) can be added using [Event Handlers](#event-handlers-for-cds-mtx-apis).
 

--- a/guides/multitenancy/old-mtx-migration.md
+++ b/guides/multitenancy/old-mtx-migration.md
@@ -1,5 +1,4 @@
 ---
-shorty: MTX Migration
 synopsis: >
   Explains how to migrate from <code>@sap/cds-mtx</code> (aka Old MTX) to 'streamlined' <code>@sap/cds-mtxs</code>.
 sitemap: false

--- a/guides/multitenancy/old-mtx-migration.md
+++ b/guides/multitenancy/old-mtx-migration.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Explains how to migrate from <code>@sap/cds-mtx</code> (aka Old MTX) to 'streamlined' <code>@sap/cds-mtxs</code>.
 sitemap: false
 impl-variants: true
@@ -10,7 +10,7 @@ impl-variants: true
 Towards new multitenancy capabilities
 {.subtitle}
 
-<div v-html="$frontmatter?.synopsis" />
+<div v-html="$frontmatter?.description" />
 
 <ImplVariantsHint />
 

--- a/guides/protocols/asyncapi.md
+++ b/guides/protocols/asyncapi.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   About how to convert events in CDS models to AsyncAPI documentation.
 ---
 

--- a/guides/protocols/asyncapi.md
+++ b/guides/protocols/asyncapi.md
@@ -2,7 +2,6 @@
 shorty: AsyncAPI
 synopsis: >
   About how to convert events in CDS models to AsyncAPI documentation.
-status: released
 ---
 
 <style scoped>

--- a/guides/protocols/asyncapi.md
+++ b/guides/protocols/asyncapi.md
@@ -1,5 +1,4 @@
 ---
-shorty: AsyncAPI
 synopsis: >
   About how to convert events in CDS models to AsyncAPI documentation.
 ---

--- a/guides/protocols/core-data-apis.md
+++ b/guides/protocols/core-data-apis.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to interact with CDS-modeled data programmatically using CAP's native Core Data Service APIs for CRUD, queries, and transactions.
 ---
 

--- a/guides/protocols/core-data-apis.md
+++ b/guides/protocols/core-data-apis.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  How to interact with CDS-modeled data programmatically using CAP's native Core Data Service APIs for CRUD, queries, and transactions.
+---
+
 # CAP-Native Core Data Service APIs
 
 CAP provides native Core Data Service (CDS) APIs that allow you to interact with your data models programmatically. These APIs are designed to work seamlessly with CAP applications, enabling you to perform CRUD operations, queries, and transactions on your data entities.
@@ -9,7 +14,7 @@ CAP provides native Core Data Service (CDS) APIs that allow you to interact with
 - **Batch Operations**: Execute batch operations to improve performance when dealing with large data sets.
 ## Using CAP Core Data APIs
 To use the CAP Core Data APIs in your application, follow these general steps:
-1. **Import the CAP Module**: Ensure that you have the necessary CAP modules imported in     
+1. **Import the CAP Module**: Ensure that you have the necessary CAP modules imported in
    your application code.
 2. **Access the Service Context**: Obtain the service context to interact with your data models.
 3. **Perform Operations**: Use the provided API methods to perform CRUD operations, queries, and transactions on your entities.

--- a/guides/protocols/index.md
+++ b/guides/protocols/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Overview of the service protocols supported by CAP, such as OData, OpenAPI, AsyncAPI, and MCP, and how to use them.
 ---
 

--- a/guides/protocols/index.md
+++ b/guides/protocols/index.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  Overview of the service protocols supported by CAP, such as OData, OpenAPI, AsyncAPI, and MCP, and how to use them.
+---
+
 # Service Protocols in CAP
 
 CAP supports multiple service protocols to expose your application data and functionality. This guide provides an overview of the available protocols and how to use them in your CAP applications.

--- a/guides/protocols/mcp.md
+++ b/guides/protocols/mcp.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Expose CAP services via the Model Context Protocol for seamless AI agent integration.
 ---
 

--- a/guides/protocols/odata.md
+++ b/guides/protocols/odata.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Feature coverage and usage details for serving OData APIs from CAP services, including supported system query options.
+---
 
 <script setup>
   import { h } from 'vue'
@@ -924,7 +928,7 @@ For the following example, simply write `@UI.Hidden: (status <> 'visible')`.
 :::
 
 In case you want to have an expression as value for an OData annotation that cannot be
-written as a [CDS expression ](#expression-annotations), 
+written as a [CDS expression ](#expression-annotations),
 you can use the "edm-json inline mechanism" by providing an [EDM JSON expression](https://docs.oasis-open.org/odata/odata-csdl-json/v4.01/odata-csdl-json-v4.01.html#_Toc38466479) as defined
 in the [JSON representation of the OData Common Schema Language](https://docs.oasis-open.org/odata/odata-csdl-json/v4.01/odata-csdl-json-v4.01.html) enclosed in `{ $edmJson: { ... }}`.
 
@@ -1147,7 +1151,7 @@ This query groups the 500 most expensive books by author name and determines the
 | `average`          | average of values                |  <X/>   | <X/>  |
 | `countdistinct`    | count of distinct values         |  <X/>   | <X/>  |
 | custom method      | custom aggregation method        |  <Na/>  | <Na/> |
-| custom aggregate   | predefined custom aggregate      |  <X/>   | <X/>  | 
+| custom aggregate   | predefined custom aggregate      |  <X/>   | <X/>  |
 | `$count`           | number of instances in input set |  <X/>   | <X/>  |
 
 

--- a/guides/protocols/odata.md
+++ b/guides/protocols/odata.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 <script setup>
   import { h } from 'vue'

--- a/guides/protocols/odata.md
+++ b/guides/protocols/odata.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Feature coverage and usage details for serving OData APIs from CAP services, including supported system query options.
 ---
 

--- a/guides/protocols/openapi.md
+++ b/guides/protocols/openapi.md
@@ -1,5 +1,4 @@
 ---
-shorty: OpenAPI
 synopsis: >
   About how to publish service APIs in OpenAPI format.
 ---

--- a/guides/protocols/openapi.md
+++ b/guides/protocols/openapi.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   About how to publish service APIs in OpenAPI format.
 ---
 

--- a/guides/protocols/openapi.md
+++ b/guides/protocols/openapi.md
@@ -2,7 +2,6 @@
 shorty: OpenAPI
 synopsis: >
   About how to publish service APIs in OpenAPI format.
-status: released
 ---
 
 <style scoped>

--- a/guides/protocols/protocol-adapters.md
+++ b/guides/protocols/protocol-adapters.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Overview of CAP's built-in protocol adapters (OData, OpenAPI, AsyncAPI, CDS APIs) and how to create custom ones.
 ---
 

--- a/guides/protocols/protocol-adapters.md
+++ b/guides/protocols/protocol-adapters.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  Overview of CAP's built-in protocol adapters (OData, OpenAPI, AsyncAPI, CDS APIs) and how to create custom ones.
+---
+
 # Protocol Adapters
 
 CAP supports various protocols to expose and consume services. These protocols are implemented via protocol adapters that translate between the CAP programming model and the respective protocol.

--- a/guides/querying/index.md
+++ b/guides/querying/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Learn about CAP's intrinsic querying capabilities, which allows
   clients to request the exact data they need, and are key enablers for
   serving requests automatically.
@@ -8,7 +8,7 @@ search: false
 
 # Querying and View Building
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 [[toc]]
 

--- a/guides/querying/index.md
+++ b/guides/querying/index.md
@@ -3,7 +3,6 @@ synopsis: >
   Learn about CAP's intrinsic querying capabilities, which allows
   clients to request the exact data they need, and are key enablers for
   serving requests automatically.
-#status: released (add link in /guides/databases/index#db-agnostic-queries to this guide when released)
 search: false
 ---
 

--- a/guides/security/authentication.md
+++ b/guides/security/authentication.md
@@ -3,7 +3,6 @@
 label: Authentication
 synopsis: >
   This guide explains how to authenticate CAP services.
-status: released
 impl-variants: true
 ---
 

--- a/guides/security/authentication.md
+++ b/guides/security/authentication.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This guide explains how to authenticate CAP services.
 impl-variants: true
 ---

--- a/guides/security/authentication.md
+++ b/guides/security/authentication.md
@@ -1,5 +1,4 @@
 ---
-label: Authentication
 synopsis: >
   This guide explains how to authenticate CAP services.
 impl-variants: true

--- a/guides/security/authentication.md
+++ b/guides/security/authentication.md
@@ -1,5 +1,4 @@
 ---
-# layout: cookbook
 label: Authentication
 synopsis: >
   This guide explains how to authenticate CAP services.

--- a/guides/security/authorization.md
+++ b/guides/security/authorization.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This guide explains how to restrict access to data by adding respective declarations to CDS models, which are then enforced by CAP's generic service providers.
 uacp: Used as link target from SAP Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html
 impl-variants: true
@@ -30,7 +30,7 @@ This guide explains how to restrict access to data by adding respective declarat
 ## Declarative Access Control { #restrictions}
 
 In essence, [authentication](./authentication#authentication) verifies the user's identity and the presented claims. Briefly, authentication reveals _who_ is using the service.
-In contrast, **authorization controls _how_ the user may interact with the application's resources**. 
+In contrast, **authorization controls _how_ the user may interact with the application's resources**.
 As access control depends on user information, authentication is a prerequisite for authorization.
 
 ![Authorization with CAP](./assets/authorization.drawio.svg){width="450px"}
@@ -56,7 +56,7 @@ Finally, according to the key concept [Customizable Security](./overview#key-con
 
 ### Internal Services
 
-CDS services that are only meant for *internal* usage shouldn't be exposed via protocol adapters. 
+CDS services that are only meant for *internal* usage shouldn't be exposed via protocol adapters.
 To prevent access from *any* external clients, annotate those services with `@protocol: 'none'`:
 
 ```cds
@@ -149,7 +149,7 @@ CodeLists such as `Languages`, `Currencies`, and `Countries` from `sap.common` a
 
 ## Role-Based Access Control { #role-based-access-control }
 
-To protect resources according to your business needs, you can declaratively restrict access according to a [CAP role](./cap-users#roles) by adding [@requires](#requires) or [@restrict](#restrict-annotation) annotations. 
+To protect resources according to your business needs, you can declaratively restrict access according to a [CAP role](./cap-users#roles) by adding [@requires](#requires) or [@restrict](#restrict-annotation) annotations.
 
 Restrictions can be defined on *different CDS resources*:
 
@@ -157,9 +157,9 @@ Restrictions can be defined on *different CDS resources*:
 - Entities
 - (Un)bound actions and functions
 
-You can influence the scope of a restriction by choosing an adequate hierarchy level in the CDS model. 
-For instance, a restriction on the service level applies to all entities in the service. 
-Additional restrictions on entities or actions can further limit authorized requests. 
+You can influence the scope of a restriction by choosing an adequate hierarchy level in the CDS model.
+For instance, a restriction on the service level applies to all entities in the service.
+Additional restrictions on entities or actions can further limit authorized requests.
 See [combined restrictions](#combined-restrictions) for more details.
 
 Beside the scope, restrictions can limit access to resources with regards to *different dimensions*:
@@ -409,8 +409,8 @@ So, the authorization for the requests in the example is delegated as follows:
 
 ## Instance-Based Access Control { #instance-based-auth }
 
-The [restrict annotation](#restrict-annotation) for an entity allows you to enforce authorization checks that statically depend on the event type and user roles. 
-In addition, you can define a `where`-condition that further limits the set of accessible instances. 
+The [restrict annotation](#restrict-annotation) for an entity allows you to enforce authorization checks that statically depend on the event type and user roles.
+In addition, you can define a `where`-condition that further limits the set of accessible instances.
 This condition, that acts like a filter, establishes *instance-based authorization*.
 
 ### Filter Conditions
@@ -433,8 +433,8 @@ annotate Articles with @(restrict: [
 Filter conditions declared as **compiler expressions** ensure validity at compile time and therefore strengthen security.
 :::
 
-The condition defined in the `where` clause typically associates domain data with static [user claims](cap-users#claims). 
-Basically, it *either filters the result set in queries or accepts only write operations on instances that meet the condition*. 
+The condition defined in the `where` clause typically associates domain data with static [user claims](cap-users#claims).
+Basically, it *either filters the result set in queries or accepts only write operations on instances that meet the condition*.
 This means that, the condition applies to following standard CDS events only:
 - `READ` (as result filter)
 - `UPDATE` (as reject condition)
@@ -653,8 +653,8 @@ It can be disabled by setting <Config java>cds.security.authorization.instance-b
 
 ## Limitations {.node}
 
-Currently, the security annotations **are only evaluated on the target entity of the request**. 
-Restrictions on associated entities touched by the operation are not regarded. 
+Currently, the security annotations **are only evaluated on the target entity of the request**.
+Restrictions on associated entities touched by the operation are not regarded.
 This has the following implications:
 - Restrictions of (recursively) expanded or inlined entities of a `READ` request aren't checked.
 - Deep inserts and updates are checked on the root entity only.
@@ -698,7 +698,7 @@ Select.from(Orders_.class,
 ```
 
 For modification statements with associated entities used in infix filters or where clauses,
-role-based authorizations are checked as well. 
+role-based authorizations are checked as well.
 Associated entities require `READ` authorization, in contrast to the target of the statement itself.
 
 The following statement requires `UPDATE` authorization on `Orders` and `READ` authorization on `Books`

--- a/guides/security/cap-users.md
+++ b/guides/security/cap-users.md
@@ -3,7 +3,6 @@
 label: CAP Users
 synopsis: >
   This guide introduces CAP user abstraction and role assignments.
-status: released
 impl-variants: true
 ---
 

--- a/guides/security/cap-users.md
+++ b/guides/security/cap-users.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This guide introduces CAP user abstraction and role assignments.
 impl-variants: true
 ---

--- a/guides/security/cap-users.md
+++ b/guides/security/cap-users.md
@@ -1,5 +1,4 @@
 ---
-# layout: cookbook
 label: CAP Users
 synopsis: >
   This guide introduces CAP user abstraction and role assignments.

--- a/guides/security/cap-users.md
+++ b/guides/security/cap-users.md
@@ -1,5 +1,4 @@
 ---
-label: CAP Users
 synopsis: >
   This guide introduces CAP user abstraction and role assignments.
 impl-variants: true
@@ -60,7 +59,7 @@ The user information is reflected in `req.user` and `req.tenant` [attached to th
 
 CAP users can be classified in multiple dimensions:
 
-**Business users vs. technical users:** 
+**Business users vs. technical users:**
 - Business users represent identifiable end users who log in to interact with the system.
 - Technical users operate on behalf of an entire tenant at a technical API level.
 
@@ -79,7 +78,7 @@ There are technical users for the provider and for all subscribers.
 | Multitenant Application | Business users | Technical user
 |---------------------------|----------------|----------------
 | Provider Tenant           |       -        | <Y/>
-| Subscriber Tenants        |      <Y/>      | <Y/> 
+| Subscriber Tenants        |      <Y/>      | <Y/>
 
 In contrast, for a single-tenant application, the provider tenant coincides with the only subscriber tenant and therefore contains all business users.
 
@@ -108,7 +107,7 @@ CAP roles, which are defined on CDS resources such as services and entities, dow
 Technically, the request user is restricted to the resources for which an appropriate CAP role is assigned.
 **Such roles should reflect basic operations performed by users interacting with the application**.
 
-In the following example, there are two different basic operations defined on domain level: 
+In the following example, there are two different basic operations defined on domain level:
 - `ReportIssues` describes users who view existing issues, report new issues and confirm provided solutions.
 - `ProcessIssues` describes users who process issues. They also write notes for customers.
 
@@ -127,7 +126,7 @@ annotate Notes with @(restrict: [
 CAP roles represent basic building blocks of authorization rules that are defined by application developers _at design time_.
 Independently of that, user administrators combine CAP roles in higher-level policies and assign them to business users in the platform's central authorization management solution _at runtime_.
 
-Dynamic assignments of roles to users can be done by 
+Dynamic assignments of roles to users can be done by
 - [AMS roles](#roles-assignment-ams) for [IAS authentication](./authentication#ias-auth).
 - [XSUAA roles](#xsuaa-roles) for [XSUAA authentication](./authentication#xsuaa-auth).
 
@@ -137,9 +136,9 @@ CDS-based authorization deliberately avoids technical concepts, such as _scopes_
 
 
 #### Pseudo Roles { #pseudo-roles}
- 
+
 Often it is useful to define access rules that aren't based on an application-specific user role, but rather on the _technical authentication level_ of the request that can be mapped to a pre-defined CAP role.
-For instance, a service should be accessible only for technical users, with or without user propagation. 
+For instance, a service should be accessible only for technical users, with or without user propagation.
 Such roles are called pseudo roles as they aren't assigned by user administrators, but are added by the runtime automatically on successful authentication, reflecting the technical level:
 
 <div class="impl java">
@@ -164,11 +163,11 @@ Such roles are called pseudo roles as they aren't assigned by user administrator
 
 </div>
 
-The pseudo-role `system-user` allows you to separate access by business users from _technical_ clients. 
+The pseudo-role `system-user` allows you to separate access by business users from _technical_ clients.
 Note that this role does not distinguish between any technical clients sending requests to the API.
 
-Pseudo-role `internal-user` allows to define application endpoints that can be accessed exclusively by the own provider tenant on technical level. 
-In contrast to `system-user`, the endpoints protected by this pseudo-role do not allow requests from any external technical clients. 
+Pseudo-role `internal-user` allows to define application endpoints that can be accessed exclusively by the own provider tenant on technical level.
+In contrast to `system-user`, the endpoints protected by this pseudo-role do not allow requests from any external technical clients.
 Hence it is suitable for **technical intra-application communication**, see [Security > Application Zone](./overview#application-zone).
 
 ::: warning
@@ -212,7 +211,7 @@ This will result in trace output like
 Resolved MockedUserInfo [id='mock/admin', name='admin', roles='[admin]', attributes='{tenant=[null]}'
 ```
 
-for mock users or 
+for mock users or
 
 ```sh
 c.s.c.f.i.IdentityUserInfoProvider : Resolved XsuaaUserInfo [id='be72646e-279a-4f96-ae40-05989a46b43b', name='max.muster@sap.com', roles='[openid, admin]', attributes='
@@ -360,8 +359,8 @@ If required, it also runs the new `cds add ias` command to configure the project
 
 :::
 
-These libraries integrate into the CAP framework to handle incoming requests. 
-Based on the user's assigned [policies](#policies), the user's roles are determined and written to the [UserInfo](#reflection) object. 
+These libraries integrate into the CAP framework to handle incoming requests.
+Based on the user's assigned [policies](#policies), the user's roles are determined and written to the [UserInfo](#reflection) object.
 The framework then authorizes the request as usual based on the user's roles.
 
 ::: details Node.js plugin `@sap/ams` added to the project
@@ -383,11 +382,11 @@ The `@sap/ams` plugin provides multiple build-time features:
 - Generate a deployer application during the build to upload the Data Control Language (DCL) base policies.
 
 
-AM provides highly flexible APIs to define and enforce authorization rules at runtime. 
+AM provides highly flexible APIs to define and enforce authorization rules at runtime.
 A relevant subset of these APIs is consumed by CAP apps by way of the AMS CAP integration plugin.
 
 ::: warning
-Make sure not to mix native AMS APIs with those provided by the CAP plugin. 
+Make sure not to mix native AMS APIs with those provided by the CAP plugin.
 :::
 
 ### Adding AMS Support { .node }
@@ -417,8 +416,8 @@ If required, it also runs the new `cds add ias` command to configure the project
 ```
 :::
 
-`@sap/ams` integrates into the CAP framework to handle incoming requests. 
-Based on the user's assigned [policies](#policies), the user's roles are determined to decorate the [user.is](/node.js/authentication#user-is) function with additional roles. 
+`@sap/ams` integrates into the CAP framework to handle incoming requests.
+Based on the user's assigned [policies](#policies), the user's roles are determined to decorate the [user.is](/node.js/authentication#user-is) function with additional roles.
 The framework then authorizes the request as usual based on the user's roles.
 
 For local development, `@sap/ams-dev` needs to compile the DCL files to Data Control Notation (DCN) files in `gen/dcn` which is the machine-readable version of DCL that is required by AMS at runtime.
@@ -430,7 +429,7 @@ Additionally, `@sap/ams` provides multiple build-time features:
 - Generate a deployer application during the build to upload the Data Control Language (DCL) base policies.
 
 ::: tip
-In general, AMS provides highly flexible APIs to define and enforce authorization rules at runtime suitable for native Cloud applications. 
+In general, AMS provides highly flexible APIs to define and enforce authorization rules at runtime suitable for native Cloud applications.
 **In the context of CAP projects, only a limited subset of these APIs is relevant and is offered in a streamlined way via the CAP integration plugins**.
 :::
 
@@ -454,8 +453,8 @@ In contrast, an AMS policy reflects a coarser-grained **business role on applica
 :::
 
 Imagine you want to provide two different CAP roles in the bookshop example:
-`ManageAuthors` allows users to manage the authors of the books being sold. 
-Users with `ManageBooks` work only with the book inventory. 
+`ManageAuthors` allows users to manage the authors of the books being sold.
+Users with `ManageBooks` work only with the book inventory.
 As each book has an association to an author, they can only manage books from authors that have already been created before:
 
 ```cds
@@ -487,7 +486,7 @@ You can simply reuse existing CAP roles for AMS. There is no need to modify the 
 Attributes for AMS offer user administrators an additional layer of flexibility to partition domain entities into smaller, more manageable units for access control.
 The domain attributes, which are exposed to user administrators for defining custom filter conditions, must be predefined by the application developer in the CDS model using the `@ams` annotation.
 
-For example, the instances of entity `Books` can be classified by the associated genre. 
+For example, the instances of entity `Books` can be classified by the associated genre.
 Hence, `genre.name` appears to be a suitable  AMS attribute value, exposed under the name `Genre`:
 
 ```cds
@@ -520,7 +519,7 @@ entity Books : withGenre { ... }
 ### Prepare Base Policies { #policies }
 
 CAP roles and attribute filters cannot be directly assigned to business users.
-Instead, the application defines AMS base policies that include CAP roles and attributes at design time. 
+Instead, the application defines AMS base policies that include CAP roles and attributes at design time.
 This allows user administrators to assign them to users or create custom policies based on the base policies at runtime.
 
 :::tip
@@ -855,7 +854,7 @@ In addition, `@sap/ams` needs to be referenced to add the deployer logic.
 </div>
 
 ::: tip
-Several microservices sharing the same IAS instance need a common folder structure the deployer task operates on. 
+Several microservices sharing the same IAS instance need a common folder structure the deployer task operates on.
 It contains the common view of policies applied to all services.
 :::
 
@@ -931,7 +930,7 @@ c.s.c.s.a.c.AmsRuntimeConfiguration      : Configured AmsUserInfoProvider
 
 </div>
 
-In addition, for detailed analysis of issues, you can set AMS logger to `DEBUG` level: 
+In addition, for detailed analysis of issues, you can set AMS logger to `DEBUG` level:
 
 <div class="impl java">
 
@@ -1007,13 +1006,13 @@ It might be useful to investigate the injected filter conditions by activating t
 
 ## Role Assignment with XSUAA { #xsuaa-roles }
 
-Information about roles and attributes can be made available to the XSUAA platform service. 
-This information enables the respective JWT tokens to be constructed and sent with the requests for authenticated users. 
+Information about roles and attributes can be made available to the XSUAA platform service.
+This information enables the respective JWT tokens to be constructed and sent with the requests for authenticated users.
 
 In particular, the following happens automatically behind-the-scenes upon build:
 
 
-### Generate Security Descriptor 
+### Generate Security Descriptor
 
 Derive scopes, attributes, and role templates from the CDS model:
 
@@ -1109,7 +1108,7 @@ Inline configuration in the _mta.yaml_ `config` block and the _xs-security.json_
 
 This is a manual step a user administrator would do in SAP BTP Cockpit to setup and assign roles for the application:
 
-By creating a service instance of the `xsuaa` service, all the roles from the _xs-security.json_ file are already added to your subaccount. 
+By creating a service instance of the `xsuaa` service, all the roles from the _xs-security.json_ file are already added to your subaccount.
 Next, you create a role collection that assigns these roles to your users.
 
 1. Open the SAP BTP Cockpit.
@@ -1128,7 +1127,7 @@ Next, you create a role collection that assigns these roles to your users.
 8. Choose *Save*
 
 
-If a user attribute isn't set for a user in the identity provider of the SAP BTP Cockpit, this means that the user has no restriction for this attribute. 
+If a user attribute isn't set for a user in the identity provider of the SAP BTP Cockpit, this means that the user has no restriction for this attribute.
 For example, if a user has no value set for an attribute "Country", they're allowed to see data records for all countries.
 In the _xs-security.json_, the `attribute` entity has a property `valueRequired` where you as the developer can specify whether unrestricted access is possible by not assigning a value to the attribute.
 
@@ -1136,12 +1135,12 @@ In the _xs-security.json_, the `attribute` entity has a property `valueRequired`
 
 ## Developing with CAP Users { #developing-with-users }
 
-CAP is not tied to any specific authentication method, nor to concrete user information such as that provided by IAS or XSUAA. 
+CAP is not tied to any specific authentication method, nor to concrete user information such as that provided by IAS or XSUAA.
 Instead, an abstract [user representation](cap-users#claims) is attached to the request which can be used to influence request processing.
 For example, both authorization enforcement and domain logic can depend on properties of the the current user.
 
 ::: warning
-Avoid writing custom code against the raw authentication information such as dedicated XSUAA properties. 
+Avoid writing custom code against the raw authentication information such as dedicated XSUAA properties.
 This undermines the decoupling between authentication strategy and your business logic.
 :::
 
@@ -1210,8 +1209,8 @@ In addition, there are getters to retrieve information about [pseudo-roles](#pse
 
 <div class="impl node">
 
-In CAP Node.js, the CAP user of a request is represented by a [`cds.User`](../../node.js/authentication#cds-user) object. 
-An instance of `cds.User` representing the current principal is available from the current request context in `req.user`. 
+In CAP Node.js, the CAP user of a request is represented by a [`cds.User`](../../node.js/authentication#cds-user) object.
+An instance of `cds.User` representing the current principal is available from the current request context in `req.user`.
 Similarly, the identifier of the user's tenant is available from `req.tenant`.
 
 ```js
@@ -1221,7 +1220,7 @@ srv.before('READ', srv.entities.Books, req => {
 })
 ```
 
-In addition to the request context, information about the current user can similarly be retrieved from the global [`cds.context`](../../node.js/events#cds-context), which provides access to the current [`cds.EventContext`](../../node.js/events#cds-event-context): 
+In addition to the request context, information about the current user can similarly be retrieved from the global [`cds.context`](../../node.js/events#cds-context), which provides access to the current [`cds.EventContext`](../../node.js/events#cds-event-context):
 
 ```js
 const cds = require('@sap/cds')
@@ -1253,7 +1252,7 @@ Depending on the configured [authentication](./authentication) strategy, CAP der
 
 <div class="impl java">
 
-In most cases, CAP's default mapping to the CAP user matches your requirements, but CAP also allows you to customize the mapping according to specific needs. 
+In most cases, CAP's default mapping to the CAP user matches your requirements, but CAP also allows you to customize the mapping according to specific needs.
 
 For instance, the logon name as injected by standard XSUAA integration might not be unique if several customer identity providers are connected to the underlying identity service.
 Here a combination of `user_name` and `origin` mapped to `$user` might be a feasible solution that you can implement in a custom adaptation.
@@ -1297,11 +1296,11 @@ public class UniqeNameUserInfoProvider implements UserInfoProvider {
 :::
 
 In the example, the `UniqeNameUserInfoProvider` defines an overlay on the default XSUAA-based provider (`defaultProvider`) by leveraging chaining technique (`@Order(1)` ensures proper ordering).
-`UserInfo.copy()` returns [`ModifiableUserInfo`](https://www.javadoc.io/doc/com.sap.cds/cds-services-api/latest/com/sap/cds/services/request/ModifiableUserInfo.html) interface which allows arbitrary modifications such as 
+`UserInfo.copy()` returns [`ModifiableUserInfo`](https://www.javadoc.io/doc/com.sap.cds/cds-services-api/latest/com/sap/cds/services/request/ModifiableUserInfo.html) interface which allows arbitrary modifications such as
 overriding the user's name by a combination of email and origin.
 
 ::: warning Be very careful when redefining `$user`
-The user name is frequently stored with business data (for example, `managed` aspect) and might introduce migration efforts. 
+The user name is frequently stored with business data (for example, `managed` aspect) and might introduce migration efforts.
 Also consider data protection and privacy regulations when storing user data.
 :::
 
@@ -1317,13 +1316,13 @@ There are multiple reasonable use cases in which user modification is a suitable
 
 <div class="impl node">
 
-In most cases, CAP's default mapping to the CAP user will match your requirements, but CAP also allows you to customize the mapping according to specific needs. 
+In most cases, CAP's default mapping to the CAP user will match your requirements, but CAP also allows you to customize the mapping according to specific needs.
 
 For instance, the logon name as injected by standard XSUAA integration might not be unique if several customer IdPs are connected to the underlying identity service.
 Here a combination of `user_name` and `origin` mapped to `$user` might be a feasible solution that you can implement in a custom adaptation.
 
-This can be done by modifying `cds.middlewares`. 
-To modify the `cds.context.user` while still relying on existing generic middlewares, a new middleware must be registered after the `auth` middleware. 
+This can be done by modifying `cds.middlewares`.
+To modify the `cds.context.user` while still relying on existing generic middlewares, a new middleware must be registered after the `auth` middleware.
 If you intend to manipulate the `cds.context.tenant` as well, the new middleware must run before `cds.context.model` is set for the current request.
 
 ::: details Sample implementation to override the user id
@@ -1350,7 +1349,7 @@ There are multiple reasonable use cases in which user modification is a suitable
 - Overriding user attributes and providing calculated attributes used for [instance-based authorization](./authorization#user-attrs) by invoking `user.attr(attributes)`.
 
 ::: warning Be very careful when redefining `$user` and customizing `cds.middlewares`
-The user name is frequently stored with business data (for example, `managed` aspect) and might introduce migration efforts. 
+The user name is frequently stored with business data (for example, `managed` aspect) and might introduce migration efforts.
 Also consider data protection and privacy regulations when storing user data.
 :::
 
@@ -1361,7 +1360,7 @@ In case you require even more control, it is possible to replace the authenticat
 </div>
 
 ### Switching Users { #switching-users }
-	
+
 <div class="impl java">
 
 There are a few typical use cases in a (multitenant) application where switching the current user of the request is required.
@@ -1426,8 +1425,8 @@ When creating new root transactions in calls to [`cds/srv.tx()`](../../node.js/c
 
 ![The graphic is explained in the accompanying text.](./assets/nameduser.drawio.svg){width="330px"}
 
-The incoming JWT token triggers the creation of an initial Request Context with a named user. 
-Accesses to the database in the OData Adapter as well as the custom `On` handler are executed within <i>tenant1</i> and authorization checks are performed for user <i>JohnDoe</i>. 
+The incoming JWT token triggers the creation of an initial Request Context with a named user.
+Accesses to the database in the OData Adapter as well as the custom `On` handler are executed within <i>tenant1</i> and authorization checks are performed for user <i>JohnDoe</i>.
 An additionally defined `After` handler wants to call out to an external service using a technical user without propagating the named user <i>JohnDoe</i>.
 To achieve this, it's required to call `requestContext()` on the current `CdsRuntime` and use the `systemUser()` method to remove the named user from the new Request Context:
 
@@ -1446,8 +1445,8 @@ public void afterHandler(EventContext context){
 
 ![The graphic is explained in the accompanying text.](./assets/nameduser-node.drawio.svg){width="330px"}
 
-The incoming JWT token triggers the creation of an initial `cds.EventContext` with a named user. 
-Accesses to the database in the OData Adapter as well as the custom `.on` handler are executed within _tenant1_ and authorization checks are performed for user _JohnDoe_. 
+The incoming JWT token triggers the creation of an initial `cds.EventContext` with a named user.
+Accesses to the database in the OData Adapter as well as the custom `.on` handler are executed within _tenant1_ and authorization checks are performed for user _JohnDoe_.
 
 In addition, there is an `.after` handler that wants to call out to an external service using a technical user without propagating the named user _JohnDoe_.
 To achieve this, you can create a new root transaction using `srv.tx` and use it to connect to the external service from within a new context:
@@ -1468,9 +1467,9 @@ srv.after('*', srv.entities.Books, async (res, req) => {
 
 ![The graphic is explained in the accompanying text.](./assets/switchprovidertenant.drawio.svg){width="500px"}
 
-The application offers a bound action in a CDS entity. Within the action, the application communicates with a remote CAP service using an internal technical user from the provider account. 
-The corresponding `on` handler of the action needs to create a new Request Context by calling `requestContext()`. 
-Using the `systemUserProvider()` method, the existing user information is removed and the tenant is automatically set to the provider tenant. 
+The application offers a bound action in a CDS entity. Within the action, the application communicates with a remote CAP service using an internal technical user from the provider account.
+The corresponding `on` handler of the action needs to create a new Request Context by calling `requestContext()`.
+Using the `systemUserProvider()` method, the existing user information is removed and the tenant is automatically set to the provider tenant.
 This allows the application to perform an HTTP call to the remote CAP service, which is secured using the pseudo-role `internal-user`.
 
 ```java
@@ -1488,8 +1487,8 @@ public void onAction(AddToOrderContext context){
 
 ![The graphic is explained in the accompanying text.](./assets/switchprovidertenant-node.drawio.svg){width="500px"}
 
-In this scenario the application offers a bound action in a CDS entity. 
-Within the action, the application communicates with a remote CAP service using a privileged user and the provider tenant. 
+In this scenario the application offers a bound action in a CDS entity.
+Within the action, the application communicates with a remote CAP service using a privileged user and the provider tenant.
 The corresponding `.on` handler of the action needs to create a new root transaction by calling `srv.tx`.
 The user passed to `srv.tx` in the `ctx` attribute will be used as the principal for requests made within the new root transaction.
 
@@ -1510,9 +1509,9 @@ srv.on('action', srv.entities.Books, async req => {
 
 ![The graphic is explained in the accompanying text.](./assets/switchtenant.drawio.svg){width="450px"}
 
-The application is using a job scheduler that needs to regularly perform tasks on behalf of a certain tenant. 
-By default, background executions (for example in a dedicated thread pool) aren't associated to any subscriber tenant and user. 
-In this case, it's necessary to explicitly define a new Request Context based on the subscribed tenant by calling `systemUser(tenantId)`. 
+The application is using a job scheduler that needs to regularly perform tasks on behalf of a certain tenant.
+By default, background executions (for example in a dedicated thread pool) aren't associated to any subscriber tenant and user.
+In this case, it's necessary to explicitly define a new Request Context based on the subscribed tenant by calling `systemUser(tenantId)`.
 This ensures that the Persistence Service performs the query for the specified tenant.
 
 ```java
@@ -1535,7 +1534,7 @@ Instead, prefer a task-based approach which processes specific subscriber tenant
 
 The application is using [`cds.spawn`](../../node.js/cds-tx#cds-spawn) to regularly perform tasks on behalf of a certain tenant.
 By default, operations that are nested within `cds.spawn` will inherit the outer context.
-You can explicitly define the context `cds.spawn` should use by passing relevant information in a `ctx` argument. 
+You can explicitly define the context `cds.spawn` should use by passing relevant information in a `ctx` argument.
 This enables to ensure that the Persistence Service performs the query for the specified tenant.
 
 ```js
@@ -1576,7 +1575,7 @@ Call application services on behalf of the privileged user only in case the serv
 
 <div class="impl java">
 
-In rare situations you might want to call a public service without sharing information of the current request user. 
+In rare situations you might want to call a public service without sharing information of the current request user.
 In this case, you explicitly prevent user propagation.
 
 Such service calls can be executed on behalf of the anonymous user, acting as a public user without personal user claims:
@@ -1591,7 +1590,7 @@ cdsRuntime.requestContext().anonymousUser().run(privilegedContext -> {
 
 <div class="impl node">
 
-In rare situations you might want to call a public service without sharing information about the current request user. 
+In rare situations you might want to call a public service without sharing information about the current request user.
 In this case, you can explicitly prevent user propagation by running in a context whose principal is the `anonymous` user.
 
 ```js
@@ -1634,7 +1633,7 @@ String jwtToken = jwtTokenInfo.getToken();
 
 CAPs generic authentication middlewares for IAS and XSUAA maintain resolved authentication information in the `authInfo` attribute of `cds.context.user`.
 For `@sap/xssec`-based authentication strategies (`ias`, `jwt`, and `xsuaa`), `cds.context.user.authInfo` is an instance of `@sap/xssec`'s [`SecurityContext`](https://www.npmjs.com/package/@sap/xssec#securitycontext).
-You can retrieve available authentication information for use in a non-CAP library from the `SecurityContext`. 
+You can retrieve available authentication information for use in a non-CAP library from the `SecurityContext`.
 
 ```js
 const authInfo = cds.context.user.authInfo  // @sap/xssec SecurityContext
@@ -1643,8 +1642,8 @@ const jwtToken = token.jwt                  // string
 ```
 
 ::: warning
-The `cds.User.authInfo` property depends on the authentication library that you use. 
-CAP does not guarantee the content of this property. Use it with caution. 
+The `cds.User.authInfo` property depends on the authentication library that you use.
+CAP does not guarantee the content of this property. Use it with caution.
 Always pin your dependencies as described in the [best practices](../../node.js/best-practices#deploy).
 :::
 
@@ -1654,9 +1653,9 @@ Always pin your dependencies as described in the [best practices](../../node.js/
 
 <div class="impl java">
 
-Remote APIs can be invoked either on behalf of a named user or a technical user, depending on the callee's specification.  
-Thus, a client executing a business request within a specific user context might need to explicitly adjust the user propagation strategy.  
-CAP's [Remote Services](../services/consuming-services) offer an easy and declarative way to define client-side representations of remote service APIs.  
+Remote APIs can be invoked either on behalf of a named user or a technical user, depending on the callee's specification.
+Thus, a client executing a business request within a specific user context might need to explicitly adjust the user propagation strategy.
+CAP's [Remote Services](../services/consuming-services) offer an easy and declarative way to define client-side representations of remote service APIs.
 Such services integrate seamlessly with CAP, managing connection setup, including [authentication and user propagation](../../java/cqn-services/remote-services#configuring-the-authentication-strategy):
 
 ```yaml
@@ -1684,9 +1683,9 @@ Remote Services configurations with `destination` section support `onBehalfOf` o
 
 <div class="impl node">
 
-CAP's [Remote Services](../services/consuming-services) offer an easy and declarative way to define client-side representations of remote service APIs.  
+CAP's [Remote Services](../services/consuming-services) offer an easy and declarative way to define client-side representations of remote service APIs.
 Such services integrate seamlessly with CAP, managing connection setup, including authentication and user propagation.
-Under the hood CAP utilizes the [BTP Destinations](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/create-destinations-from-scratch) and [`@sap-cloud-sdk/connectivity`](https://www.npmjs.com/package/@sap-cloud-sdk/connectivity) to do most of the heavy lifting. 
+Under the hood CAP utilizes the [BTP Destinations](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/create-destinations-from-scratch) and [`@sap-cloud-sdk/connectivity`](https://www.npmjs.com/package/@sap-cloud-sdk/connectivity) to do most of the heavy lifting.
 
 ```json
 {
@@ -1719,7 +1718,7 @@ Always prefer using [Remote Services](#remote-services) over natively consuming 
 
 
 On a programmatic level, the CAP runtime integrates with [Cloud SDK](https://sap.github.io/cloud-sdk/) offering an abstraction for connection setup with remote services, including authentication and user propagation.
-By default, 
+By default,
 - the *tenant* of the current Request Context is propagated under the hood.
 - the *user token* is propagated via Spring's [`SecurityContext`](#user-token).
 - *user propagation strategy* can be specified with parameter values [`OnBehalfOf`](https://sap.github.io/cloud-sdk/docs/java/features/connectivity/service-bindings#multitenancy-and-principal-propagation).
@@ -1734,22 +1733,22 @@ Prefer using [Remote Services](#remote-services) built on Cloud SDK rather than 
 
 ## Pitfalls
 
-- **Don't write custom code against user types of an identity service (XSUAA / IAS)**. 
-  
+- **Don't write custom code against user types of an identity service (XSUAA / IAS)**.
+
   Instead, if it is required at all to code against user types, use CAP's user abstraction layer (`UserInfo` in Java or `req.user` in Node.js) to handle user-related logic.
 
 - **Don't try to propagate named user context in asynchronous requests**.
-  
+
   This can happen when using the Outbox pattern or Messaging. Asynchronous tasks are typically executed outside the scope of the original request context, after successful authorization. Propagating the named user context can lead to inconsistencies or security issues. Instead, use technical users for such scenarios.
 
-- **Don't mix CAP Roles for business and technical users**. 
-  
+- **Don't mix CAP Roles for business and technical users**.
+
   CAP roles should be clearly separated based on their purpose: Business user roles are designed to reflect how end users interact with the application. Technical user roles are intended for system-level operations, such as background tasks or service-to-service communication. Mixing these roles can lead to confusion and unintended access control issues.
 
 - **Don't mix AMS Policy level with CAP Role level**.
-  
+
   AMS policies operate at the business level, while CAP roles are defined at the technical domain level. Avoid mixing these two layers, as this could undermine the clarity and maintainability of your authorization model.
 
 - **Don't choose entity attributes as AMS Attributes whose relevance is too small**.
-  
+
   Such attributes should have a broad, domain-wide relevance and be applicable across multiple entities. Typically, only a limited number of attributes (less than 10) meet this criterion. Exposing entity-specific attributes as AMS attributes can lead to unnecessary complexity and reduced reusability.

--- a/guides/security/data-privacy.md
+++ b/guides/security/data-privacy.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
     This guide discusses how CAP helps applications to comply with data privacy regulations imposed by various laws and standards.
-status: released
 ---
 
 

--- a/guides/security/data-privacy.md
+++ b/guides/security/data-privacy.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
     This guide discusses how CAP helps applications to comply with data privacy regulations imposed by various laws and standards.
 ---
 
@@ -7,7 +7,7 @@ synopsis: >
 
 # Data Privacy Overview
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ::: warning
 SAP does not give any advice on whether the features and functions provided to facilitate meeting data privacy obligations are the best method to support company, industry, regional, or country/region-specific requirements. Furthermore, this information should not be taken as advice or a recommendation regarding additional features that would be required in specific IT environments. Decisions related to data protection must be made on a case-by-case basis, considering the given system landscape and the applicable legal requirements.
@@ -94,17 +94,17 @@ The [SAP Data Retention Manager](https://help.sap.com/docs/data-retention-manage
 
 CAP doesn't store or manage any personal data on its own with some exceptions, which are mandatory to operate the applications properly:
 
-- Log outputs on verbose level might contain personal data such as user names and IP addresses. 
+- Log outputs on verbose level might contain personal data such as user names and IP addresses.
 Connect an adequate logging service to meet compliance requirements such as [SAP Application Logging Service](https://help.sap.com/docs/application-logging-service/sap-application-logging-service/sap-application-logging-service-for-cloud-foundry-environment).
 
 - Draft-enabled entities store user information for the time periods when drafts are created or modified.
 
 - When using the [managed](../domain/index#managed-data) aspect, you decided to store metadata such as who created or modified an entity instance.
 
-- Messages temporarily written to transaction outbox might contain personal data. 
+- Messages temporarily written to transaction outbox might contain personal data.
 If necessary, applications can process these messages by standard CAP functionality (CDS model `@sap/cds/srv/outbox`).
 
-Also refer to related guides of most important platform services: 
+Also refer to related guides of most important platform services:
 
 [SAP Cloud Identity Services - Configuring Privacy Policies](https://help.sap.com/docs/IDENTITY_AUTHENTICATION/6d6d63354d1242d185ab4830fc04feb1/ed48466d770f4519aa23bba754851fbd.html){.learn-more}
 [SAP HANA Cloud - Data Protection and Privacy](https://help.sap.com/docs/HANA_CLOUD_DATABASE/c82f8d6a84c147f8b78bf6416dae7290/ad9588189e844092910103f2f7b1c968.html){.learn-more}

--- a/guides/security/data-protection.md
+++ b/guides/security/data-protection.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   CAP provides several features to ensure data protection that meet industry standards and regulatory requirements.
 uacp: Used as link target from SAP Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 impl-variants: true
@@ -7,7 +7,7 @@ impl-variants: true
 
 # Product Security Overview
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 <ImplVariantsHint />
 
@@ -527,16 +527,16 @@ The total number of request of OData batches can be limited by application confi
 
 <div class="impl java">
 
-To limit the _amount of queries_ per OData `$batch`, use <Config java>cds.odataV4.batch.maxRequests</Config> or. <Config java>cds.odataV2.batch.maxRequests</Config> 
+To limit the _amount of queries_ per OData `$batch`, use <Config java>cds.odataV4.batch.maxRequests</Config> or. <Config java>cds.odataV2.batch.maxRequests</Config>
 
-To prevent clients from _requesting too much data_, you can define restrictions on `$expands` for your entities: 
+To prevent clients from _requesting too much data_, you can define restrictions on `$expands` for your entities:
 
 - Prevent any expands from the entity:
-  - `@Capabilities.ExpandRestrictions.Expandable: false` 
+  - `@Capabilities.ExpandRestrictions.Expandable: false`
 - Restrict expands for certain properties:
-  - `@Capabilities.ExpandRestrictions.NonExpandableProperties: [...]` 
+  - `@Capabilities.ExpandRestrictions.NonExpandableProperties: [...]`
 - Set maximum allowed depth of an `$expand` from this entity:
-  - `@Capabilities.ExpandRestrictions.MaxLevels: ...`  
+  - `@Capabilities.ExpandRestrictions.MaxLevels: ...`
   - Or you can set an **application-wide limit** with <Config java>cds.query.restrictions.expand.maxLevels = \<max depth\></Config> that applies to all entities. Value `-1` indicates absence of limit.
 
 :::warning
@@ -692,14 +692,14 @@ For instance, this is true for [authorizations](#secure-authorization) or applic
 It's recommended to ensure security settings by automated integration tests.
 :::
 
-CAP provides some features that are suitable for development only such as 
+CAP provides some features that are suitable for development only such as
 - Index Page
 - Mock Users
 - Developer Dashboard (Java only)
 
 These features are deactivated in the production profile by default.
 
-::: warning 
+::: warning
 **Do not manually enable features for production that are disabled by the production profile**, as this could introduce serious security vulnerabilities.
 :::
 

--- a/guides/security/dpp-annotations.md
+++ b/guides/security/dpp-annotations.md
@@ -1,6 +1,6 @@
 ---
 synopsis: >
-  In order to automate audit logging, personal data management, and data retention management as much as possible, the first and frequently only task to do as an application developer is to identify entities and elements (potentially) holding personal data using `@PersonalData` annotations. 
+  How to identify entities and elements holding personal data using `@PersonalData` annotations, to automate audit logging, personal data management, and data retention management.
 ---
 
 <style scoped>

--- a/guides/security/dpp-annotations.md
+++ b/guides/security/dpp-annotations.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to identify entities and elements holding personal data using `@PersonalData` annotations, to automate audit logging, personal data management, and data retention management.
 ---
 

--- a/guides/security/dpp-annotations.md
+++ b/guides/security/dpp-annotations.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   In order to automate audit logging, personal data management, and data retention management as much as possible, the first and frequently only task to do as an application developer is to identify entities and elements (potentially) holding personal data using `@PersonalData` annotations. 
-status: released
 ---
 
 <style scoped>

--- a/guides/security/dpp-audit-logging.md
+++ b/guides/security/dpp-audit-logging.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   The Audit Logging plugin provides out-of-the box support for automatic audit logging of data privacy-related events, in particular changes to personal data and reads of sensitive data.
-status: released
 ---
 
 

--- a/guides/security/dpp-audit-logging.md
+++ b/guides/security/dpp-audit-logging.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   The Audit Logging plugin provides out-of-the box support for automatic audit logging of data privacy-related events, in particular changes to personal data and reads of sensitive data.
 ---
 
@@ -444,7 +444,7 @@ await audit.log ('SecurityEvent', {
 
 
 
-## Custom Implementation 
+## Custom Implementation
 
 In addition, everybody could provide new implementations in the same way as we implement the mock variant:
 

--- a/guides/security/dpp-drm.md
+++ b/guides/security/dpp-drm.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Placeholder for the upcoming Data Retention Management (DRM) guide, which will cover concepts and implementation details for managing the retention and deletion of personal data in compliance with data privacy regulations.
 ---
 

--- a/guides/security/dpp-drm.md
+++ b/guides/security/dpp-drm.md
@@ -1,6 +1,6 @@
 ---
 synopsis: >
-  The Data Retention Management (DRM) guide is under construction. It will cover concepts and implementation details for managing the retention and deletion of personal data in compliance with data privacy regulations.
+  Placeholder for the upcoming Data Retention Management (DRM) guide, which will cover concepts and implementation details for managing the retention and deletion of personal data in compliance with data privacy regulations.
 ---
 
 

--- a/guides/security/dpp-drm.md
+++ b/guides/security/dpp-drm.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   The Data Retention Management (DRM) guide is under construction. It will cover concepts and implementation details for managing the retention and deletion of personal data in compliance with data privacy regulations.
-# status: released
 ---
 
 

--- a/guides/security/dpp-pdm.md
+++ b/guides/security/dpp-pdm.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   The Personal Data Management (PDM) guide explains how to integrate your CAP application with the SAP Personal Data Manager service to respond to data subject requests about their personal data stored in your application.
 ---
 
@@ -7,7 +7,7 @@ synopsis: >
 
 # Personal Data Management
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 :::warning To follow this cookbook hands-on you need an enterprise account.
 The SAP Personal Data Manager service is currently only available for [enterprise accounts](https://discovery-center.cloud.sap/missiondetail/3019/3297/). An entitlement in trial accounts is not possible.

--- a/guides/security/dpp-pdm.md
+++ b/guides/security/dpp-pdm.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   The Personal Data Management (PDM) guide explains how to integrate your CAP application with the SAP Personal Data Manager service to respond to data subject requests about their personal data stored in your application.
-status: released
 ---
 
 

--- a/guides/security/index.md
+++ b/guides/security/index.md
@@ -1,14 +1,14 @@
 ---
 synopsis: >
-  This guide teaches how to how to develop, deploy and operate CAP applications in a secure way.
+  This guide teaches how to develop, deploy and operate CAP applications in a secure way.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 
 # CAP Security and Data Privacy
 
-Security, data protection and data privacy are critical aspects of modern application development, 
+Security, data protection and data privacy are critical aspects of modern application development,
 with significant legal and ethical implications. \
-The guides in this section are for developers, operators, administrators, and security professionals 
+The guides in this section are for developers, operators, administrators, and security professionals
 who need to understand how to develop, deploy and operate secure and compliant CAP applications.
 {.abstract}
 

--- a/guides/security/index.md
+++ b/guides/security/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This guide teaches how to develop, deploy and operate CAP applications in a secure way.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---

--- a/guides/security/overview.md
+++ b/guides/security/overview.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   This section provides an overview of the security concepts and architecture of CAP applications on different platforms.
-status: released
 uacp: Used as link target from SAP Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 

--- a/guides/security/overview.md
+++ b/guides/security/overview.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   This section provides an overview of the security concepts and architecture of CAP applications on different platforms.
 uacp: Used as link target from SAP Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 
 # Overview of Security Concepts and Architecture
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 [[toc]]
 
@@ -37,11 +37,11 @@ For example, authentication can be delegated to a [separate ingress component](.
 
 Due to the plugin-based architecture, **you can modify CAP's standard functions as required or, if necessary, completely replace them**.
 This flexibility is crucial for scenarios where the default methods do not fully meet your application's requirements.
-Moreover, this integration helps to easily incorporate non-CAP and even non-BTP services, thereby providing a flexible and interoperable environment. 
+Moreover, this integration helps to easily incorporate non-CAP and even non-BTP services, thereby providing a flexible and interoperable environment.
 
 ![Overview Customizable Components with CAP](./assets/security-customizable.drawio.svg){width="600px" }
 
-For instance, you can define specific endpoints with a [custom authentication strategy](./authentication#custom-auth). 
+For instance, you can define specific endpoints with a [custom authentication strategy](./authentication#custom-auth).
 Likewise, you can override the CAP representation of the request user to match additional, application-specific requirements.
 
 ### Built on Best of Breed { #key-concept-platform-services }
@@ -58,7 +58,7 @@ Likewise, TLS termination is offered by the [platform infrastructure](#platform-
 
 ### Decoupled from Business Logic  { #key-concept-decoupled-coding }
 
-As security functions are factorized into independent components, **application code is entirely decoupled** and hence is not subject to change for any security-related adaptations. 
+As security functions are factorized into independent components, **application code is entirely decoupled** and hence is not subject to change for any security-related adaptations.
 This ensures that business logic remains independent of platform services, which are often subject to security-hardening initiatives.
 As a welcome side effect, this also allows testing application security in a **local test or development setup in a self-contained way**.
 

--- a/guides/security/remote-authentication.md
+++ b/guides/security/remote-authentication.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This guide explains how to authenticate when calling remote services.
 ---
 

--- a/guides/security/remote-authentication.md
+++ b/guides/security/remote-authentication.md
@@ -1,5 +1,4 @@
 ---
-label: Outbound Authentication
 synopsis: >
   This guide explains how to authenticate when calling remote services.
 ---

--- a/guides/security/remote-authentication.md
+++ b/guides/security/remote-authentication.md
@@ -3,7 +3,6 @@
 label: Outbound Authentication
 synopsis: >
   This guide explains how to authenticate when calling remote services.
-status: released
 ---
 
 <script setup>

--- a/guides/security/remote-authentication.md
+++ b/guides/security/remote-authentication.md
@@ -1,5 +1,4 @@
 ---
-# layout: cookbook
 label: Outbound Authentication
 synopsis: >
   This guide explains how to authenticate when calling remote services.

--- a/guides/services/constraints.md
+++ b/guides/services/constraints.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How to use declarative constraint annotations to express and enforce domain-specific input validation rules.
+---
 
 # Declarative Constraints
 

--- a/guides/services/constraints.md
+++ b/guides/services/constraints.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to use declarative constraint annotations to express and enforce domain-specific input validation rules.
 ---
 

--- a/guides/services/constraints.md
+++ b/guides/services/constraints.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Declarative Constraints
 

--- a/guides/services/consuming-services.md
+++ b/guides/services/consuming-services.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Learn how to use uniform APIs to consume local or remote services.
 impl-variants: true
 ---

--- a/guides/services/custom-actions.md
+++ b/guides/services/custom-actions.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 
 # Custom Actions and Functions

--- a/guides/services/custom-actions.md
+++ b/guides/services/custom-actions.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to define and implement custom, domain-specific actions and functions in addition to standard CRUD operations.
 ---
 

--- a/guides/services/custom-actions.md
+++ b/guides/services/custom-actions.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How to define and implement custom, domain-specific actions and functions in addition to standard CRUD operations.
+---
 
 
 # Custom Actions and Functions

--- a/guides/services/custom-code.md
+++ b/guides/services/custom-code.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 
 # Custom Event Handlers

--- a/guides/services/custom-code.md
+++ b/guides/services/custom-code.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to add custom event handlers and service implementations for logic that goes beyond CAP's generic runtime capabilities.
 ---
 

--- a/guides/services/custom-code.md
+++ b/guides/services/custom-code.md
@@ -1,10 +1,14 @@
+---
+synopsis: >
+  How to add custom event handlers and service implementations for logic that goes beyond CAP's generic runtime capabilities.
+---
 
 
 # Custom Event Handlers
 
 As most use cases are covered by [generic runtimes](served-ootb), the need for custom coding is greatly reduced. Nevertheless, there are still numerous cases where custom code is required. And the CAP runtimes provide a flexible and powerful event handler mechanism for you to add custom code at any point during request processing. {.abstract}
 
-> [!tip] Always prefer declarative techniques 
+> [!tip] Always prefer declarative techniques
 > Consider first whether your custom logic can be addressed using declarative techniques, like [status flows](./status-flows) or [declarative constraints](./constraints), before resorting over to programmatic and hence imperative options.
 
 [[toc]]

--- a/guides/services/index.md
+++ b/guides/services/index.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  Overview of how to define, provide, and consume CAP services, covering generic providers, status flows, constraints, custom code, and media data.
+---
+
 # Providing and Consuming Services
 
 [Defining Provided Services](providing-services.md)

--- a/guides/services/index.md
+++ b/guides/services/index.md
@@ -1,6 +1,3 @@
----
-status: released
----
 # Providing and Consuming Services
 
 [Defining Provided Services](providing-services.md)

--- a/guides/services/index.md
+++ b/guides/services/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Overview of how to define, provide, and consume CAP services, covering generic providers, status flows, constraints, custom code, and media data.
 ---
 

--- a/guides/services/media-data.md
+++ b/guides/services/media-data.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How to serve and stream media and binary data from CAP services using OData V4's media resource support.
+---
 
 # Serving Media Data
 

--- a/guides/services/media-data.md
+++ b/guides/services/media-data.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Serving Media Data
 

--- a/guides/services/media-data.md
+++ b/guides/services/media-data.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to serve and stream media and binary data from CAP services using OData V4's media resource support.
 ---
 

--- a/guides/services/providing-services.md
+++ b/guides/services/providing-services.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How services are defined in CDS using the `service` construct to expose data entities and operations as projections on domain models.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html
 ---

--- a/guides/services/providing-services.md
+++ b/guides/services/providing-services.md
@@ -1,4 +1,6 @@
 ---
+synopsis: >
+  How services are defined in CDS using the `service` construct to expose data entities and operations as projections on domain models.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html
 ---
 

--- a/guides/services/served-ootb.md
+++ b/guides/services/served-ootb.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Overview of CAP's generic service providers that automatically serve CRUD requests, search, pagination, and input validation out of the box.
+---
 
 
 # Generic Service Providers

--- a/guides/services/served-ootb.md
+++ b/guides/services/served-ootb.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Overview of CAP's generic service providers that automatically serve CRUD requests, search, pagination, and input validation out of the box.
 ---
 

--- a/guides/services/served-ootb.md
+++ b/guides/services/served-ootb.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 
 # Generic Service Providers

--- a/guides/services/status-flows.md
+++ b/guides/services/status-flows.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to declaratively model status-transition flows so they're validated and executed reliably without extensive custom coding.
 ---
 

--- a/guides/services/status-flows.md
+++ b/guides/services/status-flows.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How to declaratively model status-transition flows so they're validated and executed reliably without extensive custom coding.
+---
 
 # Status-Transition Flows
 

--- a/guides/services/status-flows.md
+++ b/guides/services/status-flows.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Status-Transition Flows
 

--- a/guides/uis/analytics.md
+++ b/guides/uis/analytics.md
@@ -1,4 +1,6 @@
 ---
+synopsis: >
+  How to enable data aggregation for OData V2 services to support analytical queries.
 ---
 
 

--- a/guides/uis/analytics.md
+++ b/guides/uis/analytics.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   How to enable data aggregation for OData V2 services to support analytical queries.
 ---
 
 
 # Analytics in OData V2
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 [[toc]]
 

--- a/guides/uis/fiori.md
+++ b/guides/uis/fiori.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  How to add SAP Fiori elements apps to a CAP project and annotate service definitions to drive their UIs.
+---
+
 
 # Serving SAP Fiori UIs
 

--- a/guides/uis/fiori.md
+++ b/guides/uis/fiori.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to add SAP Fiori elements apps to a CAP project and annotate service definitions to drive their UIs.
 ---
 

--- a/guides/uis/i18n.md
+++ b/guides/uis/i18n.md
@@ -1,4 +1,6 @@
 ---
+synopsis: >
+  How to internationalize a CAP application by externalizing static texts to localized text bundles.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html
 ---
 

--- a/guides/uis/i18n.md
+++ b/guides/uis/i18n.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to internationalize a CAP application by externalizing static texts to localized text bundles.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html
 ---

--- a/guides/uis/index.md
+++ b/guides/uis/index.md
@@ -1,6 +1,3 @@
----
-status: released
----
 # Serving UIs from CAP Applications
 
 CAP does not have its own UI technology, but can be used from a frontend built with any UI framework.

--- a/guides/uis/index.md
+++ b/guides/uis/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Overview of serving UIs from CAP applications, including localization, localized data, SAP Fiori UIs, and other UI frameworks.
 ---
 

--- a/guides/uis/index.md
+++ b/guides/uis/index.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  Overview of serving UIs from CAP applications, including localization, localized data, SAP Fiori UIs, and other UI frameworks.
+---
+
 # Serving UIs from CAP Applications
 
 CAP does not have its own UI technology, but can be used from a frontend built with any UI framework.

--- a/guides/uis/localized-data.md
+++ b/guides/uis/localized-data.md
@@ -1,4 +1,6 @@
 ---
+synopsis: >
+  How to declare and serve localized data, automatically fetching translations matching a user's preferred language with fallback support.
 uacp: Linked from https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html
 ---
 

--- a/guides/uis/localized-data.md
+++ b/guides/uis/localized-data.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to declare and serve localized data, automatically fetching translations matching a user's preferred language with fallback support.
 uacp: Linked from https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html
 ---

--- a/guides/uis/localized-data.md
+++ b/guides/uis/localized-data.md
@@ -1,6 +1,5 @@
 ---
 uacp: Linked from https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html
-status: released
 ---
 
 # Localized Data

--- a/guides/uis/vue-react.md
+++ b/guides/uis/vue-react.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to set up a minimal CAP project with a Vue.js or React frontend.
 ---
 

--- a/guides/uis/vue-react.md
+++ b/guides/uis/vue-react.md
@@ -1,3 +1,8 @@
+---
+synopsis: >
+  How to set up a minimal CAP project with a Vue.js or React frontend.
+---
+
 # Serving Vue.js or React
 <Since version="9.9.0" package="@sap/cds-dk" />
 

--- a/java/auditlog.md
+++ b/java/auditlog.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Find here information about the AuditLog service in CAP Java.
 ---
 
@@ -10,7 +10,7 @@ synopsis: >
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 
 <!-- #### Content

--- a/java/auditlog.md
+++ b/java/auditlog.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Find here information about the AuditLog service in CAP Java.
-status: released
 ---
 
 # Audit Logging

--- a/java/building-plugins.md
+++ b/java/building-plugins.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   A collection of different mechanisms that can be used to build plugins for CAP Java.
-status: released
 ---
 
 # Building Plugins

--- a/java/building-plugins.md
+++ b/java/building-plugins.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   A collection of different mechanisms that can be used to build plugins for CAP Java.
 ---
 
@@ -11,7 +11,7 @@ synopsis: >
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 Especially, when working with larger projects that may consist of many individual CAP Java applications or when building platform services that need to be integrated with CAP applications there's the requirement to extend CAP Java with custom, yet reusable code.
 

--- a/java/cap-plugins-in-spring-boot-apps.md
+++ b/java/cap-plugins-in-spring-boot-apps.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This guide shows how Spring Boot applications that run without a CDS model can integrate with service offerings on SAP BTP by using CAP plugins without a full migration to CAP Java.
 ---
 
@@ -17,7 +17,7 @@ synopsis: >
   const { versions } = theme.value.capire
 </script>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 CAP Java offers a [variety of plugins that integrate with SAP BTP services](../plugins/) and keep your application free of hard-coded service dependencies. In the CAP ecosystem, this approach is called [Calesi (CAP level service integration)](../get-started/concepts#the-calesi-pattern). Most Calesi plugins expose a CAP service that you can inject as a Spring Boot component. As the CAP runtime can run alongside a Spring Boot application without a CDS model, this lets you use proven service integration through CAP plugins with a growing set of SAP BTP services.
 

--- a/java/cap-plugins-in-spring-boot-apps.md
+++ b/java/cap-plugins-in-spring-boot-apps.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   This guide shows how Spring Boot applications that run without a CDS model can integrate with service offerings on SAP BTP by using CAP plugins without a full migration to CAP Java.
-status: released
 ---
 
 # Use CAP Plugins in Spring Boot Applications without a CDS Model

--- a/java/cds-data.md
+++ b/java/cds-data.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This section describes how CDS data is represented and used in CAP Java.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -12,7 +12,7 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 
 

--- a/java/change-tracking.md
+++ b/java/change-tracking.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Find here information about the change tracking feature in CAP Java.
 ---
 
@@ -164,7 +164,7 @@ For example, for a book you can store an author name if you have an association 
 
 For compositions, no special annotations are required. The identifiers of the target entity are used instead.
 
-For example, given the following model: 
+For example, given the following model:
 
 ```cds
 entity Orders : cuid {
@@ -193,11 +193,11 @@ annotate OrderItems with @changelog: [
 ];
 ```
 
-Changes for `Orders` and `OrderItems` will have their own respective target or root identifiers filled. 
+Changes for `Orders` and `OrderItems` will have their own respective target or root identifiers filled.
 
 ### Human-readable values for associations
 
-For associations, the value of the foreign key is stored in the changelog by default. You can change this and store the values of the associated entity instead. 
+For associations, the value of the foreign key is stored in the changelog by default. You can change this and store the values of the associated entity instead.
 This kind of identifier changes the values stored in the changelog, while [entity identifiers](#identifiers-for-entities) annotate changed values.
 
 You annotate your entity like this:
@@ -217,12 +217,12 @@ such cases in the custom code or use annotations, for example, [`@assert.target`
 
 ### Caveats of Identifiers
 
-Consider the following important points that are relevant for all kinds of identifiers and human-readable values: 
+Consider the following important points that are relevant for all kinds of identifiers and human-readable values:
 
 - When you define the identifier for an entity, keep in mind that the projections of the annotated entity
 inherit the annotation `@changelog`. If you change the structure of the projection,
 for example, exclude or rename the elements that are used in the identifier, you must annotate the projection again
-to provide updated element names in the identifier. This is one additional benefit of annotating the top-most projection for change tracking. 
+to provide updated element names in the identifier. This is one additional benefit of annotating the top-most projection for change tracking.
 
 - The values of the identifier are stored together with the change log as-is. They are not translated and some data types might
 not be formatted per user locale or some requirements, for example, different units of measurement or currencies.
@@ -390,7 +390,7 @@ Changes are correctly referenced to the root if the following conditions are tru
 Avoid Direct modifications of composition items, they aren't supported by change tracking.
 :::
 
-In the following example, the item's updated changelog entry _won't_ be associated with an order: 
+In the following example, the item's updated changelog entry _won't_ be associated with an order:
 
 ```java
 OrderItems item = OrderItems.create("...");
@@ -439,10 +439,10 @@ You can query the change log entries via CQN statements, as usual.
 
 ### Advanced Identifiers for Associated Entities
 
-By default, the identifier is read from the association when the feature captures images of the data. 
+By default, the identifier is read from the association when the feature captures images of the data.
 Additional joins might be expensive or impossible under some circumstances.
 
-:::warning Configuration change required! 
+:::warning Configuration change required!
 Enable [optimization for path expressions](/releases/2025/aug25#optimized-path-expressions).
 :::
 
@@ -462,7 +462,7 @@ entity Entity {
 
 Let's assume that `User` is impossible to join with the standard identifier or requires an identifier depending on the context of the user who reads the change log.
 
-You model the association like this: 
+You model the association like this:
 
 ```cds
 entity Entity {
@@ -473,9 +473,9 @@ entity Entity {
 
 The change log will contain one entry for the field `user` just like the other associations with [human-readable values](#human-readable-values-for-associations), but the identifier will be its primary key.
 
-You need a custom handler to fetch your own custom identifier. 
+You need a custom handler to fetch your own custom identifier.
 
-Here's the sketch for the handler to adapt the change log after read: 
+Here's the sketch for the handler to adapt the change log after read:
 
 ```java
 @Component

--- a/java/change-tracking.md
+++ b/java/change-tracking.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Find here information about the change tracking feature in CAP Java.
-status: released
 ---
 
 # Change Tracking

--- a/java/cqn-services/application-services.md
+++ b/java/cqn-services/application-services.md
@@ -1,6 +1,6 @@
 ---
 synopsis: >
-  Application Services define the APIs that a CAP application exposes to its clients, for example through OData. This section describes how to add business logic to these services, by extending CRUD events and implementing actions and functions.
+  How to add business logic to Application Services — the APIs a CAP application exposes to its clients, for example through OData — by extending CRUD events and implementing actions and functions.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 

--- a/java/cqn-services/application-services.md
+++ b/java/cqn-services/application-services.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to add business logic to Application Services — the APIs a CAP application exposes to its clients, for example through OData — by extending CRUD events and implementing actions and functions.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -11,7 +11,7 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ## Handling CRUD Events { #crudevents}
 

--- a/java/cqn-services/index.md
+++ b/java/cqn-services/index.md
@@ -1,5 +1,6 @@
 ---
-synopsis: CQN Services are the core services of CAP that deal with CDS data. One of the key APIs provided by these services is the uniform query API based on CQN statements.
+synopsis: >
+  Introduces CQN Services, the core services of CAP that deal with CDS data, providing a uniform query API based on CQN statements.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 

--- a/java/cqn-services/index.md
+++ b/java/cqn-services/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Introduces CQN Services, the core services of CAP that deal with CDS data, providing a uniform query API based on CQN statements.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---

--- a/java/cqn-services/persistence-services.md
+++ b/java/cqn-services/persistence-services.md
@@ -1,6 +1,6 @@
 ---
 synopsis: >
-  Persistence Services are CQN-based database clients. This section describes which database types are supported, how datasources to these databases are created and how they are turned into Persistence Services.
+  How CQN-based Persistence Services are created from datasources to supported database types and used as database clients.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 
@@ -570,7 +570,7 @@ See [Class JdbcTemplate](https://docs.spring.io/spring-framework/docs/current/ja
 
 The static model and accessor interfaces can be generated using the [CDS Maven Plugin](../developing-applications/building#cds-maven-plugin).
 
-::: warning 
+::: warning
 Currently, the generator doesn't support using reserved [Java keywords](https://docs.oracle.com/javase/specs/jls/se13/html/jls-3.html#jls-3.9) as identifiers in the CDS model. Conflicting element names can be renamed in Java using the [@cds.java.name](../cds-data#renaming-elements-in-java) annotation. For entities it is recommended to use [@cds.java.this.name](../cds-data#renaming-types-in-java).
 :::
 

--- a/java/cqn-services/persistence-services.md
+++ b/java/cqn-services/persistence-services.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How CQN-based Persistence Services are created from datasources to supported database types and used as database clients.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -11,7 +11,7 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ## Database Support { #database-support}
 

--- a/java/cqn-services/remote-services.md
+++ b/java/cqn-services/remote-services.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Remote Services are CQN-based clients to remote APIs that a CAP application consumes. This section describes how to configure and use these services.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -11,7 +11,7 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 The CAP Java SDK supports _Remote Services_ for OData V2 and V4 APIs out of the box.
 The CQN query APIs enable [late-cut microservices](../../get-started/features#late-cut-microservices) with simplified mocking capabilities. Regarding multitenant applications, these APIs keep you extensible, even towards remote APIs. In addition, they free developers from having to map CQN to OData themselves.

--- a/java/developing-applications/building.md
+++ b/java/developing-applications/building.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to create a CAP Java project from scratch, build it with Maven, and modify an existing project using the CDS Maven plugin.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---

--- a/java/developing-applications/building.md
+++ b/java/developing-applications/building.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
-  This section describes various options to create a CAP Java project from scratch, to build your application with Maven, and to modify an existing project with the CDS Maven plugin.
-
+  How to create a CAP Java project from scratch, build it with Maven, and modify an existing project using the CDS Maven plugin.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 

--- a/java/developing-applications/configuring.md
+++ b/java/developing-applications/configuring.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This section describes how to configure CAP Java applications.
 
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
@@ -42,7 +42,7 @@ Property defaults adjusted with the production profile are the following:
 
 Note, that explicit configuration in the application takes precedence over property defaults from the production profile.
 
-::: warning 
+::: warning
 **Do not manually enable features for production that are disabled by the production profile**, as this could introduce serious security vulnerabilities.
 :::
 

--- a/java/developing-applications/index.md
+++ b/java/developing-applications/index.md
@@ -2,7 +2,6 @@
 synopsis: >
   Learn here about developing a CAP Java application.
 
-status: released
 ---
 
 # Developing CAP Java Applications

--- a/java/developing-applications/index.md
+++ b/java/developing-applications/index.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   Learn here about developing a CAP Java application.
 
 ---
 
 # Developing CAP Java Applications
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 <script setup>
 import { data as pages } from './index.data.ts'

--- a/java/developing-applications/properties.md
+++ b/java/developing-applications/properties.md
@@ -1,6 +1,6 @@
 ---
 embed: link
-synopsis: >
+description: >
   Reference of all configuration properties available for configuring CAP Java applications via `application.yml`.
 ---
 

--- a/java/developing-applications/properties.md
+++ b/java/developing-applications/properties.md
@@ -1,5 +1,7 @@
 ---
 embed: link
+synopsis: >
+  Reference of all configuration properties available for configuring CAP Java applications via `application.yml`.
 ---
 
 <script setup>

--- a/java/developing-applications/properties.md
+++ b/java/developing-applications/properties.md
@@ -1,6 +1,5 @@
 ---
 embed: link
-status: released
 ---
 
 <script setup>

--- a/java/developing-applications/running.md
+++ b/java/developing-applications/running.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This section describes various options how to run CAP Java applications locally
 
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
@@ -43,7 +43,7 @@ The fastest way to run the CAP Java application is with the IDE that can run and
 
 The `auto-build` goal of the CDS Maven Plugin reacts on any CDS file change and performs a rebuild of your application CDS model. When you restart the application in the IDE or re-run tests, the updated model is picked up your application.
 
-Run this in your terminal and leave it open: 
+Run this in your terminal and leave it open:
 
 ```sh
 mvn cds:auto-build
@@ -75,15 +75,15 @@ Run this in your terminal:
 mvn cds:watch
 ```
 
-The `watch` goal uses the `spring-boot-maven-plugin` internally to start the application with the goal `run` (this also includes a CDS build). 
-When you add the [Spring Boot Devtools](../developing-applications/running#spring-boot-devtools) to your project, the `watch` goal can take advantage of the reload mechanism. 
+The `watch` goal uses the `spring-boot-maven-plugin` internally to start the application with the goal `run` (this also includes a CDS build).
+When you add the [Spring Boot Devtools](../developing-applications/running#spring-boot-devtools) to your project, the `watch` goal can take advantage of the reload mechanism.
 In case your application doesn't use the Spring Boot Devtools, the `watch` goal performs a complete restart of the application after CDS model changes, which is slower.
 
 ::: warning
 On Windows, the `watch` goal only works if the Spring Boot Devtools are enabled.
 :::
 
-You can customize the goals that are executed when the application is restarted after the change to get even faster feedback: 
+You can customize the goals that are executed when the application is restarted after the change to get even faster feedback:
 
 - Use the following command to execute the CDS build and code generator to regenerate [accessor interfaces](../cds-data#generated-accessor-interfaces):
 
@@ -110,7 +110,7 @@ See [the _Multitenancy_ guide](../../guides/multitenancy/index#test-drive-locall
 
 You can debug Java applications locally and remotely.
 
-- For local applications, it's best to start the application using the integrated debugger of your [preferred IDE](../../tools/cds-editors). 
+- For local applications, it's best to start the application using the integrated debugger of your [preferred IDE](../../tools/cds-editors).
 - You can also enable debugger using JVM arguments and attach to it from your IDE.
 - Especially for remote applications, we recommend [`cds debug`](../../tools/cds-cli#java-applications) to turn on debugging.
 

--- a/java/developing-applications/testing.md
+++ b/java/developing-applications/testing.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This section describes how to test CAP Java applications on different level.
 
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html

--- a/java/event-handlers/changeset-contexts.md
+++ b/java/event-handlers/changeset-contexts.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   ChangeSet Contexts are an abstraction around transactions. This chapter describes how ChangeSets are related to transactions and how to manage them with the CAP Java SDK.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -11,7 +11,7 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ## Overview
 

--- a/java/event-handlers/index.md
+++ b/java/event-handlers/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to register event handlers on services to extend or override the processing of CRUD events, actions, functions, and asynchronous messaging events.
 uacp: Used as link target from SAP Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---

--- a/java/event-handlers/index.md
+++ b/java/event-handlers/index.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
-  This section describes how to register event handlers on services. In CAP everything that happens at runtime is an event that is sent to a service.
-  With event handlers the processing of these events can be extended or overridden. Event handlers can be used to handle CRUD events, implement actions and functions and to handle asynchronous events from a messaging service.
+  How to register event handlers on services to extend or override the processing of CRUD events, actions, functions, and asynchronous messaging events.
 uacp: Used as link target from SAP Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 

--- a/java/event-handlers/indicating-errors.md
+++ b/java/event-handlers/indicating-errors.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Learn about the error handling capabilities provided by the CAP Java SDK.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -11,7 +11,7 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ## Overview
 

--- a/java/event-handlers/request-contexts.md
+++ b/java/event-handlers/request-contexts.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Request Contexts span the execution of multiple events on (different) services. They provide a common context to these events, by providing user or tenant information or access to headers or query parameters.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -11,7 +11,7 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 
 ## Overview

--- a/java/event-handlers/request-contexts.md
+++ b/java/event-handlers/request-contexts.md
@@ -1,6 +1,6 @@
 ---
 synopsis: >
-  Request Contexts span the execution of multiple events on (different) services. They provide a common context to these events, by providing user or tenant information or access to headers or query parameter.
+  Request Contexts span the execution of multiple events on (different) services. They provide a common context to these events, by providing user or tenant information or access to headers or query parameters.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 
@@ -127,7 +127,7 @@ public void afterHandler(EventContext context){
 }
 ```
 
-Most important use case is to switch users, for which CAP Java provides [convenience APIs](../../guides/security/cap-users#switching-users). 
+Most important use case is to switch users, for which CAP Java provides [convenience APIs](../../guides/security/cap-users#switching-users).
 
 ## Modifying Request Contexts { #modifying-requestcontext}
 

--- a/java/event-queues.md
+++ b/java/event-queues.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Java APIs and configuration for CAP's Transactional Event Queues — `OutboxService`, `AsyncCqnService`, scheduling, custom outbox services, error handling, and event versioning.
 ---
 

--- a/java/event-queues.md
+++ b/java/event-queues.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Java APIs and configuration for CAP's Transactional Event Queues — `OutboxService`, `AsyncCqnService`, scheduling, custom outbox services, error handling, and event versioning.
-status: released
 ---
 
 # Event Queues in Java

--- a/java/fiori-drafts.md
+++ b/java/fiori-drafts.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This section describes which events occur in combination with SAP Fiori Drafts.
 uacp: Used as link target from SAP Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -12,7 +12,7 @@ uacp: Used as link target from SAP Help Portal at https://help.sap.com/products/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ## Overview { #draftevents}
 
@@ -80,7 +80,7 @@ Draft-enabled entities have an extra key `IsActiveEntity` by which you can acces
 | DELETE with key `IsActiveEntity=false`                                 | `DraftService.EVENT_DRAFT_CANCEL`  | Deletes an existing draft.                                                                                                  |
 | DELETE with key `IsActiveEntity=true`                                  | `CqnService.EVENT_DELETE`          | Deletes an active entity *and* the corresponding draft.                                                                     |
 | POST with `draftPrepare` action                                        | `DraftService.EVENT_DRAFT_PREPARE` | Empty implementation.                                                                                                       |
-| POST with `draftPrepare` action and `$select=DraftMessages`            | `DraftService.EVENT_DRAFT_PREPARE`        | Simulates the draft activation to validate your document completely. The system triggers a `draftActivate` operation (`CREATE` or `UPDATE` event) in an isolated transaction and then rolls it back.        | 
+| POST with `draftPrepare` action and `$select=DraftMessages`            | `DraftService.EVENT_DRAFT_PREPARE`        | Simulates the draft activation to validate your document completely. The system triggers a `draftActivate` operation (`CREATE` or `UPDATE` event) in an isolated transaction and then rolls it back.        |
 | POST with `draftEdit` action                                           | `DraftService.EVENT_DRAFT_EDIT`    | Creates a new draft from an active entity. Internally triggers `DRAFT_CREATE`.                                              |
 | POST with `draftActivate` action                                       | `DraftService.EVENT_DRAFT_SAVE`    | Activates a draft and updates the active entity. Triggers an `CREATE` or `UPDATE` event on the affected entity.             |
 | n/a                                                                    | `DraftService.EVENT_DRAFT_CREATE`  | Stores a new draft in the database.                                                                                         |

--- a/java/getting-started.md
+++ b/java/getting-started.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to start a new CAP Java project and how to run it locally.
 ---
 
@@ -11,7 +11,7 @@ synopsis: >
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ## Introduction
 <!--Used as link target from Help Portal: https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html -->

--- a/java/getting-started.md
+++ b/java/getting-started.md
@@ -1,8 +1,6 @@
 ---
 synopsis: >
   How to start a new CAP Java project and how to run it locally.
-#notebook: true
-status: released
 ---
 
 # Getting Started

--- a/java/index.md
+++ b/java/index.md
@@ -1,6 +1,5 @@
 ---
 section: Java
-status: released
 ---
 
 <style scoped>

--- a/java/index.md
+++ b/java/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference documentation for the CAP Service SDK for Java.
 ---
 

--- a/java/index.md
+++ b/java/index.md
@@ -1,5 +1,6 @@
 ---
-section: Java
+synopsis: >
+  Reference documentation for the CAP Service SDK for Java.
 ---
 
 <style scoped>

--- a/java/messaging.md
+++ b/java/messaging.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How CAP's publish-subscribe-based Messaging support enables asynchronous communication with one or many receivers that may be unknown or unavailable at the time of sending.
 ---
 
@@ -23,7 +23,7 @@ synopsis: >
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 In contrast, the nature of synchronous communication between services can be disadvantageous depending on the desired information flow, for example, sender and receiver need to be available at the time of the request. The sender needs to know the receiver and how to call it, and that communication per request is usually point-to-point only.
 

--- a/java/messaging.md
+++ b/java/messaging.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
-  CAP Messaging provides support for publish-subscribe-based messaging, which is an asynchronous communication pattern well suited for scenarios where a sender wants to send out information to one or many receivers that are potentially unknown and/or unavailable at the time of sending.
-
+  How CAP's publish-subscribe-based Messaging support enables asynchronous communication with one or many receivers that may be unknown or unavailable at the time of sending.
 ---
 
 <script setup>

--- a/java/messaging.md
+++ b/java/messaging.md
@@ -2,7 +2,6 @@
 synopsis: >
   CAP Messaging provides support for publish-subscribe-based messaging, which is an asynchronous communication pattern well suited for scenarios where a sender wants to send out information to one or many receivers that are potentially unknown and/or unavailable at the time of sending.
 
-status: released
 ---
 
 <script setup>

--- a/java/migration.md
+++ b/java/migration.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This chapter contains comprehensive guides that help you to work through migrations such as from CAP Java 1.x to CAP Java 2.x.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -21,7 +21,7 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 [[toc]]
 

--- a/java/migration.md
+++ b/java/migration.md
@@ -1,5 +1,5 @@
 ---
-synopsis:
+synopsis: >
   This chapter contains comprehensive guides that help you to work through migrations such as from CAP Java 1.x to CAP Java 2.x.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---

--- a/java/multitenancy-classic.md
+++ b/java/multitenancy-classic.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
-  CAP applications can be run as software as a service (SaaS). That means, multiple customers (subscriber tenants) can use the application at the same time in an isolated manner.
-  This section explains how to configure multitenancy for the CAP Java.
+  How to configure the classic multitenancy setup for CAP Java applications run as software as a service (SaaS), serving multiple isolated subscriber tenants.
 # uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 

--- a/java/multitenancy-classic.md
+++ b/java/multitenancy-classic.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   How to configure the classic multitenancy setup for CAP Java applications run as software as a service (SaaS), serving multiple isolated subscriber tenants.
 # uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 
 # Multitenancy (Classic) { #multitenancy-classic}
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ::: warning
 The multitenancy services (`@sap/cds-mtx`) described in this chapter are in maintenance mode and only supported until CAP Java 2.x.

--- a/java/multitenancy.md
+++ b/java/multitenancy.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   How CAP Java applications run as software as a service (SaaS) for multiple isolated subscriber tenants, who may optionally extend their served CDS models.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 
 # Multitenancy
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ## Setup Overview
 

--- a/java/multitenancy.md
+++ b/java/multitenancy.md
@@ -1,11 +1,10 @@
 ---
 synopsis: >
-  CAP applications can be run as software as a service (SaaS). That means, multiple customers (subscriber tenants) can use the application at the same time in an isolated manner.
-  Optionally, subscriber tenants may also extend their CDS models being served.
+  How CAP Java applications run as software as a service (SaaS) for multiple isolated subscriber tenants, who may optionally extend their served CDS models.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 
-# Multitenancy 
+# Multitenancy
 
 {{ $frontmatter.synopsis }}
 
@@ -159,7 +158,7 @@ public class SubscriptionHandler implements EventHandler {
 		Optional<ServiceBinding> service = cdsRuntime.getEnvironment().
                 getServiceBindings().filter(binding -> binding.getServiceName().
                         get().equals(SERVICE_NAME)).findFirst();
-		
+
 		if (service.isPresent()) {
 			String xsappname = extractXsappname(service.get().getCredentials());
 			dependencies.add(SaasRegistryDependency.create(xsappname));
@@ -314,7 +313,7 @@ runtime.requestContext().systemUser(tenant).run(context -> {
 Note that switching the tenant in the context is a quite expensive operation as CDS model data might need to be fetched from MTX sidecar in case of tenant extensions.
 Hence, avoid setting the context for all subscribed tenants iteratively as this might overload the sidecar and also could flood the local CDS model cache.
 
-::: warning 
+::: warning
 If an application deviates from default behaviour and switches the tenant context internally, it needs to ensure data privacy and proper isolation!
 :::
 
@@ -331,7 +330,7 @@ TenantProviderService tenantProvider;
 List<TenantInfo> tenantInfo = tenantProvider.readTenants();
 ```
 
-::: warning 
+::: warning
 Retrieving the tenants is an expensive operation. It might be a good idea to cache the results if appropriate.
 :::
 
@@ -365,7 +364,7 @@ upon incoming requests.
 
 In order to activate the combined pool approach set the property `cds.multiTenancy.datasource.combinePools.enabled = true`.
 
-::: warning 
+::: warning
 Since the pool is shared among all tenants, one tenant could eat up all available connections, either intentionally or by accident. Applications using combined pools need to take adequate measures to mitigate this risk, for example by introducing rate-limiting.
 :::
 

--- a/java/operating-applications/dashboard.md
+++ b/java/operating-applications/dashboard.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   This section describes how the CAP Developer Dashboard can be set up in both the local and cloud development environment to improve the developer experience.
-status: released
 ---
 
 # Developer Dashboard

--- a/java/operating-applications/dashboard.md
+++ b/java/operating-applications/dashboard.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This section describes how the CAP Developer Dashboard can be set up in both the local and cloud development environment to improve the developer experience.
 ---
 
@@ -35,7 +35,7 @@ Add the `cds-feature-dev-dashboard` feature to your maven dependencies:
 
 ## Local Setup
 
-By default, the dashboard requires authorized access, which requires the `cds.Developer` role. The default mock user configuration provides the user `developer` already configured with this role. If you use your own mocked users, you must assign them the `cds.Developer` role if you want to give them access to the dashboard. 
+By default, the dashboard requires authorized access, which requires the `cds.Developer` role. The default mock user configuration provides the user `developer` already configured with this role. If you use your own mocked users, you must assign them the `cds.Developer` role if you want to give them access to the dashboard.
 
 ::: code-group
 ```yaml [application.yaml]
@@ -120,7 +120,7 @@ modules:
 			"source": "^/dashboard_api/(.*)",
 			"authenticationType": "xsuaa",
 			"destination": "backend"
-		}, 
+		},
     [...]
 	]
 }
@@ -157,7 +157,7 @@ In some cases, your application may run in a complex environment and you simply 
 
 	:::
 
-2. Disable authentication. 
+2. Disable authentication.
 
 	::: code-group
 	```java [WebSecurity]

--- a/java/operating-applications/index.md
+++ b/java/operating-applications/index.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   Learn here about operating a CAP Java application.
 
 ---
 
 # Operating CAP Java Applications
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 <script setup>
 import { data as pages } from './index.data.ts'

--- a/java/operating-applications/index.md
+++ b/java/operating-applications/index.md
@@ -2,7 +2,6 @@
 synopsis: >
   Learn here about operating a CAP Java application.
 
-status: released
 ---
 
 # Operating CAP Java Applications

--- a/java/operating-applications/observability.md
+++ b/java/operating-applications/observability.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Presents a set of recommended tools that help to understand the current status of running CAP services.
 ---
 
@@ -10,7 +10,7 @@ synopsis: >
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ## Logging { #logging}
 

--- a/java/operating-applications/observability.md
+++ b/java/operating-applications/observability.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Presents a set of recommended tools that help to understand the current status of running CAP services.
-status: released
 ---
 
 # Observability

--- a/java/operating-applications/optimizing.md
+++ b/java/operating-applications/optimizing.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This section describes how to optimize resource consumption of productive CAP Java applications.
 
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html

--- a/java/reflection-api.md
+++ b/java/reflection-api.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   The Model Reflection API is a set of interfaces, which provide the ability to introspect a CDS model and retrieve details on
   the services, types, entities, and their elements that are defined by the model.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
@@ -12,7 +12,7 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ## The CDS Model
 

--- a/java/security.md
+++ b/java/security.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Describes authentication and authorization specific for CAP Java.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -21,12 +21,12 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 { #security}
 
 ::: info
-This chapter appends CAP Java sepcifc information only. 
+This chapter appends CAP Java sepcifc information only.
 Consult the comprehensive [Security Guide](../guides/security/) first to learn about CAP Security features in general.
 :::
 
@@ -56,7 +56,7 @@ Both can be active for the local scenario.
 
 #### Service Bindings { #bindings }
 
-Additionally, your application must be bound to corresponding service instances depending on your scenario.  
+Additionally, your application must be bound to corresponding service instances depending on your scenario.
 The following list describes which service must be bound depending on the tokens your application should accept:
    * only accept tokens issued by XSUAA --> bind your application to an [XSUAA service instance](../guides/security/authentication#xsuaa-auth)
    * only accept tokens issued by IAS --> bind your application to an [IAS service instance](../guides/security/authentication#ias-auth)
@@ -156,7 +156,7 @@ public class ActuatorSecurityConfig {
 
 In case you want to write your own custom security configuration that acts as a last line of defense and handles any request you need to disable the CAP security configurations by setting <Config java>cds.security.authentication.authConfig.enabled: false</Config>, as Spring Security forbids registering multiple security configurations with an any request security matcher.
 
-If you even want to deactivate OAuth token validation for XSUAA or IAS, for example, to establish an own authentication strategy, 
+If you even want to deactivate OAuth token validation for XSUAA or IAS, for example, to establish an own authentication strategy,
 the following properties can be used:
 
 | Configuration Property                               | Description                                             | Default
@@ -168,7 +168,7 @@ the following properties can be used:
 
 ## CAP Users { #custom-authentication}
 
-CAP is not bound to any specific authentication method or user representation such as those introduced with XSUAA or IAS; it runs requests based on a [user abstraction](../guides/security/cap-users#claims). 
+CAP is not bound to any specific authentication method or user representation such as those introduced with XSUAA or IAS; it runs requests based on a [user abstraction](../guides/security/cap-users#claims).
 The CAP user of a request is represented by a [UserInfo](https://www.javadoc.io/doc/com.sap.cds/cds-services-api/latest/com/sap/cds/services/request/UserInfo.html) object that can be retrieved from the [RequestContext](https://www.javadoc.io/doc/com.sap.cds/cds-services-api/latest/com/sap/cds/services/request/RequestContext.html) as explained in the [authentication guide](../guides/security/cap-users#developing-with-users).
 
 ### Mock Users { #mock-users}
@@ -183,7 +183,7 @@ Mock users are only initialized if the `org.springframework.boot:spring-boot-sta
 
 #### Preconfigured Mock Users { #preconfigured-mock-users}
 
-For convenience, the runtime creates default mock users reflecting the [pseudo roles](../guides/security/cap-users#pseudo-roles): 
+For convenience, the runtime creates default mock users reflecting the [pseudo roles](../guides/security/cap-users#pseudo-roles):
 
 | Name                               | Role                                             | Password
 | :---------------------------------------------------- | :----------------------------------------------------- | ------------
@@ -192,8 +192,8 @@ For convenience, the runtime creates default mock users reflecting the [pseudo r
 | `privileged`  | privileged mode | _empty_
 
 
-For example, requests sent during a Spring MVC unit test with annotation `@WithMockUser("authenticated")` will pass authorization checks that require `authenticated-user`. 
-The privileged user will pass any authorization checks. 
+For example, requests sent during a Spring MVC unit test with annotation `@WithMockUser("authenticated")` will pass authorization checks that require `authenticated-user`.
+The privileged user will pass any authorization checks.
 
 There are several properties to control behavioud of mock users:
 

--- a/java/security.md
+++ b/java/security.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Describes authentication and authorization specific for CAP Java.
-status: released
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 

--- a/java/services.md
+++ b/java/services.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Introduces Services, one of the core concepts of CAP, describing how they're represented in the CAP Java SDK and how their event-based APIs, including the uniform query API based on CQN statements, can be used.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---

--- a/java/services.md
+++ b/java/services.md
@@ -1,5 +1,6 @@
 ---
-synopsis: Services are one of the core concepts of CAP. This section describes how services are represented in the CAP Java SDK and how their event-based APIs can be used. One of the key APIs provided by services is the uniform query API based on CQN statements.
+synopsis: >
+  Introduces Services, one of the core concepts of CAP, describing how they're represented in the CAP Java SDK and how their event-based APIs, including the uniform query API based on CQN statements, can be used.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 

--- a/java/spring-boot-integration.md
+++ b/java/spring-boot-integration.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   This section shows how CAP Java is smoothly integrated with Spring Boot.
-status: released
 ---
 
 # Spring Boot Integration

--- a/java/spring-boot-integration.md
+++ b/java/spring-boot-integration.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This section shows how CAP Java is smoothly integrated with Spring Boot.
 ---
 
@@ -10,7 +10,7 @@ synopsis: >
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 <!-- ## [CDS Properties](properties/) {.toc-redirect} -->
 

--- a/java/versions.md
+++ b/java/versions.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Learn in this chapter about CAP Java versions and their dependencies.
 ---
 
@@ -10,7 +10,7 @@ synopsis: >
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 <!-- ## [CDS Properties](properties/) {.toc-redirect} -->
 

--- a/java/versions.md
+++ b/java/versions.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Learn in this chapter about CAP Java versions and their dependencies.
-status: released
 ---
 
 # Versions & Dependencies

--- a/java/working-with-cql/index.md
+++ b/java/working-with-cql/index.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   Learn here about working with CDS CQL.
 
 ---
 
 # Working with CDS CQL
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 <script setup>
 import { data as pages } from './index.data.ts'

--- a/java/working-with-cql/index.md
+++ b/java/working-with-cql/index.md
@@ -2,7 +2,6 @@
 synopsis: >
   Learn here about working with CDS CQL.
 
-status: released
 ---
 
 # Working with CDS CQL

--- a/java/working-with-cql/query-api.md
+++ b/java/working-with-cql/query-api.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   API to fluently build CQL statements in Java.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -585,10 +585,10 @@ You can also select sub-elements of a `cds.Map` via path expressions:
 
 ```java
 Select.from(PRODUCTS)
-      .columns(p-> p.ID(), 
+      .columns(p-> p.ID(),
                p-> p.details().get("brand"))
       .where(p -> p.category().eq("tech"));
-```      
+```
 
 This query selects the sub-element `brand` of the `details` map element for all products of category "tech".
 
@@ -909,12 +909,12 @@ entity Product : cuid {
 }
 ```
 
-This following query sorts products by category and additionally by the sub-element `brand` of the map element `details`. 
+This following query sorts products by category and additionally by the sub-element `brand` of the map element `details`.
 
 ```java
 Select.from(PRODUCTS)
       .where(p -> p.category().eq("tech"))
-      .orderBy(p -> p.category().asc(), 
+      .orderBy(p -> p.category().asc(),
                p.to("details").get("brand").asc());
 ```
 
@@ -956,7 +956,7 @@ If the selected rows are already locked by another transaction, by default, the 
   ```java
   import static com.sap.cds.ql.cqn.CqnLock.Mode.EXCLUSIVE;
 
-  // wait max 10s  
+  // wait max 10s
   Select.from("bookshop.Books").byId(1).lock(EXCLUSIVE, 10);
   ```
 
@@ -987,7 +987,7 @@ If the selected rows are already locked by another transaction, by default, the 
   ::: tip
   This is useful for queue-like processing where multiple workers consume available items concurrently without blocking each other.
   :::
-  
+
 #### Restrictions
 
 Not every entity exposed via a CDS entity can be locked with the `lock()` clause. To use the `lock()` clause, databases require that the target of such statements is represented by one of the following:
@@ -1648,7 +1648,7 @@ You can use date/time functions to extract components from date/time values and 
 
 | method | return CDS | return Java | example |
 | --- | --- | --- | --- |
-| year | Int32 | Integer | `date.year()` | 
+| year | Int32 | Integer | `date.year()` |
 | month | Int32 | Integer | `CQL.year(date)` |
 | day | Int32 | Integer | `date.day()` |
 | hour | Int32 | Integer | `CQL.hour(time)` |
@@ -1669,7 +1669,7 @@ These methods allow you to compute the difference between timestamps:
 
 | method | return CDS | return Java | example |
 | --- | --- | --- | --- |
-| yearsBetween | Int32 | Integer | `start.yearsBetween(end)` | 
+| yearsBetween | Int32 | Integer | `start.yearsBetween(end)` |
 | monthsBetween | Int32 | Integer | `start.monthsBetween(end)` |
 | daysBetween | Int32 | Integer | `CQL.daysBetween(start, end)` |
 | secondsBetween | Int64 | Integer | `start.secondsBetween(end)` |
@@ -2067,7 +2067,7 @@ NOT
 
 These boolean-valued functions can be used in filters:
 
-##### Containment Test 
+##### Containment Test
 
 <table>
 <thead>

--- a/java/working-with-cql/query-execution.md
+++ b/java/working-with-cql/query-execution.md
@@ -1,5 +1,6 @@
 ---
-synopsis: API to execute CQL statements on services accepting CQN queries.
+synopsis: >
+  API to execute CQL statements on services accepting CQN queries.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
 

--- a/java/working-with-cql/query-execution.md
+++ b/java/working-with-cql/query-execution.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   API to execute CQL statements on services accepting CQN queries.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -11,7 +11,7 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 ## Query Execution { #queries}
 

--- a/java/working-with-cql/query-introspection.md
+++ b/java/working-with-cql/query-introspection.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   API to introspect CDS Query Language (CQL) statements in Java.
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/9186ed9ab00842e1a31309ff1be38792.html
 ---
@@ -11,7 +11,7 @@ uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/
   }
 </style>
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 
 ## Introduction

--- a/node.js/app-services.md
+++ b/node.js/app-services.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Application Services
 

--- a/node.js/app-services.md
+++ b/node.js/app-services.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference for class `cds.ApplicationService`, the default service provider implementation adding CAP's generic handlers.
 ---
 

--- a/node.js/app-services.md
+++ b/node.js/app-services.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Reference for class `cds.ApplicationService`, the default service provider implementation adding CAP's generic handlers.
+---
 
 # Application Services
 

--- a/node.js/authentication.md
+++ b/node.js/authentication.md
@@ -1,12 +1,12 @@
 ---
-synopsis: >
+description: >
   This guide is about authenticating users on incoming HTTP requests.
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html
 ---
 
 # Authentication
 
-{{$frontmatter?.synopsis}} This is done by [authentication middlewares](#strategies) setting the [`cds.context.user` property](#cds-user) which is then used in [authorization enforcement](#enforcement) decisions.
+{{$frontmatter?.description}} This is done by [authentication middlewares](#strategies) setting the [`cds.context.user` property](#cds-user) which is then used in [authorization enforcement](#enforcement) decisions.
 
 [[toc]]
 

--- a/node.js/authentication.md
+++ b/node.js/authentication.md
@@ -1,5 +1,4 @@
 ---
-label: Authentication
 synopsis: >
   This guide is about authenticating users on incoming HTTP requests.
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html

--- a/node.js/authentication.md
+++ b/node.js/authentication.md
@@ -2,7 +2,6 @@
 label: Authentication
 synopsis: >
   This guide is about authenticating users on incoming HTTP requests.
-# layout: node-js
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html
 ---
 

--- a/node.js/best-practices.md
+++ b/node.js/best-practices.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Learn about Node.js best practices.
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html
 ---

--- a/node.js/best-practices.md
+++ b/node.js/best-practices.md
@@ -1,5 +1,4 @@
 ---
-label: Best Practices
 synopsis: >
   Learn about Node.js best practices.
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html

--- a/node.js/cds-compile.md
+++ b/node.js/cds-compile.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference for `cds.compile`, the API used to parse and compile CDS models into various target formats.
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html
 ---

--- a/node.js/cds-compile.md
+++ b/node.js/cds-compile.md
@@ -1,4 +1,6 @@
 ---
+synopsis: >
+  Reference for `cds.compile`, the API used to parse and compile CDS models into various target formats.
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/855e00bd559742a3b8276fbed4af1008.html
 ---
 

--- a/node.js/cds-connect.md
+++ b/node.js/cds-connect.md
@@ -1,7 +1,6 @@
 ---
 shorty: cds.connect
 # layout: node-js
-status: released
 ---
 
 # Connecting to Required Services

--- a/node.js/cds-connect.md
+++ b/node.js/cds-connect.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference for `cds.connect.to()`, used to connect to local or external required services configured in `cds.requires`.
 ---
 

--- a/node.js/cds-connect.md
+++ b/node.js/cds-connect.md
@@ -1,6 +1,5 @@
 ---
 shorty: cds.connect
-# layout: node-js
 ---
 
 # Connecting to Required Services

--- a/node.js/cds-connect.md
+++ b/node.js/cds-connect.md
@@ -1,6 +1,3 @@
----
-shorty: cds.connect
----
 
 # Connecting to Required Services
 

--- a/node.js/cds-connect.md
+++ b/node.js/cds-connect.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Reference for `cds.connect.to()`, used to connect to local or external required services configured in `cds.requires`.
+---
 
 # Connecting to Required Services
 

--- a/node.js/cds-env.md
+++ b/node.js/cds-env.md
@@ -1,11 +1,11 @@
 ---
-synopsis: >
+description: >
   Learn here about using cds.env to specify and access configuration options for the Node.js runtimes as well as the @sap/cds-dk CLI commands.
 ---
 
 # Project-Specific Configurations
 
-{{ $frontmatter.synopsis }}
+{{ $frontmatter.description }}
 
 
 ## CLI `cds env` Command {#cli}

--- a/node.js/cds-env.md
+++ b/node.js/cds-env.md
@@ -2,7 +2,6 @@
 label: Configuration
 synopsis: >
   Learn here about using cds.env to specify and access configuration options for the Node.js runtimes as well as the @sap/cds-dk CLI commands.
-status: released
 ---
 
 # Project-Specific Configurations

--- a/node.js/cds-env.md
+++ b/node.js/cds-env.md
@@ -1,5 +1,4 @@
 ---
-label: Configuration
 synopsis: >
   Learn here about using cds.env to specify and access configuration options for the Node.js runtimes as well as the @sap/cds-dk CLI commands.
 ---

--- a/node.js/cds-facade.md
+++ b/node.js/cds-facade.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference for the `cds` façade object, the single entry point providing access to all CAP Node.js APIs.
 ---
 

--- a/node.js/cds-facade.md
+++ b/node.js/cds-facade.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 
 

--- a/node.js/cds-facade.md
+++ b/node.js/cds-facade.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Reference for the `cds` façade object, the single entry point providing access to all CAP Node.js APIs.
+---
 
 
 

--- a/node.js/cds-i18n.md
+++ b/node.js/cds-i18n.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference for the `cds.i18n` module, used for localizing UIs and runtime error messages, and directly in custom code.
 ---
 

--- a/node.js/cds-i18n.md
+++ b/node.js/cds-i18n.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Reference for the `cds.i18n` module, used for localizing UIs and runtime error messages, and directly in custom code.
+---
 
 # Localization / i18n
 

--- a/node.js/cds-i18n.md
+++ b/node.js/cds-i18n.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Localization / i18n
 

--- a/node.js/cds-log.md
+++ b/node.js/cds-log.md
@@ -2,7 +2,6 @@
 shorty: cds.log
 # layout: node-js
 subtocs: false
-status: released
 ---
 
 # Minimalistic Logging Facade

--- a/node.js/cds-log.md
+++ b/node.js/cds-log.md
@@ -1,6 +1,6 @@
 ---
 subtocs: false
-synopsis: >
+description: >
   Reference for `cds.log`, CAP's minimalistic logging facade for obtaining and configuring loggers.
 ---
 

--- a/node.js/cds-log.md
+++ b/node.js/cds-log.md
@@ -1,5 +1,4 @@
 ---
-shorty: cds.log
 subtocs: false
 ---
 

--- a/node.js/cds-log.md
+++ b/node.js/cds-log.md
@@ -1,5 +1,7 @@
 ---
 subtocs: false
+synopsis: >
+  Reference for `cds.log`, CAP's minimalistic logging facade for obtaining and configuring loggers.
 ---
 
 # Minimalistic Logging Facade

--- a/node.js/cds-log.md
+++ b/node.js/cds-log.md
@@ -1,6 +1,5 @@
 ---
 shorty: cds.log
-# layout: node-js
 subtocs: false
 ---
 

--- a/node.js/cds-plugins.md
+++ b/node.js/cds-plugins.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # CDS Plugin Packages
 

--- a/node.js/cds-plugins.md
+++ b/node.js/cds-plugins.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How the `cds-plugin` technique lets packages provide auto-configured extensions loaded automatically by CAP Node.js servers.
 ---
 

--- a/node.js/cds-plugins.md
+++ b/node.js/cds-plugins.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How the `cds-plugin` technique lets packages provide auto-configured extensions loaded automatically by CAP Node.js servers.
+---
 
 # CDS Plugin Packages
 

--- a/node.js/cds-ql.md
+++ b/node.js/cds-ql.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 
 # Querying in JavaScript

--- a/node.js/cds-ql.md
+++ b/node.js/cds-ql.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference for `cds.ql`, the module for constructing CQN queries in Node.js using fluent API and tagged template literal styles.
 ---
 

--- a/node.js/cds-ql.md
+++ b/node.js/cds-ql.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Reference for `cds.ql`, the module for constructing CQN queries in Node.js using fluent API and tagged template literal styles.
+---
 
 
 # Querying in JavaScript
@@ -359,7 +363,7 @@ q2 = cds.ql.clone (q1)
 ```
 We can then modify `q2` without changing `q1`, for example like this:
 ```js
-// Override where clause 
+// Override where clause
 q2.SELECT.where = cds.ql.predicate`author.name = 'Emily%'`
 ```
 ```js

--- a/node.js/cds-reflect.md
+++ b/node.js/cds-reflect.md
@@ -1,11 +1,11 @@
 ---
-synopsis: >
+description: >
   Find here information about reflecting parsed CDS models in CSN representation.
 ---
 
 # Reflecting CDS Models
 
-{{$frontmatter?.synopsis}}
+{{$frontmatter?.description}}
 
 <!--- % assign m = '<span style="color:grey"> m</span>' %} -->
 <!--- % include links-for-node.md %} -->

--- a/node.js/cds-reflect.md
+++ b/node.js/cds-reflect.md
@@ -1,5 +1,4 @@
 ---
-shorty: cds.reflect
 synopsis: >
   Find here information about reflecting parsed CDS models in CSN representation.
 ---

--- a/node.js/cds-reflect.md
+++ b/node.js/cds-reflect.md
@@ -2,7 +2,6 @@
 shorty: cds.reflect
 synopsis: >
   Find here information about reflecting parsed CDS models in CSN representation.
-status: released
 ---
 
 # Reflecting CDS Models

--- a/node.js/cds-serve.md
+++ b/node.js/cds-serve.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference for `cds.serve()`, used to construct and expose service providers from CDS service definitions.
 ---
 

--- a/node.js/cds-serve.md
+++ b/node.js/cds-serve.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Reference for `cds.serve()`, used to construct and expose service providers from CDS service definitions.
+---
 
 
 

--- a/node.js/cds-serve.md
+++ b/node.js/cds-serve.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 
 

--- a/node.js/cds-server.md
+++ b/node.js/cds-server.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How CAP Node.js servers are bootstrapped via the built-in `server.js` module and `cds serve` CLI command, including custom bootstrapping.
+---
 
 
 

--- a/node.js/cds-server.md
+++ b/node.js/cds-server.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 
 

--- a/node.js/cds-server.md
+++ b/node.js/cds-server.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How CAP Node.js servers are bootstrapped via the built-in `server.js` module and `cds serve` CLI command, including custom bootstrapping.
 ---
 

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Reference for `cds.test`, CAP's testing utility for writing and running tests against CAP services.
+---
 
 # Testing with `cds.test`
 

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Testing with `cds.test`
 

--- a/node.js/cds-test.md
+++ b/node.js/cds-test.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference for `cds.test`, CAP's testing utility for writing and running tests against CAP services.
 ---
 

--- a/node.js/cds-tx.md
+++ b/node.js/cds-tx.md
@@ -1,5 +1,6 @@
 ---
-label: Transactions
+synopsis: >
+  How CAP automatically manages database transactions, principal propagation, and tenant isolation for service requests.
 ---
 
 # Transaction Management

--- a/node.js/cds-tx.md
+++ b/node.js/cds-tx.md
@@ -1,5 +1,4 @@
 ---
-# layout: node-js
 label: Transactions
 ---
 

--- a/node.js/cds-tx.md
+++ b/node.js/cds-tx.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How CAP automatically manages database transactions, principal propagation, and tenant isolation for service requests.
 ---
 

--- a/node.js/cds-utils.md
+++ b/node.js/cds-utils.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference for `cds.utils`, a module of common utility functions such as UUID generation and file access.
 ---
 

--- a/node.js/cds-utils.md
+++ b/node.js/cds-utils.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Reference for `cds.utils`, a module of common utility functions such as UUID generation and file access.
+---
 
 # Common Utility Functions
 

--- a/node.js/cds-utils.md
+++ b/node.js/cds-utils.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Common Utility Functions
 

--- a/node.js/core-services.md
+++ b/node.js/core-services.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How CAP applications provide and consume services, covering service definitions, implementations, and event handlers.
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html
 ---

--- a/node.js/core-services.md
+++ b/node.js/core-services.md
@@ -1,4 +1,6 @@
 ---
+synopsis: >
+  How CAP applications provide and consume services, covering service definitions, implementations, and event handlers.
 uacp: This page is linked from the Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html
 ---
 

--- a/node.js/databases.md
+++ b/node.js/databases.md
@@ -1,11 +1,11 @@
 ---
-synopsis: >
+description: >
   Class <code>cds.DatabaseService</code> and subclasses thereof are technical services representing persistent storage.
 ---
 
 # Database Services
 
-<div v-html="$frontmatter?.synopsis" />
+<div v-html="$frontmatter?.description" />
 
 [[toc]]
 

--- a/node.js/databases.md
+++ b/node.js/databases.md
@@ -1,5 +1,4 @@
 ---
-label: Databases
 synopsis: >
   Class <code>cds.DatabaseService</code> and subclasses thereof are technical services representing persistent storage.
 ---
@@ -89,7 +88,7 @@ Pool configuration can be adjusted by setting the `pool` option as shown in the 
 }
 ```
 
-::: warning 
+::: warning
 The parameters are very specific to the current technical setup, such as the application environment and database location.
 Even though we provide a default pool configuration, we expect that each application provides its own configuration based on its specific needs.
 :::

--- a/node.js/databases.md
+++ b/node.js/databases.md
@@ -2,7 +2,6 @@
 label: Databases
 synopsis: >
   Class <code>cds.DatabaseService</code> and subclasses thereof are technical services representing persistent storage.
-status: released
 ---
 
 # Database Services

--- a/node.js/event-queues.md
+++ b/node.js/event-queues.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Node.js APIs and configuration for CAP's Transactional Event Queues — `cds.queued`, `cds.unqueued`, `srv.schedule`, `cds.flush`, callbacks, and queue configuration.
-status: released
 ---
 
 # Event Queues in Node.js

--- a/node.js/event-queues.md
+++ b/node.js/event-queues.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Node.js APIs and configuration for CAP's Transactional Event Queues — `cds.queued`, `cds.unqueued`, `srv.schedule`, `cds.flush`, callbacks, and queue configuration.
 ---
 

--- a/node.js/events.md
+++ b/node.js/events.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Reference for accessing the current event context, such as tenant, user, and locale, via `cds.context`.
+---
 
 # Events and Requests
 
@@ -369,7 +373,7 @@ AdminService.update(Books,201).with({...})
 AdminService.delete(Books,201)
 ```
 
-... `req.subject` would always look like that: 
+... `req.subject` would always look like that:
 
 ```js
 req.subject //> ...
@@ -387,7 +391,7 @@ UPDATE(req.subject)...    //> updates the single target row
 DELETE.from(req.subject)   //> deletes the single target row
 ```
 
-> [!warning] 
+> [!warning]
 > You can use `req.subject` in custom handlers for inbound `READ`, `UPDATE` and `DELETE` requests, as well as in _bound_ actions, addressing **_single rows_**.
 > **You can't use it** reasonably in custom handlers for `INSERT` requests or other requests addressing **_multiple rows_**.
 

--- a/node.js/events.md
+++ b/node.js/events.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Events and Requests
 

--- a/node.js/events.md
+++ b/node.js/events.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference for accessing the current event context, such as tenant, user, and locale, via `cds.context`.
 ---
 

--- a/node.js/fiori.md
+++ b/node.js/fiori.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference for SAP Fiori draft support in CAP, including draft-enabled entities.
 ---
 

--- a/node.js/fiori.md
+++ b/node.js/fiori.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  Reference for SAP Fiori draft support in CAP, including draft-enabled entities.
+---
 
 
 # Fiori Support

--- a/node.js/fiori.md
+++ b/node.js/fiori.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 
 # Fiori Support

--- a/node.js/index.md
+++ b/node.js/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Reference documentation for the CAP Service SDK for Node.js, covering how to implement domain-specific custom logic.
 ---
 

--- a/node.js/index.md
+++ b/node.js/index.md
@@ -1,6 +1,5 @@
 ---
 section: Node.js
-status: released
 ---
 
 # CAP Service SDK for Node.js

--- a/node.js/index.md
+++ b/node.js/index.md
@@ -1,5 +1,6 @@
 ---
-section: Node.js
+synopsis: >
+  Reference documentation for the CAP Service SDK for Node.js, covering how to implement domain-specific custom logic.
 ---
 
 # CAP Service SDK for Node.js

--- a/node.js/messaging.md
+++ b/node.js/messaging.md
@@ -2,7 +2,6 @@
 synopsis: >
   Learn details about using messaging services and outbox for asynchronous communications.
 # layout: node-js
-status: released
 ---
 
 # Messaging

--- a/node.js/messaging.md
+++ b/node.js/messaging.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   Learn details about using messaging services and outbox for asynchronous communications.
-# layout: node-js
 ---
 
 # Messaging

--- a/node.js/messaging.md
+++ b/node.js/messaging.md
@@ -1,11 +1,11 @@
 ---
-synopsis: >
+description: >
   Learn details about using messaging services and outbox for asynchronous communications.
 ---
 
 # Messaging
 
-{{$frontmatter?.synopsis}}
+{{$frontmatter?.description}}
 
 [[toc]]
 
@@ -14,10 +14,10 @@ synopsis: >
 
 ## Overview
 
-Messaging enables decoupled communication between services using events. 
+Messaging enables decoupled communication between services using events.
 CAP distinguishes between the logical and technical messaging layers, separating business concerns from technical infrastructure.
 
-The **logical layer** consists of three primary components: 
+The **logical layer** consists of three primary components:
 
 **Modeled Events**: Events are defined in CDS models with typed schemas, providing compile-time validation and IDE support. These events represent business occurrences like `'orderProcessed'`, or `'stockUpdated'`.
 
@@ -42,7 +42,7 @@ The message flow follows a clear path through both layers:
 
 ### Summary Table
 
- 
+
 | CDS Event Declaration         | Emitting via `srv.emit` | Emitting via `messaging.emit` | Broker Topic         | Receiving via `srv.on` | Receiving via `messaging.on` |
 |------------------------------|-------------------------|-------------------------------|----------------------|------------------------|------------------------------|
 | No `@topic`                  | `'reviewed'`           | `'OrderSrv.reviewed'`         | `OrderSrv.reviewed`  | `'reviewed'`           | `'OrderSrv.reviewed'`        |
@@ -369,7 +369,7 @@ Example:
 }
 ```
 
-::: warning 
+::: warning
 When using `enterprise-messaging-shared` in a multitenant scenario, only the provider account will have an event bus. There is no tenant isolation.
 :::
 

--- a/node.js/remote-services.md
+++ b/node.js/remote-services.md
@@ -1,5 +1,4 @@
 ---
-label: Remote Services
 synopsis: >
   Class `cds.RemoteService` is a service proxy class to consume remote services via different [protocols](cds-serve#cds-protocols), like OData or plain REST.
 ---

--- a/node.js/remote-services.md
+++ b/node.js/remote-services.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Class `cds.RemoteService` is a service proxy class to consume remote services via different [protocols](cds-serve#cds-protocols), like OData or plain REST.
 ---
 

--- a/node.js/remote-services.md
+++ b/node.js/remote-services.md
@@ -3,7 +3,6 @@ label: Remote Services
 synopsis: >
   Class `cds.RemoteService` is a service proxy class to consume remote services via different [protocols](cds-serve#cds-protocols), like OData or plain REST.
 # layout: node-js
-status: released
 ---
 
 # Remote Services <Concept />

--- a/node.js/remote-services.md
+++ b/node.js/remote-services.md
@@ -2,7 +2,6 @@
 label: Remote Services
 synopsis: >
   Class `cds.RemoteService` is a service proxy class to consume remote services via different [protocols](cds-serve#cds-protocols), like OData or plain REST.
-# layout: node-js
 ---
 
 # Remote Services <Concept />

--- a/node.js/streaming.md
+++ b/node.js/streaming.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to use streaming in CAP Node.js applications to process large datasets with minimal memory usage.
 ---
 

--- a/node.js/streaming.md
+++ b/node.js/streaming.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  How to use streaming in CAP Node.js applications to process large datasets with minimal memory usage.
+---
 
 # Streaming
 
@@ -47,7 +51,7 @@ let count = 0
 for await(const row of generator()) {
   if(count > 1000) break
   // ...
-} 
+}
 ```
 
 This principle applies at every step of the `pipeline`. For example you can limit how much data can be uploaded to your application:

--- a/node.js/streaming.md
+++ b/node.js/streaming.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 # Streaming
 

--- a/node.js/typescript.md
+++ b/node.js/typescript.md
@@ -1,7 +1,9 @@
+---
+synopsis: >
+  How to enable and use TypeScript in a CAP Node.js project.
+---
 
 # Using TypeScript
-
-While CAP itself is written in _JavaScript_, it's possible to use _TypeScript_ within your project as outlined here.
 
 [[toc]]
 

--- a/node.js/typescript.md
+++ b/node.js/typescript.md
@@ -1,6 +1,5 @@
 ---
 # layout: node-js
-status: released
 ---
 
 # Using TypeScript

--- a/node.js/typescript.md
+++ b/node.js/typescript.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to enable and use TypeScript in a CAP Node.js project.
 ---
 

--- a/node.js/typescript.md
+++ b/node.js/typescript.md
@@ -1,6 +1,3 @@
----
-# layout: node-js
----
 
 # Using TypeScript
 

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -1,3 +1,7 @@
+---
+synopsis: >
+  A curated list of CAP plugins that integrate with SAP BTP services and other SAP products.
+---
 
 <script setup>
 import { useData } from 'vitepress'

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 <script setup>
 import { useData } from 'vitepress'

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   A curated list of CAP plugins that integrate with SAP BTP services and other SAP products.
 ---
 

--- a/tools/apis/cds-add.md
+++ b/tools/apis/cds-add.md
@@ -1,5 +1,4 @@
 ---
-label: cds-add
 synopsis: >
   Learn how to create a <code>cds add</code> plugin.
 ---

--- a/tools/apis/cds-add.md
+++ b/tools/apis/cds-add.md
@@ -2,7 +2,6 @@
 label: cds-add
 synopsis: >
   Learn how to create a <code>cds add</code> plugin.
-status: released
 ---
 
 <style scoped lang="scss">

--- a/tools/apis/cds-add.md
+++ b/tools/apis/cds-add.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Learn how to create a <code>cds add</code> plugin.
 ---
 

--- a/tools/apis/cds-build.md
+++ b/tools/apis/cds-build.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   The guide provides an overview of custom build processes for CAP projects, explaining how to tailor the standard build process to specific project requirements.
 ---
 

--- a/tools/apis/cds-build.md
+++ b/tools/apis/cds-build.md
@@ -1,7 +1,6 @@
 ---
 synopsis: >
   The guide provides an overview of custom build processes for CAP projects, explaining how to tailor the standard build process to specific project requirements.
-status: released
 ---
 
 # Implement Build Plugins <Since version="7.5.0" package="@sap/cds-dk" />

--- a/tools/apis/cds-import.md
+++ b/tools/apis/cds-import.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Programmatically use <code>cds.import</code>.
 ---
 

--- a/tools/apis/index.md
+++ b/tools/apis/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   APIs of the <code>@sap/cds-dk</code> package like <code>cds.import</code>.
 ---
 
@@ -22,7 +22,7 @@ cds.import(...)
 ```
 
 > [!important] Don't load cds-dk code at runtime
-> Note that `@sap/cds-dk` is a design-time dependency that runs locally or in continuous integration (CI) pipelines. 
+> Note that `@sap/cds-dk` is a design-time dependency that runs locally or in continuous integration (CI) pipelines.
 > Avoid loading the previously shown code at application runtime in deployed applications.
 
 <script setup>

--- a/tools/cds-bind.md
+++ b/tools/cds-bind.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   How to locally test your application with real cloud services.
 permalink: advanced/hybrid-testing
 uacp: Used as link target from Help Portal at https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/29c25e504fdb4752b0383d3c407f52a6.html and https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/e4a7559baf9f4e4394302442745edcd9.html

--- a/tools/cds-bind.md
+++ b/tools/cds-bind.md
@@ -1,5 +1,4 @@
 ---
-label: Hybrid Testing
 synopsis: >
   How to locally test your application with real cloud services.
 permalink: advanced/hybrid-testing

--- a/tools/cds-cli.md
+++ b/tools/cds-cli.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Available commands of the <code>cds</code> command line client.
 ---
 

--- a/tools/cds-editors.md
+++ b/tools/cds-editors.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   Supported development environments (IDEs) and features of the CDS language editor.
 ---
 

--- a/tools/cds-lint/index.md
+++ b/tools/cds-lint/index.md
@@ -2,7 +2,6 @@
 label: cds-lint
 synopsis: >
   This page explains the ESLint plugin for CDS in depth.
-status: released
 ---
 
 # CDS Lint

--- a/tools/cds-lint/index.md
+++ b/tools/cds-lint/index.md
@@ -1,5 +1,4 @@
 ---
-label: cds-lint
 synopsis: >
   This page explains the ESLint plugin for CDS in depth.
 ---

--- a/tools/cds-lint/index.md
+++ b/tools/cds-lint/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This page explains the ESLint plugin for CDS in depth.
 ---
 

--- a/tools/cds-lint/rules/assoc2many-ambiguous-key/index.md
+++ b/tools/cds-lint/rules/assoc2many-ambiguous-key/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/auth-no-empty-restrictions/index.md
+++ b/tools/cds-lint/rules/auth-no-empty-restrictions/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/auth-restrict-grant-service/index.md
+++ b/tools/cds-lint/rules/auth-restrict-grant-service/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/auth-use-requires/index.md
+++ b/tools/cds-lint/rules/auth-use-requires/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/auth-valid-restrict-grant/index.md
+++ b/tools/cds-lint/rules/auth-valid-restrict-grant/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/auth-valid-restrict-keys/index.md
+++ b/tools/cds-lint/rules/auth-valid-restrict-keys/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/auth-valid-restrict-to/index.md
+++ b/tools/cds-lint/rules/auth-valid-restrict-to/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/auth-valid-restrict-where/index.md
+++ b/tools/cds-lint/rules/auth-valid-restrict-where/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/case-sensitive-well-known-events/index.md
+++ b/tools/cds-lint/rules/case-sensitive-well-known-events/index.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 <script setup>
   import PlaygroundBadge from '../../components/PlaygroundBadge.vue'

--- a/tools/cds-lint/rules/extension-restrictions/index.md
+++ b/tools/cds-lint/rules/extension-restrictions/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/index.md
+++ b/tools/cds-lint/rules/index.md
@@ -1,5 +1,4 @@
 ---
-label: cds-lint-rules
 synopsis: >
   This page lists the rules contained in the ESLint plugin for CDS in depth.
 ---

--- a/tools/cds-lint/rules/index.md
+++ b/tools/cds-lint/rules/index.md
@@ -2,7 +2,6 @@
 label: cds-lint-rules
 synopsis: >
   This page lists the rules contained in the ESLint plugin for CDS in depth.
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/index.md
+++ b/tools/cds-lint/rules/index.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This page lists the rules contained in the ESLint plugin for CDS in depth.
 ---
 

--- a/tools/cds-lint/rules/latest-cds-version/index.md
+++ b/tools/cds-lint/rules/latest-cds-version/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/no-cross-service-import/index.md
+++ b/tools/cds-lint/rules/no-cross-service-import/index.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 <script setup>
   import PlaygroundBadge from '../../components/PlaygroundBadge.vue'

--- a/tools/cds-lint/rules/no-db-keywords/index.md
+++ b/tools/cds-lint/rules/no-db-keywords/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/no-deep-sap-cds-import/index.md
+++ b/tools/cds-lint/rules/no-deep-sap-cds-import/index.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 <script setup>
   import PlaygroundBadge from '../../components/PlaygroundBadge.vue'

--- a/tools/cds-lint/rules/no-dollar-prefixed-names/index.md
+++ b/tools/cds-lint/rules/no-dollar-prefixed-names/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/no-escaped-anno-brackets/index.md
+++ b/tools/cds-lint/rules/no-escaped-anno-brackets/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/no-java-keywords/index.md
+++ b/tools/cds-lint/rules/no-java-keywords/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/no-join-on-draft/index.md
+++ b/tools/cds-lint/rules/no-join-on-draft/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/no-shared-handler-variable/index.md
+++ b/tools/cds-lint/rules/no-shared-handler-variable/index.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 <script setup>
   import PlaygroundBadge from '../../components/PlaygroundBadge.vue'

--- a/tools/cds-lint/rules/sql-cast-suggestion/index.md
+++ b/tools/cds-lint/rules/sql-cast-suggestion/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/sql-null-comparison/index.md
+++ b/tools/cds-lint/rules/sql-null-comparison/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/start-elements-lowercase/index.md
+++ b/tools/cds-lint/rules/start-elements-lowercase/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/start-entities-uppercase/index.md
+++ b/tools/cds-lint/rules/start-entities-uppercase/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-lint/rules/use-cql-select-template-strings/index.md
+++ b/tools/cds-lint/rules/use-cql-select-template-strings/index.md
@@ -1,6 +1,3 @@
----
-status: released
----
 
 <script setup>
   import PlaygroundBadge from '../../components/PlaygroundBadge.vue'

--- a/tools/cds-lint/rules/valid-csv-header/index.md
+++ b/tools/cds-lint/rules/valid-csv-header/index.md
@@ -1,9 +1,5 @@
 ---
 outline: [2,2]
-breadcrumbs:
-  - CDS Lint
-    - Rules Reference
-status: released
 ---
 
 <script setup>

--- a/tools/cds-typer.md
+++ b/tools/cds-typer.md
@@ -6,7 +6,6 @@ typedModels:
   bookshop: assets/bookshop
   farm: assets/animal-farm
   incidents: assets/incidents
-status: released
 ---
 
 # CDS Typer {#cds-typer}

--- a/tools/cds-typer.md
+++ b/tools/cds-typer.md
@@ -1,5 +1,4 @@
 ---
-label: cds-typer
 synopsis: >
   This page explains the package cds-typer in depth.
 typedModels:

--- a/tools/cds-typer.md
+++ b/tools/cds-typer.md
@@ -1,5 +1,5 @@
 ---
-synopsis: >
+description: >
   This page explains the package cds-typer in depth.
 typedModels:
   bookshop: assets/bookshop

--- a/tools/index.md
+++ b/tools/index.md
@@ -1,10 +1,10 @@
 ---
-synopsis: >
+description: >
   Overview of the command-line and IDE tools available for developing CAP applications.
 ---
 
 # Choose Your Preferred Tools
-{{$frontmatter?.synopsis}}
+{{$frontmatter?.description}}
 
 
 <script setup>

--- a/tools/index.md
+++ b/tools/index.md
@@ -1,5 +1,6 @@
 ---
-section: Tools
+synopsis: >
+  Overview of the command-line and IDE tools available for developing CAP applications.
 ---
 
 # Choose Your Preferred Tools

--- a/tools/index.md
+++ b/tools/index.md
@@ -1,7 +1,6 @@
 ---
 section: Tools
 shorty: Tools
-status: released
 ---
 
 # Choose Your Preferred Tools

--- a/tools/index.md
+++ b/tools/index.md
@@ -1,6 +1,5 @@
 ---
 section: Tools
-shorty: Tools
 ---
 
 # Choose Your Preferred Tools


### PR DESCRIPTION
- Use Vitepress standard [`description` field](https://vitepress.dev/reference/frontmatter-config#description) instead of `synopsis`.
- Add `description` where it was missing
- Revisit existing `description`/`synopsis` fields for grammar and style
- Remove unused frontmatter entries `breadcrumbs`, `index`, `label`, `#layout`, `status`, `section`, `shorty`
