### PR TITLE
remove `--ws-pack` from microservices guide

### DIFF
--- a/guides/deploy/microservices.md
+++ b/guides/deploy/microservices.md
@@ -356,14 +356,10 @@ build-parameters:
       commands:
         - npm ci
         - npx cds build ./shared-db --for hana --production
-        - npx cds build ./orders --for nodejs --production --ws-pack # [!code ++]
+        - npx cds build ./orders --for nodejs --production # [!code ++]
         - npx cds build ./reviews --for nodejs --production # [!code ++]
-        - npx cds build ./bookstore --for nodejs --production --ws-pack # [!code ++]
+        - npx cds build ./bookstore --for nodejs --production # [!code ++]
 ```
-:::
-
-::: info --ws-pack
-Note that we use the *--ws-pack* option for some modules. It's important for node modules referencing other repository-local node modules.
 :::
 
 


### PR DESCRIPTION
Will not be required with cds-dk 10.1 any more.