### PR TITLE
Fix click on StatusBadge in dev mode

### DIFF
--- a/.vitepress/theme/components/StatusBadge.vue
+++ b/.vitepress/theme/components/StatusBadge.vue
@@ -1,17 +1,10 @@
 <template>
-  <Badge
-    :type="type"
-    :text="text"
-    :title="title"
-    @click="click" style="cursor: pointer"
-  />
+  <a :href="withBase('/releases/#status-badges')">
+    <Badge :type="type" :text="text" :title="title" />
+  </a>
 </template>
 
 <script setup lang="ts">
 defineProps<{ type: string, text:string, title:string  }>()
-
 import { withBase } from 'vitepress'
-function click() {
-  location.href = withBase('/releases/index#status-badges')
-}
 </script>


### PR DESCRIPTION
The onclick navigation for a status badge doesn't seem to carry over the hash. Fix is to use a normal `<a href=...>` instead.  This is also more straight forward.